### PR TITLE
Migrate to MVVM Architecture

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -9,3 +9,4 @@ You must follow these rules when generating or modifying code:
 
 4. The date format must be MM/DD/YYYY.
 5. Do not omit the file header.
+6. All new logic code must have unit tests for 100% code coverage

--- a/Spot.xcodeproj/project.pbxproj
+++ b/Spot.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		6428440D2E20429B00DC9E8A /* Spot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6428441A2E20429E00DC9E8A /* SpotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		642844242E20429E00DC9E8A /* SpotUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpotUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		645351FE2F5671840012DDA1 /* Spot.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Spot.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -137,6 +138,7 @@
 		642844042E20429B00DC9E8A = {
 			isa = PBXGroup;
 			children = (
+				645351FE2F5671840012DDA1 /* Spot.xctestplan */,
 				6428440F2E20429B00DC9E8A /* Spot */,
 				6428441D2E20429E00DC9E8A /* SpotTests */,
 				642844272E20429E00DC9E8A /* SpotUITests */,

--- a/Spot.xcodeproj/xcshareddata/xcschemes/Spot.xcscheme
+++ b/Spot.xcodeproj/xcshareddata/xcschemes/Spot.xcscheme
@@ -27,8 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Spot.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Spot.xcodeproj/xcshareddata/xcschemes/SpotTests.xcscheme
+++ b/Spot.xcodeproj/xcshareddata/xcschemes/SpotTests.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "642844192E20429E00DC9E8A"
+               BuildableName = "SpotTests.xctest"
+               BlueprintName = "SpotTests"
+               ReferencedContainer = "container:Spot.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Spot.xctestplan
+++ b/Spot.xctestplan
@@ -1,0 +1,38 @@
+{
+  "configurations" : [
+    {
+      "id" : "B439296D-578A-48F9-A4F0-9381DDBE3F25",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Spot.xcodeproj",
+      "identifier" : "6428440C2E20429B00DC9E8A",
+      "name" : "Spot"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Spot.xcodeproj",
+        "identifier" : "642844192E20429E00DC9E8A",
+        "name" : "SpotTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Spot.xcodeproj",
+        "identifier" : "642844232E20429E00DC9E8A",
+        "name" : "SpotUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Spot/ViewModels/FeedViewModel.swift
+++ b/Spot/ViewModels/FeedViewModel.swift
@@ -1,0 +1,129 @@
+//
+//  FeedViewModel.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+
+class FeedViewModel: ObservableObject {
+    @Published var spots: [Spot] = []
+    @Published var mapSpots: [Spot] = []
+    @Published var isLoading = false
+    @Published var hasMore = true
+    @Published var deletingSpotIds: Set<String> = []
+    private var loadTask: Task<Void, Never>?
+    private let repo = FeedRepository.shared
+    private var hasRecordedFirstItem = false
+
+    deinit {
+        loadTask?.cancel()
+    }
+
+    /// Spots for feed list (no filtering).
+    var validSpots: [Spot] { spots }
+
+    /// Spots with valid coordinates for map display.
+    var validMapSpots: [Spot] {
+        mapSpots.filter { $0.latitude != nil && $0.longitude != nil }
+    }
+
+    /// Call when feed state is updated; records first-item metric once. No PerfMetrics in views.
+    func recordFirstItemIfNeeded() {
+        guard !hasRecordedFirstItem, !spots.isEmpty else { return }
+        hasRecordedFirstItem = true
+        let t = PerfMetrics.shared.measure("t_first_item") ?? 0
+        PerfMetrics.shared.recordOnce("t_first_item", value: t)
+    }
+
+    func loadInitialSpots() async {
+        loadTask?.cancel()
+        loadTask = Task {
+            await MainActor.run { self.isLoading = true }
+            await repo.loadInitial()
+            await MainActor.run {
+                self.spots = repo.spots
+                self.hasMore = repo.moreAvailable
+                self.isLoading = false
+                recordFirstItemIfNeeded()
+            }
+        }
+    }
+
+    func loadMoreSpots() {
+        guard !isLoading, hasMore else { return }
+
+        loadTask?.cancel()
+
+        loadTask = Task {
+            await MainActor.run { self.isLoading = true }
+            await repo.loadMore()
+            await MainActor.run {
+                let new = repo.spots
+                self.spots = new
+                self.hasMore = repo.moreAvailable
+                self.isLoading = false
+                recordFirstItemIfNeeded()
+            }
+        }
+    }
+
+    func refreshFeed() async {
+        loadTask?.cancel()
+
+        loadTask = Task {
+            await MainActor.run { self.isLoading = true }
+            await repo.loadInitial()
+            await MainActor.run {
+                self.spots = repo.spots
+                self.hasMore = repo.moreAvailable
+                self.isLoading = false
+                recordFirstItemIfNeeded()
+            }
+        }
+        await loadTask?.value
+    }
+
+    // MARK: - Insert newly posted spot
+    @MainActor
+    func insertNewSpot(_ spot: Spot) {
+        spots.removeAll { $0.id == spot.id }
+        spots.insert(spot, at: 0)
+        SpotLogger.info("Inserted new spot at top of feed", details: ["spotId": spot.safeId])
+    }
+
+    func loadMapSpots(forceRefresh: Bool = false) {
+        SpotLogger.debug("Map spots warm disabled; viewport loader handles fetching", details: [:])
+        self.mapSpots = []
+    }
+
+    // MARK: - Delete
+    @MainActor
+    func delete(spot: Spot) async {
+        guard let id = spot.id else {
+            SpotLogger.error("Delete requested for spot without id", details: [:])
+            return
+        }
+        if deletingSpotIds.contains(id) { return }
+        deletingSpotIds.insert(id)
+
+        let prevSpots = spots
+        let prevMap = mapSpots
+        spots.removeAll { $0.id == id }
+        mapSpots.removeAll { $0.id == id }
+
+        do {
+            SpotLogger.info("Deleting spot", details: ["spotId": id])
+            try await SpotService.shared.deleteSpot(spot)
+            deletingSpotIds.remove(id)
+            loadMapSpots(forceRefresh: true)
+        } catch {
+            SpotLogger.error("Delete failed", details: ["spotId": id, "error": error.localizedDescription])
+            spots = prevSpots
+            mapSpots = prevMap
+            deletingSpotIds.remove(id)
+        }
+    }
+}

--- a/Spot/ViewModels/HomepageViewModel.swift
+++ b/Spot/ViewModels/HomepageViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  HomepageViewModel.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+import SwiftUI
+
+final class HomepageViewModel: ObservableObject {
+    @Published var selectedTab: String = "Home"
+    @Published var feedViewType: String = "Feed"
+    @Published var showUploadView: Bool = false
+    @Published var showRulesSheet: Bool = false
+    @Published var showVerifyToast: Bool = false
+    @Published var showPostSuccessToast: Bool = false
+
+    private let toastDismissDuration: TimeInterval = 2.0
+    private var verifyToastTask: Task<Void, Never>?
+    private var postSuccessToastTask: Task<Void, Never>?
+
+    /// Call when + is tapped; shows posting rules first.
+    func onPlusTapped() {
+        showRulesSheet = true
+    }
+
+    /// Call when user agrees to rules; opens upload if email is verified.
+    func agreeToRulesThenOpenUpload(isEmailVerified: Bool) {
+        if isEmailVerified {
+            showRulesSheet = false
+            showUploadView = true
+        }
+    }
+
+    /// Show verify-email toast and auto-dismiss after delay.
+    func showVerifyEmailToast() {
+        verifyToastTask?.cancel()
+        showVerifyToast = true
+        verifyToastTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(toastDismissDuration * 1_000_000_000))
+            if !Task.isCancelled {
+                withAnimation { self.showVerifyToast = false }
+            }
+        }
+    }
+
+    /// Show post-success toast and auto-dismiss after delay.
+    func showPostSuccessToastBanner() {
+        postSuccessToastTask?.cancel()
+        showPostSuccessToast = true
+        postSuccessToastTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(toastDismissDuration * 1_000_000_000))
+            if !Task.isCancelled {
+                withAnimation { self.showPostSuccessToast = false }
+            }
+        }
+    }
+
+    func dismissVerifyToast() {
+        verifyToastTask?.cancel()
+        showVerifyToast = false
+    }
+
+    func dismissPostSuccessToast() {
+        postSuccessToastTask?.cancel()
+        showPostSuccessToast = false
+    }
+}

--- a/Spot/ViewModels/MapViewModel.swift
+++ b/Spot/ViewModels/MapViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  MapViewModel.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+
+@MainActor
+final class MapViewModel: ObservableObject {
+    @Published var visibleSpots: [Spot] = []
+    @Published var isLoadingAllSpots: Bool = false
+
+    func loadAllSpots() {
+        guard !isLoadingAllSpots else { return }
+        isLoadingAllSpots = true
+
+        SpotService.shared.fetchSpotsForMap(forceRefresh: true) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isLoadingAllSpots = false
+                switch result {
+                case .success(let spots):
+                    self.visibleSpots = spots
+                    SpotLogger.info("Map loaded all spots", details: ["count": spots.count])
+                case .failure(let error):
+                    SpotLogger.error("Failed to load all spots for map", details: ["error": error.localizedDescription])
+                }
+            }
+        }
+    }
+}

--- a/Spot/ViewModels/PostFlowViewModel.swift
+++ b/Spot/ViewModels/PostFlowViewModel.swift
@@ -1,0 +1,230 @@
+//
+//  PostFlowViewModel.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
+import UIKit
+
+class PostFlowViewModel: ObservableObject {
+    @Published var currentStep = 1
+    @Published var selectedImages: [UIImage] = []
+    @Published var selectedLocation: LocationData?
+    @Published var selectedVibe: String = ""
+    @Published var isUploading = false
+    @Published var isPosting = false
+    @Published var showToast = false
+    @Published var toastMessage = ""
+    @Published var toastIsError = false
+    @Published var showSuccessBanner = false
+
+    var onPostSuccess: ((Spot) -> Void)?
+    var onShouldDismiss: (() -> Void)?
+
+    let totalSteps = 3
+
+    var isEmailVerified: Bool {
+        Auth.auth().currentUser?.isEmailVerified ?? false
+    }
+
+    var canProceedToNextStep: Bool {
+        switch currentStep {
+        case 1: return !selectedImages.isEmpty
+        case 2: return selectedLocation != nil
+        case 3: return !selectedVibe.isEmpty
+        default: return false
+        }
+    }
+
+    func goBack() {
+        guard currentStep > 1 else { return }
+        SpotLogger.debug("User went back from step \(currentStep) to step \(currentStep - 1)")
+        withAnimation(.easeInOut(duration: 0.3)) {
+            currentStep -= 1
+        }
+    }
+
+    func goNext() {
+        guard currentStep < totalSteps else { return }
+        SpotLogger.debug("User progressed from step \(currentStep) to step \(currentStep + 1)")
+        withAnimation(.easeInOut(duration: 0.3)) {
+            currentStep += 1
+        }
+    }
+
+    func submitPost() {
+        guard !isPosting else { return }
+        isPosting = true
+        SpotLogger.info("User completed post flow")
+        SpotLogger.debug("Post data - Images: \(selectedImages.count), Location: \(selectedLocation?.placeName ?? "None"), Vibe: \(selectedVibe)")
+
+        guard let location = selectedLocation,
+              !selectedVibe.isEmpty,
+              !location.placeName.isEmpty,
+              location.coordinate.latitude != 0,
+              location.coordinate.longitude != 0
+        else {
+            showToastWith(message: "All fields are required to post a spot.", isError: true)
+            isPosting = false
+            return
+        }
+
+        isUploading = true
+        let imagesToUpload = selectedImages
+        let vibe = selectedVibe
+        let lat = location.coordinate.latitude
+        let lon = location.coordinate.longitude
+        let placeName = location.placeName
+
+        if imagesToUpload.count <= 1, let image = imagesToUpload.first {
+            SpotUploader.shared.uploadSpot(
+                image: image,
+                vibeTag: vibe,
+                latitude: lat,
+                longitude: lon,
+                placeName: placeName
+            ) { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.isUploading = false
+                    switch result {
+                    case .success:
+                        if let userId = Auth.auth().currentUser?.uid {
+                            SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: vibe)
+                        }
+                        Task { await self?.awaitModerationAndFinish() }
+                    case .failure(let error):
+                        self?.showToastWith(message: error.localizedDescription, isError: true)
+                        SpotLogger.error("Spot upload failed: \(error.localizedDescription)")
+                        self?.isPosting = false
+                    }
+                }
+            }
+            return
+        }
+
+        SpotUploader.shared.uploadSpot(
+            images: imagesToUpload,
+            vibeTag: vibe,
+            latitude: lat,
+            longitude: lon,
+            placeName: placeName
+        ) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isUploading = false
+                switch result {
+                case .success:
+                    if let userId = Auth.auth().currentUser?.uid {
+                        SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: vibe)
+                    }
+                    Task { await self?.awaitModerationAndFinish() }
+                case .failure(let error):
+                    self?.showToastWith(message: error.localizedDescription, isError: true)
+                    SpotLogger.error("Spot upload failed: \(error.localizedDescription)")
+                    self?.isPosting = false
+                }
+            }
+        }
+    }
+
+    private func awaitModerationAndFinish() async {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            await MainActor.run { isPosting = false }
+            return
+        }
+        let db = Firestore.firestore()
+        do {
+            let snap = try await db.collection("spots")
+                .whereField("userId", isEqualTo: uid)
+                .order(by: "createdAt", descending: true)
+                .limit(to: 1)
+                .getDocuments()
+            guard let doc = snap.documents.first else {
+                await MainActor.run { isPosting = false }
+                return
+            }
+            let spotRef = doc.reference
+            SpotLogger.info("Moderation.Check.Begin spotId=\(doc.documentID)")
+
+            for _ in 0..<20 {
+                let latest = try await spotRef.getDocument()
+                if await evaluateModeration(doc: latest) { return }
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+            SpotLogger.error("Moderation check timeout", details: ["spotId": doc.documentID])
+            await MainActor.run {
+                showToastWith(message: "We couldn't verify your image yet. Please retry.", isError: true)
+                isPosting = false
+            }
+        } catch {
+            SpotLogger.error("Moderation gate error: \(error.localizedDescription)")
+            await MainActor.run { isPosting = false }
+        }
+    }
+
+    private func evaluateModeration(doc: DocumentSnapshot) async -> Bool {
+        let data = doc.data() ?? [:]
+        let moderation = data["moderation"] as? [String: Any]
+        let status = moderation?["status"] as? String ?? "pending"
+        let scores = moderation?["scores"] as? [String: Any]
+
+        if status == "approved" {
+            let (ok, reason) = ModerationPolicy.evaluate(scores: scores)
+            if ok {
+                SpotLogger.info("Moderation.Check.Approved spotId=\(doc.documentID) scores=\(String(describing: scores))")
+                if var spot = try? doc.data(as: Spot.self) {
+                    spot.id = doc.documentID
+                    await MainActor.run {
+                        AnalyticsService.shared.trackUserAction("spot_posted", contentType: "spot", contentId: doc.documentID, parameters: [
+                            "vibe_tag": spot.vibeTag ?? "",
+                            "has_multiple_images": (spot.imageURLs?.count ?? 0) > 1
+                        ])
+                        onPostSuccess?(spot)
+                        isPosting = false
+                        onShouldDismiss?()
+                    }
+                } else {
+                    await MainActor.run {
+                        AnalyticsService.shared.trackUserAction("spot_posted", contentType: "spot", contentId: doc.documentID)
+                        onPostSuccess?(Spot(id: doc.documentID))
+                        isPosting = false
+                        onShouldDismiss?()
+                    }
+                }
+                return true
+            } else {
+                SpotLogger.error("Post blocked by moderation", details: ["reason": reason ?? "over_threshold", "spotId": doc.documentID])
+                await MainActor.run {
+                    showToastWith(message: "This photo violates our guidelines and can't be posted.", isError: true)
+                    isPosting = false
+                }
+                return true
+            }
+        } else if status == "rejected" {
+            SpotLogger.error("Moderation check rejected", details: ["spotId": doc.documentID, "scores": String(describing: scores)])
+            try? await doc.reference.delete()
+            await MainActor.run {
+                showToastWith(message: "This photo violates our guidelines and can't be posted.", isError: true)
+                isPosting = false
+            }
+            return true
+        } else {
+            SpotLogger.debug("Moderation.Check.Pending spotId=\(doc.documentID)")
+            return false
+        }
+    }
+
+    func showToastWith(message: String, isError: Bool) {
+        toastMessage = message
+        toastIsError = isError
+        withAnimation { showToast = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            withAnimation { self?.showToast = false }
+        }
+    }
+}

--- a/Spot/ViewModels/PostFlowViewModel.swift
+++ b/Spot/ViewModels/PostFlowViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import SwiftUI
-import FirebaseAuth
 import FirebaseFirestore
 import UIKit
 
@@ -27,10 +26,17 @@ class PostFlowViewModel: ObservableObject {
     var onPostSuccess: ((Spot) -> Void)?
     var onShouldDismiss: (() -> Void)?
 
+    /// Injected by PostFlowView from environment; used instead of Auth.auth().
+    weak var authViewModel: AuthViewModel?
+
     let totalSteps = 3
 
     var isEmailVerified: Bool {
-        Auth.auth().currentUser?.isEmailVerified ?? false
+        authViewModel?.isEmailVerified ?? false
+    }
+
+    private var currentUserId: String? {
+        authViewModel?.userId
     }
 
     var canProceedToNextStep: Bool {
@@ -94,7 +100,7 @@ class PostFlowViewModel: ObservableObject {
                     self?.isUploading = false
                     switch result {
                     case .success:
-                        if let userId = Auth.auth().currentUser?.uid {
+                        if let userId = self?.currentUserId {
                             SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: vibe)
                         }
                         Task { await self?.awaitModerationAndFinish() }
@@ -119,7 +125,7 @@ class PostFlowViewModel: ObservableObject {
                 self?.isUploading = false
                 switch result {
                 case .success:
-                    if let userId = Auth.auth().currentUser?.uid {
+                    if let userId = self?.currentUserId {
                         SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: vibe)
                     }
                     Task { await self?.awaitModerationAndFinish() }
@@ -133,7 +139,7 @@ class PostFlowViewModel: ObservableObject {
     }
 
     private func awaitModerationAndFinish() async {
-        guard let uid = Auth.auth().currentUser?.uid else {
+        guard let uid = currentUserId else {
             await MainActor.run { isPosting = false }
             return
         }

--- a/Spot/ViewModels/ProfileViewModel.swift
+++ b/Spot/ViewModels/ProfileViewModel.swift
@@ -1,21 +1,41 @@
+//
+//  ProfileViewModel.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
 import Foundation
 import FirebaseFirestore
-import FirebaseAuth
-import CoreLocation // Added for geocoding
 
 class ProfileViewModel: ObservableObject {
-    @Published var user: User?
+    @Published var username: String?
+    @Published var profileImageURL: String?
     @Published var spots: [Spot] = []
     @Published var isLoading = false
     @Published var error: Error?
+    @Published var isPrivateProfile = false
+    @Published var isProProfile = false
+    @Published var isFollowingUser = false
+    @Published var hasRequestedFollow = false
+    @Published var canViewContent = true
+    @Published var deletingSpotIds: Set<String> = []
+    @Published var followRequestsCount: Int = 0
+
     private var loadTask: Task<Void, Never>?
+    private var followReqListener: ListenerRegistration?
+    private var lastLoadedUserId: String?
 
     deinit {
         loadTask?.cancel()
+        stopFollowRequestsListener()
     }
 
-    func loadUserProfile() async {
-        guard let userId = Auth.auth().currentUser?.uid else { return }
+    /// Load profile for the given user (nil = current user). Uses ProfileService.
+    func loadUser(userId: String?, forceReload: Bool = false) async {
+        guard !isLoading else { return }
+        if !forceReload, lastLoadedUserId == userId { return }
 
         await MainActor.run {
             isLoading = true
@@ -25,156 +45,126 @@ class ProfileViewModel: ObservableObject {
         loadTask?.cancel()
         loadTask = Task {
             do {
-                let docRef = Firestore.firestore().collection("users").document(userId)
-                let snapshot = try await docRef.getDocument()
-
-                guard let data = snapshot.data() else {
-                    await MainActor.run {
-                        self.isLoading = false
-                        self.error = ProfileError.userNotFound
-                    }
-                    return
-                }
-
-                let username = data["username"] as? String ?? "User"
-                let profileImageURL = data["profileImageURL"] as? String
-                let vibeStats = data["vibeStats"] as? [String: Int]
-                let createdAt = (data["createdAt"] as? Timestamp)?.dateValue()
-
-                let user = User(
-                    id: userId,
-                    username: username,
-                    profileImageURL: profileImageURL,
-                    isPrivate: false,
-                    isCurrentUser: true,
-                    vibeStats: vibeStats,
-                    createdAt: createdAt
-                )
-
+                let data = try await ProfileService.fetchProfile(for: userId)
                 await MainActor.run {
-                    self.user = user
+                    self.username = data.username
+                    self.profileImageURL = data.profileImageURL
+                    self.spots = data.spots
+                    self.isPrivateProfile = data.isPrivate
+                    self.isProProfile = data.isPro
+                    self.isFollowingUser = data.isFollowing
+                    self.hasRequestedFollow = data.hasRequested
+                    self.canViewContent = data.canView
+                    self.lastLoadedUserId = userId
                     self.isLoading = false
                 }
-
-                SpotLogger.info("Loaded profile for user: \(username)")
-                await loadUserSpots()
+                SpotLogger.info("Loaded profile for user: \(data.username)")
             } catch {
-                SpotLogger.error("Failed to load user profile: \(error.localizedDescription)")
                 await MainActor.run {
                     self.error = error
                     self.isLoading = false
                 }
+                SpotLogger.error("Profile loadUser failed: \(error.localizedDescription)")
+            }
+        }
+        await loadTask?.value
+    }
+
+    /// Delete spot with optimistic update; rollback on failure.
+    @MainActor
+    func deleteSpot(_ spot: Spot) async {
+        guard let id = spot.id else { return }
+        if deletingSpotIds.contains(id) { return }
+        deletingSpotIds.insert(id)
+        let prevSpots = spots
+        spots.removeAll { $0.id == id }
+
+        do {
+            try await SpotService.shared.deleteSpot(spot)
+            deletingSpotIds.remove(id)
+        } catch {
+            SpotLogger.error("Profile delete failed: \(error.localizedDescription)")
+            spots = prevSpots
+            deletingSpotIds.remove(id)
+        }
+    }
+
+    /// Start listening to follow-request count for own private profile.
+    func startFollowRequestsListener(ownUserId: String?) {
+        stopFollowRequestsListener()
+        guard let uid = ownUserId else { return }
+        followReqListener = FollowRequestsService.shared.listenPendingCount(for: uid) { [weak self] n in
+            DispatchQueue.main.async {
+                self?.followRequestsCount = n
             }
         }
     }
 
-    func loadUserSpots() async {
-        guard let userId = Auth.auth().currentUser?.uid else { return }
+    func stopFollowRequestsListener() {
+        followReqListener?.remove()
+        followReqListener = nil
+    }
 
-        loadTask?.cancel()
-        loadTask = Task {
-            do {
-                let query = Firestore.firestore()
-                    .collection("spots")
-                    .whereField("userId", isEqualTo: userId)
-                    .order(by: "createdAt", descending: true)
-
-                let snapshot = try await query.getDocuments()
-
-                let spots = try await withThrowingTaskGroup(of: Spot?.self) { group in
-                    for document in snapshot.documents {
-                        group.addTask {
-                            return try await Spot.fromDocument(document)
-                        }
-                    }
-
-                    var validSpots: [Spot] = []
-                    for try await spot in group {
-                        if let spot = spot {
-                            validSpots.append(spot)
-                        }
-                    }
-                    // Ensure newest-first descending order (createdAt desc; tie-break by id)
-                    return validSpots.sorted { lhs, rhs in
-                        let l = lhs.createdAt ?? .distantPast
-                        let r = rhs.createdAt ?? .distantPast
-                        if l != r { return l > r }
-                        return (lhs.id ?? "") > (rhs.id ?? "")
-                    }
-                }
-
-                await MainActor.run {
-                    self.spots = spots
-                }
-
-                SpotLogger.info("Loaded \(spots.count) spots for user: \(userId)")
-            } catch {
-                SpotLogger.error("Failed to load user spots: \(error.localizedDescription)")
-                await MainActor.run {
-                    self.error = error
-                }
+    func follow(targetUserId: String) {
+        isFollowingUser = true
+        UserSpotService.shared.follow(userId: targetUserId) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .failure = result { self?.isFollowingUser = false }
             }
         }
     }
 
-    func togglePrivateProfile() {
-        guard let userId = Auth.auth().currentUser?.uid else { return }
-
-        Task {
-            do {
-                let userRef = Firestore.firestore().collection("users").document(userId)
-                let currentPrivacy = user?.isPrivate ?? false
-
-                try await userRef.updateData([
-                    "isPrivate": !currentPrivacy
-                ])
-
-                await MainActor.run {
-                    // Create a new User instance with updated privacy
-                    if var updatedUser = self.user {
-                        updatedUser.isPrivate = !currentPrivacy
-                        self.user = updatedUser
-                    }
-                }
-
-                SpotLogger.info("Updated profile privacy: \(!currentPrivacy)")
-            } catch {
-                SpotLogger.error("Failed to toggle profile privacy: \(error.localizedDescription)")
-                await MainActor.run {
-                    self.error = error
-                }
+    func unfollow(targetUserId: String) {
+        isFollowingUser = false
+        UserSpotService.shared.unfollow(userId: targetUserId) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .failure = result { self?.isFollowingUser = true }
             }
         }
     }
 
-    func requestAccess() {
-        guard let targetUserId = user?.id,
-              let currentUserId = Auth.auth().currentUser?.uid else { return }
-
-        Task {
-            do {
-                let requestData: [String: Any] = [
-                    "fromUserId": currentUserId,
-                    "toUserId": targetUserId,
-                    "status": "pending",
-                    "createdAt": FieldValue.serverTimestamp()
-                ]
-
-                try await Firestore.firestore().collection("accessRequests").addDocument(data: requestData)
-                SpotLogger.info("Sent access request to user: \(targetUserId)")
-            } catch {
-                SpotLogger.error("Failed to send access request: \(error.localizedDescription)")
-                await MainActor.run {
-                    self.error = error
-                }
+    func requestFollow(targetUserId: String) {
+        hasRequestedFollow = true
+        UserSpotService.shared.requestFollow(userId: targetUserId) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .failure = result { self?.hasRequestedFollow = false }
             }
         }
+    }
+
+    func cancelFollowRequest(targetUserId: String) {
+        hasRequestedFollow = false
+        UserSpotService.shared.cancelFollowRequest(userId: targetUserId) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .failure = result { self?.hasRequestedFollow = true }
+            }
+        }
+    }
+
+    // MARK: - Legacy (for existing callers that use current-user-only profile)
+    var user: User? {
+        guard let id = lastLoadedUserId else { return nil }
+        return User(
+            id: id,
+            username: username ?? "User",
+            profileImageURL: profileImageURL,
+            isPrivate: isPrivateProfile,
+            isCurrentUser: true,
+            vibeStats: nil,
+            createdAt: nil,
+            blockedUsers: nil,
+            customVibeTags: nil
+        )
+    }
+
+    func loadUserProfile() async {
+        await loadUser(userId: nil)
     }
 
     // MARK: - Preview Data
     static let previewViewModel: ProfileViewModel = {
         let vm = ProfileViewModel()
-        vm.user = User.previewUser
+        vm.username = "Eddie Wynman"
         vm.spots = [
             Spot(
                 id: "spot1",
@@ -212,13 +202,9 @@ class ProfileViewModel: ObservableObject {
 
     static let previewOtherUserViewModel: ProfileViewModel = {
         let vm = ProfileViewModel()
-        vm.user = User(
-            id: "other123",
-            username: "John Doe",
-            profileImageURL: "https://example.com/profile.jpg",
-            isPrivate: false,
-            isCurrentUser: false
-        )
+        vm.username = "John Doe"
+        vm.profileImageURL = "https://example.com/profile.jpg"
+        vm.isPrivateProfile = false
         vm.spots = [
             Spot(
                 id: "spot3",
@@ -241,25 +227,14 @@ class ProfileViewModel: ObservableObject {
 
     static let previewPrivateViewModel: ProfileViewModel = {
         let vm = ProfileViewModel()
-        vm.user = User(
-            id: "private123",
-            username: "Private User",
-            profileImageURL: nil,
-            isPrivate: true,
-            isCurrentUser: false
-        )
+        vm.username = "Private User"
+        vm.isPrivateProfile = true
         return vm
     }()
 
     static let previewEmptyViewModel: ProfileViewModel = {
         let vm = ProfileViewModel()
-        vm.user = User(
-            id: "empty123",
-            username: "New User",
-            profileImageURL: nil,
-            isPrivate: false,
-            isCurrentUser: false
-        )
+        vm.username = "New User"
         vm.spots = []
         return vm
     }()

--- a/Spot/Views/Components/EmptyFeedView.swift
+++ b/Spot/Views/Components/EmptyFeedView.swift
@@ -1,0 +1,33 @@
+//
+//  EmptyFeedView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct EmptyFeedView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 60))
+                .foregroundColor(.gray)
+
+            Text("No Spots Yet")
+                .font(FontManager.sectionHeader())
+                .foregroundColor(Constants.Colors.primary)
+
+            Text("Follow people to see their spots!")
+                .font(FontManager.primaryText())
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+        }
+        .background(Color(hex: "F5F3EF"))
+    }
+}

--- a/Spot/Views/Components/FeedContentView.swift
+++ b/Spot/Views/Components/FeedContentView.swift
@@ -1,0 +1,106 @@
+//
+//  FeedContentView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct FeedContentView: View {
+    @Binding var isLoading: Bool
+    let spots: [Spot]
+    let mapSpots: [Spot]
+    let selectedTab: String
+    let onScrolledToBottom: () -> Void
+    let onRefresh: () async -> Void
+    let userId: String?
+    let onDeleteSpot: (Spot) -> Void
+    var onFirstItemAppeared: (() -> Void)? = nil
+    @State private var firstItemRecorded = false
+    @State private var failedImageSpotIds: Set<String> = []
+
+    var body: some View {
+        Group {
+            if selectedTab == "Map" {
+                MapView(spots: mapSpots)
+                    .ignoresSafeArea(edges: .all)
+            } else if isLoading && spots.isEmpty {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(0..<3, id: \.self) { _ in
+                            SkeletonSpotCard()
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                }
+            } else if !spots.isEmpty {
+                ScrollView {
+                    RefreshControl(coordinateSpace: .named("RefreshControl")) {
+                        failedImageSpotIds.removeAll()
+                        Task { await onRefresh() }
+                    }
+
+                    LazyVStack(spacing: 0) {
+                        ForEach(spots.indices, id: \.self) { idx in
+                            let spot = spots[idx]
+                            Group {
+                                if (spot.imageURL ?? "").isEmpty {
+                                    SkeletonSpotCard()
+                                } else {
+                                    SpotCard(
+                                        spot: spot,
+                                        showUserInfo: true,
+                                        userId: userId,
+                                        onDelete: { onDeleteSpot(spot) },
+                                        source: "Feed",
+                                        onImageFailure: { failed in
+                                            if let failedId = failed.id { failedImageSpotIds.insert(failedId) }
+                                        },
+                                        onImageRetry: { retrySpot in
+                                            if let rid = retrySpot.id { failedImageSpotIds.remove(rid) }
+                                        }
+                                    )
+                                }
+                            }
+                            .onAppear {
+                                if (spot.imageURL ?? "").isEmpty {
+                                    SpotLogger.error("Feed missing imageURL for spot id=\(spot.safeId) — rendering placeholder")
+                                }
+                                if !firstItemRecorded {
+                                    onFirstItemAppeared?()
+                                    firstItemRecorded = true
+                                }
+                                let progress = Double(idx + 1) / Double(max(spots.count, 1))
+                                if progress >= 0.7 { onScrolledToBottom() }
+                            }
+                        }
+                        if isLoading {
+                            ProgressView().padding()
+                        } else {
+                            GeometryReader { geo in
+                                Color.clear
+                                    .onAppear {
+                                        if geo.frame(in: .global).maxY < UIScreen.main.bounds.height + 100 {
+                                            onScrolledToBottom()
+                                        }
+                                    }
+                            }
+                            .frame(height: 1)
+                        }
+                    }
+                }
+                .refreshable {
+                    failedImageSpotIds.removeAll()
+                    await onRefresh()
+                }
+                .coordinateSpace(name: "RefreshControl")
+                .background(Color(hex: "F5F3EF"))
+            } else {
+                EmptyFeedView()
+            }
+        }
+        .background(Color(hex: "F5F3EF"))
+    }
+}

--- a/Spot/Views/Components/FeedMapTabBarView.swift
+++ b/Spot/Views/Components/FeedMapTabBarView.swift
@@ -1,0 +1,38 @@
+//
+//  FeedMapTabBarView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct FeedMapTabBarView: View {
+    @Binding var selectedFeedView: String
+    let tabs: [String]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 32) {
+                ForEach(tabs, id: \.self) { tab in
+                    VStack(spacing: 4) {
+                        Text(tab)
+                            .font(FontManager.primaryText())
+                            .fontWeight(selectedFeedView == tab ? .semibold : .regular)
+                            .foregroundColor(selectedFeedView == tab ? Constants.Colors.primary : .gray)
+                        Rectangle()
+                            .fill(selectedFeedView == tab ? Constants.Colors.primary : Color.clear)
+                            .frame(height: 2)
+                    }
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: 0.2)) { selectedFeedView = tab }
+                    }
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+        }
+        .padding(.top, 8)
+    }
+}

--- a/Spot/Views/Components/LoadingView.swift
+++ b/Spot/Views/Components/LoadingView.swift
@@ -1,0 +1,21 @@
+//
+//  LoadingView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            ProgressView()
+                .scaleEffect(1.5)
+            Spacer()
+        }
+        .background(Color(hex: "F5F3EF"))
+    }
+}

--- a/Spot/Views/Components/RefreshControl.swift
+++ b/Spot/Views/Components/RefreshControl.swift
@@ -1,0 +1,43 @@
+//
+//  RefreshControl.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct RefreshControl: View {
+    let coordinateSpace: CoordinateSpace
+    let onRefresh: () -> Void
+
+    @State private var isRefreshing = false
+
+    var body: some View {
+        GeometryReader { geo in
+            if geo.frame(in: coordinateSpace).midY > 50 {
+                Spacer()
+                    .onAppear {
+                        if !isRefreshing {
+                            isRefreshing = true
+                            onRefresh()
+                        }
+                    }
+            } else if geo.frame(in: coordinateSpace).midY < 0 {
+                Spacer()
+                    .onAppear {
+                        isRefreshing = false
+                    }
+            }
+            HStack {
+                Spacer()
+                if isRefreshing {
+                    ProgressView()
+                }
+                Spacer()
+            }
+        }
+        .padding(.top, -50)
+    }
+}

--- a/Spot/Views/Components/SpotMapMarker.swift
+++ b/Spot/Views/Components/SpotMapMarker.swift
@@ -1,0 +1,33 @@
+//
+//  SpotMapMarker.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+import MapKit
+
+struct SpotAnnotation: Identifiable {
+    let id = UUID()
+    let spot: Spot
+    let coordinate: CLLocationCoordinate2D
+
+    init(spot: Spot) {
+        self.spot = spot
+        self.coordinate = CLLocationCoordinate2D(
+            latitude: spot.latitude ?? 0.0,
+            longitude: spot.longitude ?? 0.0
+        )
+    }
+}
+
+struct SpotMapMarker: View {
+    let spot: Spot
+    var body: some View {
+        Image("green_marker")
+            .resizable()
+            .frame(width: 20, height: 20)
+    }
+}

--- a/Spot/Views/Components/SpotsListView.swift
+++ b/Spot/Views/Components/SpotsListView.swift
@@ -1,0 +1,25 @@
+//
+//  SpotsListView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct SpotsListView: View {
+    let spots: [Spot]
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(spots) { spot in
+                    SpotCard(spot: spot)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .background(Color(hex: "F5F3EF"))
+    }
+}

--- a/Spot/Views/Components/TabNavigationView.swift
+++ b/Spot/Views/Components/TabNavigationView.swift
@@ -1,0 +1,49 @@
+//
+//  TabNavigationView.swift
+//  Spot
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+
+struct TabNavigationView: View {
+    @Binding var selectedTab: String
+    let tabs: [String]
+
+    var body: some View {
+        HStack(spacing: 32) {
+            ForEach(tabs, id: \.self) { tab in
+                TabItemView(tab: tab, isSelected: selectedTab == tab) {
+                    SpotLogger.debug("User switched to tab: \(tab)")
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedTab = tab
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .background(Color(hex: "F5F3EF"))
+    }
+}
+
+struct TabItemView: View {
+    let tab: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(tab)
+                .font(FontManager.primaryText())
+                .fontWeight(isSelected ? .semibold : .regular)
+                .foregroundColor(isSelected ? Constants.Colors.primary : .gray)
+
+            Rectangle()
+                .fill(isSelected ? Constants.Colors.primary : Color.clear)
+                .frame(height: 2)
+        }
+        .onTapGesture(perform: onTap)
+    }
+}

--- a/Spot/Views/Home/HomepageView.swift
+++ b/Spot/Views/Home/HomepageView.swift
@@ -1,119 +1,4 @@
 import SwiftUI
-import MapKit
-import FirebaseFirestore // Added for DocumentSnapshot
-import FirebaseAuth
-
-class FeedViewModel: ObservableObject {
-    @Published var spots: [Spot] = []
-    @Published var mapSpots: [Spot] = []
-    @Published var isLoading = false
-    @Published var hasMore = true
-    @Published var deletingSpotIds: Set<String> = []
-    private var loadTask: Task<Void, Never>?
-    private let repo = FeedRepository.shared
-
-    deinit {
-        loadTask?.cancel()
-    }
-
-    func loadInitialSpots() async {
-        loadTask?.cancel()
-        loadTask = Task {
-            await MainActor.run { self.isLoading = true }
-            await repo.loadInitial()
-            await MainActor.run {
-                self.spots = repo.spots
-                self.hasMore = repo.moreAvailable
-                self.isLoading = false
-            }
-        }
-    }
-
-    func loadMoreSpots() {
-        guard !isLoading, hasMore else { return }
-
-        // Cancel any existing task
-        loadTask?.cancel()
-
-        // Start new loading task
-        loadTask = Task {
-            await MainActor.run { self.isLoading = true }
-            await repo.loadMore()
-            await MainActor.run {
-                let new = repo.spots
-                self.spots = new
-                self.hasMore = repo.moreAvailable
-                self.isLoading = false
-            }
-        }
-    }
-
-    func refreshFeed() async {
-        // Cancel any existing task
-        loadTask?.cancel()
-
-        // Start new refresh task
-        loadTask = Task {
-            await MainActor.run { self.isLoading = true }
-            await repo.loadInitial()
-            await MainActor.run {
-                self.spots = repo.spots
-                self.hasMore = repo.moreAvailable
-                self.isLoading = false
-            }
-        }
-        // Wait for the task to complete
-        await loadTask?.value
-    }
-    
-    // MARK: - Insert newly posted spot
-    @MainActor
-    func insertNewSpot(_ spot: Spot) {
-        // Remove if already exists (shouldn't happen, but safety check)
-        spots.removeAll { $0.id == spot.id }
-        // Insert at the beginning
-        spots.insert(spot, at: 0)
-        SpotLogger.info("Inserted new spot at top of feed", details: ["spotId": spot.safeId])
-    }
-
-    func loadMapSpots(forceRefresh: Bool = false) {
-        // No-op: Map now loads by viewport; keep an empty set here
-        SpotLogger.debug("Map spots warm disabled; viewport loader handles fetching", details: [:])
-        self.mapSpots = []
-    }
-
-    // MARK: - Delete
-    @MainActor
-    func delete(spot: Spot) async {
-        guard let id = spot.id else {
-            SpotLogger.error("Delete requested for spot without id", details: [:])
-            return
-        }
-        if deletingSpotIds.contains(id) { return }
-        deletingSpotIds.insert(id)
-
-        // Optimistic removal
-        let prevSpots = spots
-        let prevMap = mapSpots
-        spots.removeAll { $0.id == id }
-        mapSpots.removeAll { $0.id == id }
-
-        do {
-            SpotLogger.info("Deleting spot", details: ["spotId": id])
-            // Run deletion off main
-            try await SpotService.shared.deleteSpot(spot)
-            deletingSpotIds.remove(id)
-            // Force refresh map spots after successful deletion
-            loadMapSpots(forceRefresh: true)
-        } catch {
-            SpotLogger.error("Delete failed", details: ["spotId": id, "error": error.localizedDescription])
-            // Rollback
-            spots = prevSpots
-            mapSpots = prevMap
-            deletingSpotIds.remove(id)
-        }
-    }
-}
 
 struct HomepageView: View {
     @EnvironmentObject var authVM: AuthViewModel
@@ -122,8 +7,11 @@ struct HomepageView: View {
     @State private var showPostSuccessToast = false
     // Tour
     @StateObject private var tourManager = HomeTourManager()
-    var isFirstSessionAfterSignup: Bool { authVM.isAuthenticated && (authVM.likedSpots.isEmpty && authVM.bookmarkedSpots.isEmpty) && !tourManager.hasSeenHomeTour }
     @State private var coachFrames: [CoachTarget: CGRect] = [:]
+
+    private var isFirstSessionAfterSignup: Bool {
+        authVM.isAuthenticated && (authVM.likedSpots.isEmpty && authVM.bookmarkedSpots.isEmpty) && !tourManager.hasSeenHomeTour
+    }
 
     var body: some View {
         NavigationStack {
@@ -147,7 +35,8 @@ struct HomepageView: View {
                         userId: authVM.userId,
                         onDeleteSpot: { spot in
                             Task { await feedVM.delete(spot: spot) }
-                        }
+                        },
+                        onFirstItemAppeared: { feedVM.recordFirstItemIfNeeded() }
                     )
                 }
             }
@@ -156,20 +45,10 @@ struct HomepageView: View {
                     if showVerifyToast {
                         ToastView(message: "Please verify your email to post a spot.", isError: true)
                             .transition(.move(edge: .top))
-                            .onAppear {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                    withAnimation { showVerifyToast = false }
-                                }
-                            }
                     }
                     if showPostSuccessToast {
                         SuccessToastView(message: "Spot posted!")
                             .transition(.move(edge: .top))
-                            .onAppear {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                    withAnimation { showPostSuccessToast = false }
-                                }
-                            }
                     }
                 }
                 .padding(.top, 8)
@@ -199,227 +78,9 @@ struct HomepageView: View {
     }
 }
 
-// MARK: - Feed Content Component
-struct FeedContentView: View {
-    @Binding var isLoading: Bool
-    let spots: [Spot]
-    let mapSpots: [Spot]
-    let selectedTab: String
-    let onScrolledToBottom: () -> Void
-    let onRefresh: () async -> Void
-    let userId: String?
-    let onDeleteSpot: (Spot) -> Void
-    @State private var firstItemRecorded = false
-    @State private var failedImageSpotIds: Set<String> = []
-
-    var validSpots: [Spot] { spots }
-
-    var validMapSpots: [Spot] {
-        mapSpots.filter { spot in
-            spot.latitude != nil &&
-            spot.longitude != nil
-        }
-    }
-
-    var body: some View {
-        Group {
-            if selectedTab == "Map" {
-                MapView(spots: validMapSpots)
-                    .ignoresSafeArea(edges: .all)
-            } else if isLoading && spots.isEmpty {
-                // Skeletons while initial load
-                ScrollView {
-                    LazyVStack(spacing: 12) {
-                        ForEach(0..<3, id: \.self) { _ in
-                            SkeletonSpotCard()
-                        }
-                    }
-                    .padding(.horizontal, 12)
-                }
-            } else if !validSpots.isEmpty {
-                ScrollView {
-                    RefreshControl(coordinateSpace: .named("RefreshControl")) {
-                        failedImageSpotIds.removeAll()
-                        Task { await onRefresh() }
-                    }
-
-                    LazyVStack(spacing: 0) {
-                        ForEach(validSpots.indices, id: \.self) { idx in
-                            let spot = validSpots[idx]
-                            Group {
-                                if (spot.imageURL ?? "").isEmpty {
-                                    SkeletonSpotCard()
-                                } else {
-                                    SpotCard(
-                                        spot: spot,
-                                        showUserInfo: true,
-                                        userId: userId,
-                                        onDelete: { onDeleteSpot(spot) },
-                                        source: "Feed",
-                                        onImageFailure: { failed in
-                                            if let failedId = failed.id { failedImageSpotIds.insert(failedId) }
-                                        },
-                                        onImageRetry: { retrySpot in
-                                            // Remove from failed set to allow re-attempt render
-                                            if let rid = retrySpot.id { failedImageSpotIds.remove(rid) }
-                                        }
-                                    )
-                                }
-                            }
-                            .onAppear {
-                                if (spot.imageURL ?? "").isEmpty {
-                                    SpotLogger.error("Feed missing imageURL for spot id=\(spot.safeId) — rendering placeholder")
-                                }
-                                if !firstItemRecorded {
-                                    let t = PerfMetrics.shared.measure("t_first_item") ?? 0
-                                    PerfMetrics.shared.recordOnce("t_first_item", value: t)
-                                    firstItemRecorded = true
-                                }
-                                let progress = Double(idx + 1) / Double(max(validSpots.count, 1))
-                                if progress >= 0.7 { onScrolledToBottom() }
-                            }
-                        }
-                        if isLoading {
-                            ProgressView().padding()
-                        } else {
-                            GeometryReader { geo in
-                                Color.clear
-                                    .onAppear {
-                                        if geo.frame(in: .global).maxY < UIScreen.main.bounds.height + 100 {
-                                            onScrolledToBottom()
-                                        }
-                                    }
-                            }
-                            .frame(height: 1)
-                        }
-                    }
-                }
-                .refreshable {
-                    failedImageSpotIds.removeAll()
-                    await onRefresh()
-                }
-                .coordinateSpace(name: "RefreshControl")
-                .background(Color(hex: "F5F3EF"))
-            } else {
-                EmptyFeedView()
-            }
-        }
-        .background(Color(hex: "F5F3EF"))
-    }
-}
-
-struct RefreshControl: View {
-    let coordinateSpace: CoordinateSpace
-    let onRefresh: () -> Void
-
-    @State private var isRefreshing = false
-
-    var body: some View {
-        GeometryReader { geo in
-            if geo.frame(in: coordinateSpace).midY > 50 {
-                Spacer()
-                    .onAppear {
-                        if !isRefreshing {
-                            isRefreshing = true
-                            onRefresh()
-                        }
-                    }
-            } else if geo.frame(in: coordinateSpace).midY < 0 {
-                Spacer()
-                    .onAppear {
-                        isRefreshing = false
-                    }
-            }
-            HStack {
-                Spacer()
-                if isRefreshing {
-                    ProgressView()
-                }
-                Spacer()
-            }
-        }
-        .padding(.top, -50)
-    }
-}
-
-struct LoadingView: View {
-    var body: some View {
-        VStack {
-                    Spacer()
-                    ProgressView()
-                        .scaleEffect(1.5)
-                    Spacer()
-        }
-        .background(Color(hex: "F5F3EF"))
-    }
-}
-
-struct EmptyFeedView: View {
-    var body: some View {
-                    VStack(spacing: 20) {
-                        Spacer()
-
-                        Image(systemName: "photo.on.rectangle.angled")
-                            .font(.system(size: 60))
-                            .foregroundColor(.gray)
-
-                        Text("No Spots Yet")
-                            .font(FontManager.sectionHeader())
-                            .foregroundColor(Constants.Colors.primary)
-
-            Text("Follow people to see their spots!")
-                            .font(FontManager.primaryText())
-                            .foregroundColor(.gray)
-                            .multilineTextAlignment(.center)
-
-                        Spacer()
-                    }
-        .background(Color(hex: "F5F3EF"))
-    }
-}
-
-struct SpotsListView: View {
-    let spots: [Spot]
-
-    var body: some View {
-                    ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(spots) { spot in
-                                SpotCard(spot: spot)
-                            }
-                        }
-                        .padding(.vertical, 8)
-        }
-        .background(Color(hex: "F5F3EF"))
-                    }
-                }
-
 #Preview() {
     HomepageView()
-}
-
-// MARK: - Map Components
-struct SpotAnnotation: Identifiable {
-    let id = UUID()
-    let spot: Spot
-    let coordinate: CLLocationCoordinate2D
-
-    init(spot: Spot) {
-        self.spot = spot
-        self.coordinate = CLLocationCoordinate2D(
-            latitude: spot.latitude ?? 0.0,
-            longitude: spot.longitude ?? 0.0
-        )
-    }
-}
-
-struct SpotMapMarker: View {
-    let spot: Spot
-    var body: some View {
-        Image("green_marker")
-            .resizable()
-            .frame(width: 20, height: 20)
-    }
+        .environmentObject(AuthViewModel())
 }
 
 // SpotCard Preview

--- a/Spot/Views/Home/MapView.swift
+++ b/Spot/Views/Home/MapView.swift
@@ -1,34 +1,28 @@
 import SwiftUI
 import MapKit
 import CoreLocation
-import FirebaseFirestore
 
 @MainActor
 struct MapView: View {
-    let spots: [Spot]
+    @StateObject private var mapVM = MapViewModel()
     @StateObject private var locationManager = LocationManager.shared
     @EnvironmentObject var authVM: AuthViewModel
 
-    // iOS 17 camera replacement for coordinateRegion
     @State private var cameraPosition: MapCameraPosition
     @State private var selectedSpot: Spot?
     @State private var hasPerformedInitialFit: Bool = false
-    @State private var visibleSpots: [Spot] = []
     @State private var regionLoadTask: Task<Void, Never>?
-    @State private var isLoadingAllSpots: Bool = false
 
     @Environment(\.verticalSizeClass) private var vSize
 
-    init(spots: [Spot]) {
-        self.spots = spots
+    init(spots: [Spot] = []) {
         _cameraPosition = State(initialValue: .region(LocationManager.shared.getUserRegion()))
     }
 
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .bottom) {
-                // Clustered map (UIKit-backed) for performance with many pins
-                ClusteredSpotMap(spots: visibleSpots, onRegionChanged: { region in
+                ClusteredSpotMap(spots: mapVM.visibleSpots, onRegionChanged: { _ in
                     // Region changes don't need to reload - we show all spots
                 }) { spot, coord in
                     select(spot, coord)
@@ -45,8 +39,7 @@ struct MapView: View {
             .onAppear {
                 locationManager.startUpdatingLocation()
                 performInitialFitIfNeeded()
-                // Load all spots for map
-                loadAllSpots()
+                mapVM.loadAllSpots()
             }
             .onDisappear { 
                 locationManager.stopUpdatingLocation()
@@ -63,8 +56,7 @@ struct MapView: View {
                     hasPerformedInitialFit = true
                 }
             }
-            .onChange(of: spots) { _, _ in
-                // When spots load asynchronously, perform initial fit once.
+            .onChange(of: mapVM.visibleSpots) { _, _ in
                 performInitialFitIfNeeded()
             }
         }
@@ -108,7 +100,7 @@ struct MapView: View {
     private func zoomToFitAllPins() { /* handled inside ClusteredSpotMap */ }
 
     private var hasValidSpots: Bool {
-        return spots.contains { $0.latitude != nil && $0.longitude != nil }
+        return mapVM.visibleSpots.contains { $0.latitude != nil && $0.longitude != nil }
     }
 
     private func performInitialFitIfNeeded() {
@@ -121,24 +113,6 @@ struct MapView: View {
         hasPerformedInitialFit = true
     }
 
-    private func loadAllSpots() {
-        guard !isLoadingAllSpots else { return }
-        isLoadingAllSpots = true
-        
-        SpotService.shared.fetchSpotsForMap(forceRefresh: true) { result in
-            DispatchQueue.main.async {
-                self.isLoadingAllSpots = false
-                switch result {
-                case .success(let spots):
-                    self.visibleSpots = spots
-                    SpotLogger.info("Map loaded all spots", details: ["count": spots.count])
-                case .failure(let error):
-                    SpotLogger.error("Failed to load all spots for map", details: ["error": error.localizedDescription])
-                }
-            }
-        }
-    }
-    
     private func debounceLoad(for region: MKCoordinateRegion) {
         // Keep for region changes if needed, but initial load uses loadAllSpots
         regionLoadTask?.cancel()

--- a/Spot/Views/PostFlow/PostFlowView.swift
+++ b/Spot/Views/PostFlow/PostFlowView.swift
@@ -3,6 +3,7 @@ import CoreLocation
 
 struct PostFlowView: View {
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var authVM: AuthViewModel
     @StateObject private var viewModel = PostFlowViewModel()
 
     var onPostSuccess: ((Spot) -> Void)?
@@ -88,6 +89,7 @@ struct PostFlowView: View {
             }
         }
         .onAppear {
+            viewModel.authViewModel = authVM
             viewModel.onPostSuccess = onPostSuccess
             viewModel.onShouldDismiss = { dismiss() }
         }
@@ -221,4 +223,5 @@ struct ToastView: View {
 
 #Preview {
     PostFlowView()
+        .environmentObject(AuthViewModel())
 }

--- a/Spot/Views/PostFlow/PostFlowView.swift
+++ b/Spot/Views/PostFlow/PostFlowView.swift
@@ -1,32 +1,17 @@
 import SwiftUI
-import FirebaseAuth
-import FirebaseFirestore
 import CoreLocation
 
 struct PostFlowView: View {
     @Environment(\.dismiss) var dismiss
-    @State private var currentStep = 1
-    @State private var selectedImages: [UIImage] = []
-    @State private var selectedLocation: LocationData?
-    @State private var selectedVibe: String = ""
-    @State private var isUploading = false
-    @State private var isPosting = false
-    @State private var moderationMessage: String?
-    @State private var showToast = false
-    @State private var toastMessage = ""
-    @State private var toastIsError = false
-    @State private var showSuccessBanner = false
+    @StateObject private var viewModel = PostFlowViewModel()
 
     var onPostSuccess: ((Spot) -> Void)?
-
-    private let totalSteps = 3
 
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
                 VStack(spacing: 0) {
-                    // Gate: require verified email
-                    if !(Auth.auth().currentUser?.isEmailVerified ?? false) {
+                    if !viewModel.isEmailVerified {
                         VStack(spacing: 12) {
                             Text("Email verification required to post")
                                 .font(FontManager.primaryText())
@@ -45,51 +30,47 @@ struct PostFlowView: View {
                         .padding(16)
                         .background(Constants.Colors.background)
                     } else {
-                    // Progress Indicator
-                    ProgressIndicatorView(currentStep: currentStep, totalSteps: totalSteps)
+                        ProgressIndicatorView(currentStep: viewModel.currentStep, totalSteps: viewModel.totalSteps)
 
-                    // Step Content
-                    Group {
-                        switch currentStep {
-                        case 1:
-                            PhotoSelectionView(selectedImages: $selectedImages)
-                        case 2:
-                            LocationSelectionView(selectedLocation: $selectedLocation)
-                        case 3:
-                            VibeSelectionView(selectedVibe: $selectedVibe)
-                        default:
-                            EmptyView()
+                        Group {
+                            switch viewModel.currentStep {
+                            case 1:
+                                PhotoSelectionView(selectedImages: $viewModel.selectedImages)
+                            case 2:
+                                LocationSelectionView(selectedLocation: $viewModel.selectedLocation)
+                            case 3:
+                                VibeSelectionView(selectedVibe: $viewModel.selectedVibe)
+                            default:
+                                EmptyView()
+                            }
                         }
-                    }
-                    .transition(.asymmetric(
+                        .transition(.asymmetric(
                         insertion: .move(edge: .trailing),
                         removal: .move(edge: .leading)
                     ))
 
-                    // Navigation Buttons
-                    NavigationButtonsView(
-                        currentStep: $currentStep,
-                        totalSteps: totalSteps,
-                        canProceed: canProceedToNextStep && !isPosting,
-                        isPosting: isPosting,
-                        onBack: handleBack,
-                        onNext: handleNext,
-                        onFinish: handleFinish
-                    )
-                }
+                        NavigationButtonsView(
+                            currentStep: $viewModel.currentStep,
+                            totalSteps: viewModel.totalSteps,
+                            canProceed: viewModel.canProceedToNextStep && !viewModel.isPosting,
+                            isPosting: viewModel.isPosting,
+                            onBack: { viewModel.goBack() },
+                            onNext: { viewModel.goNext() },
+                            onFinish: { viewModel.submitPost() }
+                        )
+                    }
                 }
 
-                // Top status overlays
                 VStack(spacing: 8) {
-                    if isUploading {
+                    if viewModel.isUploading {
                         ProgressBarView()
                             .transition(.move(edge: .top))
                     }
-                    if showToast {
-                        ToastView(message: toastMessage, isError: toastIsError)
+                    if viewModel.showToast {
+                        ToastView(message: viewModel.toastMessage, isError: viewModel.toastIsError)
                             .transition(.move(edge: .top))
                     }
-                    if showSuccessBanner {
+                    if viewModel.showSuccessBanner {
                         SuccessToastView(message: "Spot posted!")
                             .transition(.move(edge: .top))
                     }
@@ -106,212 +87,13 @@ struct PostFlowView: View {
                 }
             }
         }
-    }
-
-    private var canProceedToNextStep: Bool {
-        switch currentStep {
-        case 1:
-            return !selectedImages.isEmpty
-        case 2:
-            return selectedLocation != nil
-        case 3:
-            return !selectedVibe.isEmpty
-        default:
-            return false
-        }
-    }
-
-    private func handleBack() {
-        if currentStep > 1 {
-            SpotLogger.debug("User went back from step \(currentStep) to step \(currentStep - 1)")
-            withAnimation(.easeInOut(duration: 0.3)) {
-                currentStep -= 1
-            }
-        }
-    }
-
-    private func handleNext() {
-        if currentStep < totalSteps {
-            SpotLogger.debug("User progressed from step \(currentStep) to step \(currentStep + 1)")
-            withAnimation(.easeInOut(duration: 0.3)) {
-                currentStep += 1
-            }
-        }
-    }
-
-    private func handleFinish() {
-        if isPosting { return }
-        isPosting = true
-        SpotLogger.info("User completed post flow")
-        SpotLogger.debug("Post data - Images: \(selectedImages.count), Location: \(selectedLocation?.placeName ?? "None"), Vibe: \(selectedVibe)")
-
-        guard let location = selectedLocation,
-              !selectedVibe.isEmpty,
-              !location.placeName.isEmpty,
-              location.coordinate.latitude != 0,
-              location.coordinate.longitude != 0
-        else {
-            showToastWith(message: "All fields are required to post a spot.", isError: true)
-            return
-        }
-
-        isUploading = true
-
-        let imagesToUpload = selectedImages
-        if imagesToUpload.count <= 1, let image = imagesToUpload.first {
-            SpotUploader.shared.uploadSpot(
-                image: image,
-                vibeTag: selectedVibe,
-                latitude: location.coordinate.latitude,
-                longitude: location.coordinate.longitude,
-                placeName: location.placeName
-            ) { result in
-                DispatchQueue.main.async {
-                    isUploading = false
-                    switch result {
-                    case .success:
-                        if let userId = Auth.auth().currentUser?.uid {
-                            SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: selectedVibe)
-                        }
-                        Task { await self.awaitModerationAndFinish() }
-                    case .failure(let error):
-                        showToastWith(message: error.localizedDescription, isError: true)
-                        SpotLogger.error("Spot upload failed: \(error.localizedDescription)")
-                        isPosting = false
-                    }
-                }
-            }
-            return
-        }
-
-        // Multi-image upload
-        SpotUploader.shared.uploadSpot(
-            images: imagesToUpload,
-            vibeTag: selectedVibe,
-            latitude: location.coordinate.latitude,
-            longitude: location.coordinate.longitude,
-            placeName: location.placeName
-        ) { result in
-            DispatchQueue.main.async {
-                isUploading = false
-                switch result {
-                case .success:
-                    if let userId = Auth.auth().currentUser?.uid {
-                        SpotUploader.incrementUserVibeStat(userId: userId, vibeTag: selectedVibe)
-                    }
-                    Task { await self.awaitModerationAndFinish() }
-                case .failure(let error):
-                    showToastWith(message: error.localizedDescription, isError: true)
-                    SpotLogger.error("Spot upload failed: \(error.localizedDescription)")
-                    isPosting = false
-                }
-            }
-        }
-    }
-
-    private func awaitModerationAndFinish() async {
-        guard let uid = Auth.auth().currentUser?.uid else { isPosting = false; return }
-        // We need the latest spot doc; since SpotUploader writes the doc ID internally, fetch most recent by this user
-        // If you have the postId, prefer using it directly.
-        let db = Firestore.firestore()
-        do {
-            let snap = try await db.collection("spots").whereField("userId", isEqualTo: uid).order(by: "createdAt", descending: true).limit(to: 1).getDocuments()
-            guard let doc = snap.documents.first else { isPosting = false; return }
-            let spotRef = doc.reference
-            SpotLogger.info("Moderation.Check.Begin spotId=\(doc.documentID)")
-
-            // Poll up to ~20s to avoid blocking issues
-            for _ in 0..<20 {
-                let latest = try await spotRef.getDocument()
-                if await self.evaluateModeration(doc: latest) { return }
-                try await Task.sleep(nanoseconds: 1_000_000_000) // 1s
-            }
-            SpotLogger.error("Moderation check timeout", details: ["spotId": doc.documentID])
-            await MainActor.run {
-                self.moderationMessage = "We couldn’t verify your image yet. Please retry.This is day zero of making the best new social media app and youre coming along for the eride this is anoytjer angle even though you dont get to see my screen and now I have my third angle ho[wejfijwhefowenfiuwhc0ijckjwnhcoijwdlnweoim"
-                self.showToastWith(message: self.moderationMessage ?? "", isError: true)
-                self.isPosting = false
-            }
-        } catch {
-            SpotLogger.error("Moderation gate error: \(error.localizedDescription)")
-            await MainActor.run { self.isPosting = false }
-        }
-    }
-
-    private func evaluateModeration(doc: DocumentSnapshot) async -> Bool {
-        let data = doc.data() ?? [:]
-        let moderation = data["moderation"] as? [String: Any]
-        let status = moderation?["status"] as? String ?? "pending"
-        let scores = moderation?["scores"] as? [String: Any]
-
-        if status == "approved" {
-            let (ok, reason) = ModerationPolicy.evaluate(scores: scores)
-                if ok {
-                    SpotLogger.info("Moderation.Check.Approved spotId=\(doc.documentID) scores=\(scores ?? [:])")
-                    // Convert document to Spot and pass to callback
-                    if var spot = try? doc.data(as: Spot.self) {
-                        spot.id = doc.documentID
-                        await MainActor.run {
-                            // Track successful post
-                            AnalyticsService.shared.trackUserAction("spot_posted", contentType: "spot", contentId: doc.documentID, parameters: [
-                                "vibe_tag": spot.vibeTag ?? "",
-                                "has_multiple_images": spot.imageURLs?.count ?? 0 > 1
-                            ])
-                            // Dismiss immediately, success will show on homepage
-                            self.onPostSuccess?(spot)
-                            self.isPosting = false
-                            self.dismiss()
-                        }
-                    } else {
-                        // Fallback if conversion fails
-                        await MainActor.run {
-                            AnalyticsService.shared.trackUserAction("spot_posted", contentType: "spot", contentId: doc.documentID)
-                            self.onPostSuccess?(Spot(id: doc.documentID))
-                            self.isPosting = false
-                            self.dismiss()
-                        }
-                    }
-                    return true
-            } else {
-                SpotLogger.error("Post blocked by moderation", details: ["reason": reason ?? "over_threshold", "spotId": doc.documentID])
-                await MainActor.run {
-                    self.moderationMessage = "This photo violates our guidelines and can’t be posted."
-                    self.showToastWith(message: self.moderationMessage ?? "", isError: true)
-                    self.isPosting = false
-                }
-                return true
-            }
-        } else if status == "rejected" {
-            SpotLogger.error("Moderation check rejected", details: ["spotId": doc.documentID, "scores": scores ?? [:]])
-            // Hard block: delete the spot doc so it never surfaces
-            try? await doc.reference.delete()
-            await MainActor.run {
-                self.moderationMessage = "This photo violates our guidelines and can’t be posted."
-                self.showToastWith(message: self.moderationMessage ?? "", isError: true)
-                self.isPosting = false
-            }
-            return true
-        } else {
-            SpotLogger.debug("Moderation.Check.Pending spotId=\(doc.documentID)")
-            return false
-        }
-    }
-
-    private func showToastWith(message: String, isError: Bool) {
-        toastMessage = message
-        toastIsError = isError
-        withAnimation {
-            showToast = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-            withAnimation {
-                showToast = false
-            }
+        .onAppear {
+            viewModel.onPostSuccess = onPostSuccess
+            viewModel.onShouldDismiss = { dismiss() }
         }
     }
 }
 
-// MARK: - Progress Indicator
 struct ProgressIndicatorView: View {
     let currentStep: Int
     let totalSteps: Int

--- a/Spot/Views/Profile/ProfileView.swift
+++ b/Spot/Views/Profile/ProfileView.swift
@@ -7,35 +7,21 @@
 
 import SwiftUI
 import MapKit
-import FirebaseFirestore
 
 struct ProfileView: View {
     var userId: String?
-    // If true, this screen was pushed from another screen (e.g., Feed/Search).
-    // In that case, show a custom back button and hide bottom nav.
     var fromNavigationPush: Bool = false
     @EnvironmentObject var authVM: AuthViewModel
-    @State private var username: String? = ""
-    @State private var profileImageURL: String?
-    @State private var spots: [Spot] = []
+    @StateObject private var viewModel = ProfileViewModel()
     @State private var selectedTab = "Spots"
-    @State private var isLoading = true
     @State private var selectedSpot: Spot?
     @State private var pendingDeleteSpot: Spot?
     @State private var showDeleteConfirm: Bool = false
-    @State private var deletingSpotIds: Set<String> = []
-    @State private var isPrivateProfile: Bool = false
-    @State private var isProProfile: Bool = false
-    @State private var isFollowingUser: Bool = false
-    @State private var hasRequestedFollow: Bool = false
-    @State private var canViewContent: Bool = true
     @State private var showMenu: Bool = false
     @State private var showSettingsNav: Bool = false
     @State private var showLikesNav: Bool = false
     @State private var showBookmarksNav: Bool = false
     @State private var showFollowRequestsNav: Bool = false
-    @State private var followRequestsCount: Int = 0
-    @State private var followReqListener: ListenerRegistration?
     @State private var isMapExpanded: Bool = false
 
     @Environment(\.dismiss) private var dismiss
@@ -138,7 +124,7 @@ struct ProfileView: View {
                 .padding(.top, 8)
 
                 // MARK: — Loading State
-                if isLoading {
+                if viewModel.isLoading {
                     Spacer()
                     ProgressView()
                     Spacer()
@@ -149,7 +135,7 @@ struct ProfileView: View {
                         if selectedSpot == nil && !(selectedTab == "Map" && isMapExpanded) {
                             // Full header
                             VStack(spacing: 12) {
-                                if let url = profileImageURL {
+                                if let url = viewModel.profileImageURL {
                                     AsyncImage(url: URL(string: url)) { img in
                                         img.resizable()
                                            .aspectRatio(contentMode: .fill)
@@ -168,10 +154,10 @@ struct ProfileView: View {
                                 }
 
                                 HStack(spacing: 8) {
-                                    Text(username ?? "")
+                                    Text(viewModel.username ?? "")
                                         .font(FontManager.sectionHeader())
                                         .foregroundColor(.black)
-                                    if (userId == nil || userId == authVM.userId) ? authVM.isPro : isProProfile {
+                                    if (userId == nil || userId == authVM.userId) ? authVM.isPro : viewModel.isProProfile {
                                         Text("Pro")
                                             .font(.caption)
                                             .foregroundColor(Constants.Colors.buttonText)
@@ -182,7 +168,7 @@ struct ProfileView: View {
                                     }
                                 }
 
-                                Text("\(spots.count) spots shared")
+                                Text("\(viewModel.spots.count) spots shared")
                                     .font(FontManager.primaryText())
                                     .foregroundColor(.gray)
                             }
@@ -190,7 +176,7 @@ struct ProfileView: View {
                         } else if selectedSpot != nil && selectedTab == "Map" {
                             // Collapsed header when spot is selected on map
                             HStack(spacing: 12) {
-                                if let url = profileImageURL {
+                                if let url = viewModel.profileImageURL {
                                     AsyncImage(url: URL(string: url)) { img in
                                         img.resizable()
                                            .aspectRatio(contentMode: .fill)
@@ -208,11 +194,11 @@ struct ProfileView: View {
                                         .foregroundColor(.gray)
                                 }
                                 
-                                Text(username ?? "")
+                                Text(viewModel.username ?? "")
                                     .font(FontManager.primaryText())
                                     .foregroundColor(.black)
                                 
-                                if (userId == nil || userId == authVM.userId) ? authVM.isPro : isProProfile {
+                                if (userId == nil || userId == authVM.userId) ? authVM.isPro : viewModel.isProProfile {
                                     Text("Pro")
                                         .font(.caption2)
                                         .foregroundColor(Constants.Colors.buttonText)
@@ -231,22 +217,9 @@ struct ProfileView: View {
                         // Follow / Request actions centered under header when viewing someone else
                         if let viewedUserId = userId, viewedUserId != authVM.userId {
                             VStack {
-                                if isFollowingUser {
+                                if viewModel.isFollowingUser {
                                     Button {
-                                        // Optimistic update
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            self.isFollowingUser = false
-                                        }
-                                        UserSpotService.shared.unfollow(userId: viewedUserId) { result in
-                                            DispatchQueue.main.async {
-                                                if case .failure = result {
-                                                    // Revert on error
-                                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                                        self.isFollowingUser = true
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        viewModel.unfollow(targetUserId: viewedUserId)
                                     } label: {
                                         Text("Unfollow")
                                             .font(FontManager.primaryText())
@@ -257,26 +230,13 @@ struct ProfileView: View {
                                             .cornerRadius(20)
                                     }
                                     .buttonStyle(PlainButtonStyle())
-                                } else if isPrivateProfile {
+                                } else if viewModel.isPrivateProfile {
                                     VStack(spacing: 8) {
                                         Button {
-                                            if hasRequestedFollow { return }
-                                            // Optimistic update
-                                            withAnimation(.easeInOut(duration: 0.2)) {
-                                                self.hasRequestedFollow = true
-                                            }
-                                            UserSpotService.shared.requestFollow(userId: viewedUserId) { result in
-                                                DispatchQueue.main.async {
-                                                    if case .failure = result {
-                                                        // Revert on error
-                                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                                            self.hasRequestedFollow = false
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                            if viewModel.hasRequestedFollow { return }
+                                            viewModel.requestFollow(targetUserId: viewedUserId)
                                         } label: {
-                                            Text(hasRequestedFollow ? "Requested" : "Request to Follow")
+                                            Text(viewModel.hasRequestedFollow ? "Requested" : "Request to Follow")
                                                 .font(FontManager.primaryText())
                                                 .foregroundColor(Constants.Colors.buttonText)
                                                 .padding(.horizontal, 16)
@@ -284,25 +244,12 @@ struct ProfileView: View {
                                                 .background(Constants.Colors.primary)
                                                 .cornerRadius(20)
                                         }
-                                        .disabled(hasRequestedFollow)
+                                        .disabled(viewModel.hasRequestedFollow)
                                         .buttonStyle(PlainButtonStyle())
 
-                                        if hasRequestedFollow {
+                                        if viewModel.hasRequestedFollow {
                                             Button {
-                                                // Optimistic update
-                                                withAnimation(.easeInOut(duration: 0.2)) {
-                                                    self.hasRequestedFollow = false
-                                                }
-                                                UserSpotService.shared.cancelFollowRequest(userId: viewedUserId) { result in
-                                                    DispatchQueue.main.async {
-                                                        if case .failure = result {
-                                                            // Revert on error
-                                                            withAnimation(.easeInOut(duration: 0.2)) {
-                                                                self.hasRequestedFollow = true
-                                                            }
-                                                        }
-                                                    }
-                                                }
+                                                viewModel.cancelFollowRequest(targetUserId: viewedUserId)
                                             } label: {
                                                 Text("Cancel Request")
                                                     .font(FontManager.primaryText())
@@ -313,20 +260,7 @@ struct ProfileView: View {
                                     }
                                 } else {
                                     Button {
-                                        // Optimistic update
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            self.isFollowingUser = true
-                                        }
-                                        UserSpotService.shared.follow(userId: viewedUserId) { result in
-                                            DispatchQueue.main.async {
-                                                if case .failure = result {
-                                                    // Revert on error
-                                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                                        self.isFollowingUser = false
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        viewModel.follow(targetUserId: viewedUserId)
                                     } label: {
                                         Text("Follow")
                                             .font(FontManager.primaryText())
@@ -375,14 +309,14 @@ struct ProfileView: View {
                                 .transition(.opacity)
                                 .zIndex(1)
                             } else {
-                                SpotsGridView(spots: spots) { tapped in
+                                SpotsGridView(spots: viewModel.spots) { tapped in
                                     selectedSpot = tapped
                                 }
                                 .zIndex(0)
                             }
                         } else {
                             // Map tab
-                            ProfileMapView(spots: spots, onSpotTap: { tapped in
+                            ProfileMapView(spots: viewModel.spots, onSpotTap: { tapped in
                                 selectedSpot = tapped
                             }, onCollapseChange: { expanded in
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) { isMapExpanded = expanded }
@@ -402,7 +336,7 @@ struct ProfileView: View {
                     .onTapGesture { withAnimation { showMenu = false } }
 
                 VStack(alignment: .leading, spacing: 0) {
-                    if userId == nil || userId == authVM.userId, !isProProfile {
+                    if userId == nil || userId == authVM.userId, !viewModel.isProProfile {
                         Button {
                             withAnimation { showMenu = false }
                             SpotLogger.info("Open paywall from profile menu")
@@ -452,7 +386,7 @@ struct ProfileView: View {
 
                     Divider()
 
-                    if isPrivateProfile {
+                    if viewModel.isPrivateProfile {
                         Button {
                             withAnimation { showMenu = false }
                             showFollowRequestsNav = true
@@ -461,8 +395,8 @@ struct ProfileView: View {
                                 Image(systemName: "person.badge.plus")
                                 Text("Follow Requests")
                                     .font(FontManager.primaryText())
-                                if followRequestsCount > 0 {
-                                    Text("\(followRequestsCount)")
+                                if viewModel.followRequestsCount > 0 {
+                                    Text("\(viewModel.followRequestsCount)")
                                         .font(.caption)
                                         .padding(.horizontal, 6)
                                         .padding(.vertical, 2)
@@ -508,28 +442,17 @@ struct ProfileView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .onAppear {
-            // Only load if we haven't loaded this user yet
-            if lastLoadedUserId != userId {
-                loadUser()
-            }
-            // Start/stop pending count listener for own private profile
+            Task { await viewModel.loadUser(userId: userId) }
             let isSelf = (userId == nil) || (userId == authVM.userId)
-            if isSelf && isPrivateProfile, let uid = authVM.userId {
-                followReqListener?.remove()
-                followReqListener = FollowRequestsService.shared.listenPendingCount(for: uid) { n in
-                    followRequestsCount = n
-                }
+            if isSelf && viewModel.isPrivateProfile {
+                viewModel.startFollowRequestsListener(ownUserId: authVM.userId)
             }
         }
-        .onDisappear { 
-            followReqListener?.remove(); 
-            followReqListener = nil
-            // Clear selected spot with a small delay to ensure map cleanup completes
-            // This prevents Metal crashes when navigating away
+        .onDisappear {
+            viewModel.stopFollowRequestsListener()
             Task { @MainActor in
                 selectedSpot = nil
-                // Small delay to let Metal finish rendering before view deallocation
-                try? await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
+                try? await Task.sleep(nanoseconds: 150_000_000)
             }
         }
         .navigationDestination(isPresented: $showSettingsNav) {
@@ -551,55 +474,14 @@ struct ProfileView: View {
         }
         .alert("Delete this spot? This can't be undone.", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
-                if let spot = pendingDeleteSpot { Task { await deleteSpotFromProfile(spot) } }
+                if let spot = pendingDeleteSpot { Task { await viewModel.deleteSpot(spot) } }
+                pendingDeleteSpot = nil
             }
             Button("Cancel", role: .cancel) { pendingDeleteSpot = nil }
         }
         .onChange(of: authVM.isPro) { _, newValue in
-            // Update isProProfile when viewing own profile
             if userId == nil || userId == authVM.userId {
-                isProProfile = newValue
-            }
-        }
-    }
-
-    @State private var isLoadingUser = false
-    @State private var lastLoadedUserId: String?
-
-    private func loadUser(forceReload: Bool = false) {
-        // Prevent multiple concurrent calls
-        guard !isLoadingUser else { return }
-
-        // Prevent reloading the same user unless forced
-        if !forceReload, let lastLoaded = lastLoadedUserId, lastLoaded == userId {
-            return
-        }
-
-        isLoadingUser = true
-        isLoading = true
-
-        Task {
-            do {
-                let data = try await ProfileService.fetchProfile(for: userId)
-                await MainActor.run {
-                    username = data.username
-                    profileImageURL = data.profileImageURL
-                    spots = data.spots
-                    isPrivateProfile = data.isPrivate
-                    isProProfile = data.isPro
-                    isFollowingUser = data.isFollowing
-                    hasRequestedFollow = data.hasRequested
-                    canViewContent = data.canView
-                    lastLoadedUserId = userId
-                    isLoading = false
-                    isLoadingUser = false
-                }
-            } catch {
-                await MainActor.run {
-                    isLoading = false
-                    isLoadingUser = false
-                }
-                SpotLogger.error("Profile loadUser failed: \(error.localizedDescription)")
+                viewModel.isProProfile = newValue
             }
         }
     }
@@ -610,26 +492,4 @@ struct ProfileView: View {
     auth.isPro = true
     return ProfileView(userId: nil, fromNavigationPush: false)
         .environmentObject(auth)
-}
-
-// MARK: - Deletion helpers
-extension ProfileView {
-    @MainActor
-    private func deleteSpotFromProfile(_ spot: Spot) async {
-        guard let id = spot.id else { return }
-        if deletingSpotIds.contains(id) { return }
-        deletingSpotIds.insert(id)
-
-        let prevSpots = spots
-        spots.removeAll { $0.id == id }
-
-        do {
-            try await SpotService.shared.deleteSpot(spot)
-            deletingSpotIds.remove(id)
-        } catch {
-            SpotLogger.error("Profile delete failed: \(error.localizedDescription)")
-            spots = prevSpots
-            deletingSpotIds.remove(id)
-        }
-    }
 }

--- a/SpotTests/ConstantsTests.swift
+++ b/SpotTests/ConstantsTests.swift
@@ -1,0 +1,34 @@
+//
+//  ConstantsTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import SwiftUI
+import Testing
+@testable import Spot
+
+struct ConstantsTests {
+
+    @Test func colorHexParsing() {
+        let color = Color(hex: "#FF0000")
+        #expect(color != nil)
+    }
+
+    @Test func colorHexWithoutHash() {
+        let color = Color(hex: "00FF00")
+        #expect(color != nil)
+    }
+
+    @Test func colorHexBlack() {
+        let color = Color(hex: "#000000")
+        #expect(color != nil)
+    }
+
+    @Test func colorHexWhite() {
+        let color = Color(hex: "#FFFFFF")
+        #expect(color != nil)
+    }
+}

--- a/SpotTests/DebouncerTests.swift
+++ b/SpotTests/DebouncerTests.swift
@@ -6,16 +6,25 @@
 //  Date: 03/02/2025
 //
 
+import Foundation
 import Testing
 @testable import Spot
 
 struct DebouncerTests {
 
+    /// Runs the main run loop for the given duration so DispatchQueue.main work can execute.
+    private func runMainLoop(for duration: TimeInterval) async {
+        await MainActor.run {
+            RunLoop.main.run(until: Date().addingTimeInterval(duration))
+        }
+    }
+
     @Test func scheduleRunsBlock() async throws {
-        let debouncer = Debouncer(interval: 0.1)
+        let debouncer = Debouncer(interval: 0.15)
         var ran = false
         debouncer.schedule { ran = true }
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(10))  // Let schedule enqueue
+        await runMainLoop(for: 0.35)
         #expect(ran)
     }
 
@@ -24,7 +33,7 @@ struct DebouncerTests {
         var ran = false
         debouncer.schedule { ran = true }
         debouncer.cancel()
-        try await Task.sleep(for: .milliseconds(200))
+        await runMainLoop(for: 0.25)
         #expect(!ran)
     }
 
@@ -34,7 +43,7 @@ struct DebouncerTests {
         var second = false
         debouncer.schedule { first = true }
         debouncer.schedule { second = true }
-        try await Task.sleep(for: .milliseconds(150))
+        await runMainLoop(for: 0.2)
         #expect(!first)
         #expect(second)
     }

--- a/SpotTests/DebouncerTests.swift
+++ b/SpotTests/DebouncerTests.swift
@@ -1,0 +1,41 @@
+//
+//  DebouncerTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct DebouncerTests {
+
+    @Test func scheduleRunsBlock() async throws {
+        let debouncer = Debouncer(interval: 0.1)
+        var ran = false
+        debouncer.schedule { ran = true }
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(ran)
+    }
+
+    @Test func cancelPreventsExecution() async throws {
+        let debouncer = Debouncer(interval: 10.0)
+        var ran = false
+        debouncer.schedule { ran = true }
+        debouncer.cancel()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(!ran)
+    }
+
+    @Test func scheduleReplacesPrevious() async throws {
+        let debouncer = Debouncer(interval: 0.1)
+        var first = false
+        var second = false
+        debouncer.schedule { first = true }
+        debouncer.schedule { second = true }
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(!first)
+        #expect(second)
+    }
+}

--- a/SpotTests/DeepLinkRouterTests.swift
+++ b/SpotTests/DeepLinkRouterTests.swift
@@ -1,0 +1,100 @@
+//
+//  DeepLinkRouterTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+import Testing
+@testable import Spot
+
+struct DeepLinkRouterTests {
+
+    private let router = DeepLinkRouter.shared
+
+    @Test func parseUniversalLinkSpotDetail() {
+        let url = URL(string: "https://spotapp.online/s/abc123xyz")!
+        let route = router.parseURL(url)
+        if case .spotDetail(let spotId) = route {
+            #expect(spotId == "abc123xyz")
+        } else { Issue.record("Expected spotDetail") }
+    }
+
+    @Test func parseLocalhostUniversalLink() {
+        let url = URL(string: "http://localhost/s/validSpotId")!
+        let route = router.parseURL(url)
+        if case .spotDetail(let spotId) = route {
+            #expect(spotId == "validSpotId")
+        } else { Issue.record("Expected spotDetail") }
+    }
+
+    @Test func parseCustomSchemeHostVariant() {
+        let url = URL(string: "spotapp://spot/abc123")!
+        let route = router.parseURL(url)
+        if case .spotDetail(let spotId) = route {
+            #expect(spotId == "abc123")
+        } else { Issue.record("Expected spotDetail") }
+    }
+
+    @Test func parseCustomSchemePathVariant() {
+        let url = URL(string: "spotapp:///spot/xyz789")!
+        let route = router.parseURL(url)
+        if case .spotDetail(let spotId) = route {
+            #expect(spotId == "xyz789")
+        } else { Issue.record("Expected spotDetail") }
+    }
+
+    @Test func parseCustomSchemeQueryVariant() {
+        let url = URL(string: "spotapp://open?spotId=querySpotId")!
+        let route = router.parseURL(url)
+        if case .spotDetail(let spotId) = route {
+            #expect(spotId == "querySpotId")
+        } else { Issue.record("Expected spotDetail") }
+    }
+
+    @Test func parseSubscriptionReturn() {
+        let url = URL(string: "spotapp://subscription/return")!
+        let route = router.parseURL(url)
+        if case .subscriptionReturn = route { } else { Issue.record("Expected subscriptionReturn") }
+    }
+
+    @Test func parseUnknownScheme() {
+        let url = URL(string: "mailto:test@example.com")!
+        let route = router.parseURL(url)
+        if case .unknown = route { } else { Issue.record("Expected unknown") }
+    }
+
+    @Test func parseInvalidSpotIdEmpty() {
+        let url = URL(string: "https://spotapp.online/s/")!
+        let route = router.parseURL(url)
+        if case .unknown = route { } else { Issue.record("Expected unknown for empty spotId") }
+    }
+
+    @Test func parseInvalidSpotIdTooLong() {
+        let longId = String(repeating: "a", count: 51)
+        let url = URL(string: "https://spotapp.online/s/\(longId)")!
+        let route = router.parseURL(url)
+        if case .unknown = route { } else { Issue.record("Expected unknown for too long spotId") }
+    }
+
+    @Test func parseInvalidSpotIdInvalidChars() {
+        let url = URL(string: "https://spotapp.online/s/spot%20id")!
+        let route = router.parseURL(url)
+        if case .unknown = route { } else { Issue.record("Expected unknown for invalid chars") }
+    }
+
+    @Test func urlQueryParameters() {
+        let url = URL(string: "https://example.com?foo=bar&baz=qux")!
+        let params = url.queryParameters
+        #expect(params != nil)
+        #expect(params?["foo"] == "bar")
+        #expect(params?["baz"] == "qux")
+    }
+
+    @Test func urlQueryParametersNilWhenNoQuery() {
+        let url = URL(string: "https://example.com/path")!
+        #expect(url.queryParameters == nil)
+    }
+}

--- a/SpotTests/FeedRankerTests.swift
+++ b/SpotTests/FeedRankerTests.swift
@@ -1,0 +1,143 @@
+//
+//  FeedRankerTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import CoreLocation
+import Testing
+@testable import Spot
+
+struct FeedRankerTests {
+
+    private func makeSpot(id: String? = "s1", userId: String = "u1", vibeTag: String? = "Chill", lat: Double? = nil, lon: Double? = nil, createdAt: Date? = nil) -> Spot {
+        Spot(id: id, userId: userId, vibeTag: vibeTag, latitude: lat, longitude: lon, createdAt: createdAt ?? Date())
+    }
+
+    @Test func scoreVibeWeight() {
+        let ranker = FeedRanker.shared
+        let spot = makeSpot(vibeTag: "Chill")
+        let ctx = FeedRanker.Context(
+            followeeIds: [],
+            userVibeStats: ["Chill": 3, "Other": 1],
+            userLocation: nil,
+            seenSpotIds: []
+        )
+        let s = ranker.score(spot, ctx: ctx)
+        #expect(s > 0)
+        #expect(s <= 1.0)
+    }
+
+    @Test func scoreFreshnessDecay() {
+        let ranker = FeedRanker.shared
+        let spot = makeSpot(createdAt: Date().addingTimeInterval(-3600))
+        let ctx = FeedRanker.Context(
+            followeeIds: [],
+            userVibeStats: [:],
+            userLocation: nil,
+            seenSpotIds: []
+        )
+        let s = ranker.score(spot, ctx: ctx)
+        #expect(s >= 0)
+    }
+
+    @Test func scoreAffinityFollowee() {
+        let ranker = FeedRanker.shared
+        let spot = makeSpot(userId: "followee1")
+        let ctx = FeedRanker.Context(
+            followeeIds: ["followee1"],
+            userVibeStats: ["Chill": 1],
+            userLocation: nil,
+            seenSpotIds: []
+        )
+        let sFollowee = ranker.score(spot, ctx: ctx)
+        let spotNonFollowee = makeSpot(userId: "other")
+        let sNonFollowee = ranker.score(spotNonFollowee, ctx: ctx)
+        #expect(sFollowee > sNonFollowee)
+    }
+
+    @Test func scoreDistanceWithinNearKm() {
+        let ranker = FeedRanker.shared
+        let userLoc = CLLocation(latitude: 40.7, longitude: -74.0)
+        let spot = makeSpot(lat: 40.71, lon: -74.01)
+        let ctx = FeedRanker.Context(
+            followeeIds: [],
+            userVibeStats: ["Chill": 1],
+            userLocation: userLoc,
+            seenSpotIds: []
+        )
+        let s = ranker.score(spot, ctx: ctx)
+        #expect(s > 0)
+    }
+
+    @Test func scoreDistanceFarDecays() {
+        let ranker = FeedRanker.shared
+        let userLoc = CLLocation(latitude: 40.7, longitude: -74.0)
+        let spot = makeSpot(lat: 50.0, lon: -74.0)
+        let ctx = FeedRanker.Context(
+            followeeIds: [],
+            userVibeStats: ["Chill": 1],
+            userLocation: userLoc,
+            seenSpotIds: []
+        )
+        let s = ranker.score(spot, ctx: ctx)
+        #expect(s >= 0)
+    }
+
+    @Test func scoreZeroVibeStats() {
+        let ranker = FeedRanker.shared
+        let spot = makeSpot()
+        let ctx = FeedRanker.Context(
+            followeeIds: [],
+            userVibeStats: [:],
+            userLocation: nil,
+            seenSpotIds: []
+        )
+        let s = ranker.score(spot, ctx: ctx)
+        #expect(s >= 0)
+    }
+
+    @Test func blendMergesFolloweesAndGlobal() {
+        let ranker = FeedRanker.shared
+        let f1 = makeSpot(id: "f1", userId: "u1")
+        let g1 = makeSpot(id: "g1", userId: "u2")
+        let result = ranker.blend(followees: [f1], global: [g1], pageSize: 24)
+        #expect(result.count >= 2)
+    }
+
+    @Test func blendDeduplicatesById() {
+        let ranker = FeedRanker.shared
+        let s1 = makeSpot(id: "same", userId: "u1")
+        let s2 = makeSpot(id: "same", userId: "u1")
+        let result = ranker.blend(followees: [s1], global: [s2], pageSize: 24)
+        #expect(result.count == 1)
+    }
+
+    @Test func blendCreatorCap() {
+        let ranker = FeedRanker.shared
+        let s1 = makeSpot(id: "a1", userId: "u1")
+        let s2 = makeSpot(id: "a2", userId: "u1")
+        let s3 = makeSpot(id: "a3", userId: "u1")
+        let result = ranker.blend(followees: [s1, s2, s3], global: [], pageSize: 24, creatorCap: 2)
+        let fromU1 = result.filter { $0.userId == "u1" }
+        #expect(fromU1.count <= 2)
+    }
+
+    @Test func blendFallbackKeyForNilId() {
+        let ranker = FeedRanker.shared
+        let s1 = makeSpot(id: nil, userId: "u1", createdAt: Date(timeIntervalSince1970: 1000))
+        let s2 = makeSpot(id: nil, userId: "u1", createdAt: Date(timeIntervalSince1970: 1001))
+        let result = ranker.blend(followees: [s1, s2], global: [], pageSize: 24)
+        #expect(result.count == 2)
+    }
+
+    @Test func blendBackfillWhenUnderfilled() {
+        let ranker = FeedRanker.shared
+        let f1 = makeSpot(id: "f1", userId: "u1")
+        let g1 = makeSpot(id: "g1", userId: "u2")
+        let result = ranker.blend(followees: [f1], global: [g1], pageSize: 10)
+        #expect(result.count >= 2)
+    }
+}

--- a/SpotTests/FeedViewModelTests.swift
+++ b/SpotTests/FeedViewModelTests.swift
@@ -1,0 +1,53 @@
+//
+//  FeedViewModelTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Foundation
+import Testing
+@testable import Spot
+
+struct FeedViewModelTests {
+
+    private func makeSpot(id: String? = "s1", lat: Double? = nil, lon: Double? = nil) -> Spot {
+        Spot(id: id, userId: "u1", vibeTag: "Chill", latitude: lat, longitude: lon, createdAt: Date())
+    }
+
+    @Test func validSpotsReturnsSpotsUnfiltered() {
+        let vm = FeedViewModel()
+        let spot1 = makeSpot(id: "a", lat: 40.0, lon: -74.0)
+        let spot2 = makeSpot(id: "b", lat: nil, lon: nil)
+        vm.spots = [spot1, spot2]
+        #expect(vm.validSpots.count == 2)
+        #expect(vm.validSpots[0].id == "a")
+        #expect(vm.validSpots[1].id == "b")
+    }
+
+    @Test func validMapSpotsFiltersOutSpotsWithoutCoordinates() {
+        let vm = FeedViewModel()
+        let withCoords = makeSpot(id: "with", lat: 40.0, lon: -74.0)
+        let noLat = makeSpot(id: "noLat", lat: nil, lon: -74.0)
+        let noLon = makeSpot(id: "noLon", lat: 40.0, lon: nil)
+        let noCoords = makeSpot(id: "noCoords", lat: nil, lon: nil)
+        vm.mapSpots = [withCoords, noLat, noLon, noCoords]
+        #expect(vm.validMapSpots.count == 1)
+        #expect(vm.validMapSpots[0].id == "with")
+    }
+
+    @Test func validMapSpotsIncludesAllWhenAllHaveCoordinates() {
+        let vm = FeedViewModel()
+        let s1 = makeSpot(id: "1", lat: 40.0, lon: -74.0)
+        let s2 = makeSpot(id: "2", lat: 41.0, lon: -73.0)
+        vm.mapSpots = [s1, s2]
+        #expect(vm.validMapSpots.count == 2)
+    }
+
+    @Test func validMapSpotsEmptyWhenMapSpotsEmpty() {
+        let vm = FeedViewModel()
+        vm.mapSpots = []
+        #expect(vm.validMapSpots.isEmpty)
+    }
+}

--- a/SpotTests/GeoHashTests.swift
+++ b/SpotTests/GeoHashTests.swift
@@ -1,0 +1,59 @@
+//
+//  GeoHashTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct GeoHashTests {
+
+    @Test func encodeReturnsCorrectHash() {
+        let hash = GeoHash.encode(latitude: 37.7749, longitude: -122.4194, precision: 7)
+        #expect(!hash.isEmpty)
+        #expect(hash.count == 7)
+        #expect(hash.allSatisfy { "0123456789bcdefghjkmnpqrstuvwxyz".contains($0) })
+    }
+
+    @Test func encodeWithPrecision1() {
+        let hash = GeoHash.encode(latitude: 0, longitude: 0, precision: 1)
+        #expect(hash.count == 1)
+    }
+
+    @Test func encodeSameCoordsSameHash() {
+        let h1 = GeoHash.encode(latitude: 40.7, longitude: -74.0, precision: 5)
+        let h2 = GeoHash.encode(latitude: 40.7, longitude: -74.0, precision: 5)
+        #expect(h1 == h2)
+    }
+
+    @Test func neighborsEmptyReturnsEmpty() {
+        let result = GeoHash.neighbors(of: "")
+        #expect(result.isEmpty)
+    }
+
+    @Test func neighborsSingleCharReturnsAdjacent() {
+        let result = GeoHash.neighbors(of: "u")
+        #expect(!result.isEmpty)
+        #expect(result.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test func neighborsMultiCharReturns8Variants() {
+        let hash = "ezjmg"
+        let result = GeoHash.neighbors(of: hash)
+        #expect(!result.isEmpty)
+        #expect(Set(result).count == result.count)
+    }
+
+    @Test func endRangeReturnsPrefixWithTilde() {
+        let result = GeoHash.endRange(for: "abc123")
+        #expect(result == "abc123~")
+    }
+
+    @Test func endRangeEmptyPrefix() {
+        let result = GeoHash.endRange(for: "")
+        #expect(result == "~")
+    }
+}

--- a/SpotTests/HomepageViewModelTests.swift
+++ b/SpotTests/HomepageViewModelTests.swift
@@ -1,0 +1,61 @@
+//
+//  HomepageViewModelTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct HomepageViewModelTests {
+
+    @Test func initialState() {
+        let vm = HomepageViewModel()
+        #expect(vm.selectedTab == "Home")
+        #expect(vm.feedViewType == "Feed")
+        #expect(vm.showUploadView == false)
+        #expect(vm.showRulesSheet == false)
+        #expect(vm.showVerifyToast == false)
+        #expect(vm.showPostSuccessToast == false)
+    }
+
+    @Test func onPlusTappedShowsRulesSheet() {
+        let vm = HomepageViewModel()
+        #expect(vm.showRulesSheet == false)
+        vm.onPlusTapped()
+        #expect(vm.showRulesSheet == true)
+    }
+
+    @Test func agreeToRulesThenOpenUploadWhenVerifiedOpensUpload() {
+        let vm = HomepageViewModel()
+        vm.showRulesSheet = true
+        vm.agreeToRulesThenOpenUpload(isEmailVerified: true)
+        #expect(vm.showRulesSheet == false)
+        #expect(vm.showUploadView == true)
+    }
+
+    @Test func agreeToRulesThenOpenUploadWhenNotVerifiedDoesNothing() {
+        let vm = HomepageViewModel()
+        vm.showRulesSheet = true
+        vm.showUploadView = false
+        vm.agreeToRulesThenOpenUpload(isEmailVerified: false)
+        #expect(vm.showRulesSheet == true)
+        #expect(vm.showUploadView == false)
+    }
+
+    @Test func dismissVerifyToastClearsFlag() {
+        let vm = HomepageViewModel()
+        vm.showVerifyToast = true
+        vm.dismissVerifyToast()
+        #expect(vm.showVerifyToast == false)
+    }
+
+    @Test func dismissPostSuccessToastClearsFlag() {
+        let vm = HomepageViewModel()
+        vm.showPostSuccessToast = true
+        vm.dismissPostSuccessToast()
+        #expect(vm.showPostSuccessToast == false)
+    }
+}

--- a/SpotTests/ModerationPolicyTests.swift
+++ b/SpotTests/ModerationPolicyTests.swift
@@ -1,0 +1,96 @@
+//
+//  ModerationPolicyTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct ModerationPolicyTests {
+
+    @Test func evaluateNilScoresReturnsNotApproved() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: nil)
+        #expect(!approved)
+        #expect(reason == "missing_scores")
+    }
+
+    @Test func evaluateEmptyScoresReturnsApproved() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: [:])
+        #expect(approved)
+        #expect(reason == nil)
+    }
+
+    @Test func evaluateSexualOverThresholdBlocks() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["sexual": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:sexual")
+    }
+
+    @Test func evaluateViolenceOverThresholdBlocks() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["violence": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:violence")
+    }
+
+    @Test func evaluateHateOverThresholdBlocks() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["hate": 4])
+        #expect(!approved)
+        #expect(reason == "over_threshold:hate")
+    }
+
+    @Test func evaluateSelfHarmOverThresholdBlocks() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["selfharm": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:selfharm")
+    }
+
+    @Test func evaluateBelowThresholdApproved() {
+        let (approved, _) = ModerationPolicy.evaluate(scores: ["sexual": 2, "violence": 1, "hate": 3])
+        #expect(approved)
+    }
+
+    @Test func evaluateDoubleValueRounds() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["sexual": 3.7])
+        #expect(!approved)
+        #expect(reason == "over_threshold:sexual")
+    }
+
+    @Test func evaluateStringValueParsed() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["sexual": "3"])
+        #expect(!approved)
+        #expect(reason == "over_threshold:sexual")
+    }
+
+    @Test func evaluateCaseInsensitiveKeys() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["SEXUAL": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:sexual")
+    }
+
+    @Test func evaluateAdultAlias() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["adult": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:sexual")
+    }
+
+    @Test func evaluateViolentAlias() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["violent": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:violence")
+    }
+
+    @Test func evaluateHatespeechAlias() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["hatespeech": 4])
+        #expect(!approved)
+        #expect(reason == "over_threshold:hate")
+    }
+
+    @Test func evaluateSelfInjuryAlias() {
+        let (approved, reason) = ModerationPolicy.evaluate(scores: ["selfinjury": 3])
+        #expect(!approved)
+        #expect(reason == "over_threshold:selfharm")
+    }
+}

--- a/SpotTests/PlaceNameValidatorTests.swift
+++ b/SpotTests/PlaceNameValidatorTests.swift
@@ -1,0 +1,52 @@
+//
+//  PlaceNameValidatorTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct PlaceNameValidatorTests {
+
+    @Test func validateTooShort() {
+        let validator = PlaceNameValidator()
+        if case .tooShort = validator.validate("a") { } else { Issue.record("Expected tooShort") }
+    }
+
+    @Test func validateTooLong() {
+        let validator = PlaceNameValidator()
+        let long = String(repeating: "x", count: 61)
+        if case .tooLong = validator.validate(long) { } else { Issue.record("Expected tooLong") }
+    }
+
+    @Test func validateOk() {
+        let validator = PlaceNameValidator()
+        if case .ok(let s) = validator.validate("Central Park") {
+            #expect(!s.isEmpty)
+        } else { Issue.record("Expected ok") }
+    }
+
+    @Test func validateBlockedExact() {
+        let validator = PlaceNameValidator()
+        if case .blocked = validator.validate("fuck") { } else { Issue.record("Expected blocked") }
+    }
+
+    @Test func validateBlockedContains() {
+        let validator = PlaceNameValidator()
+        if case .blocked = validator.validate("My fuck place") { } else { Issue.record("Expected blocked") }
+    }
+
+    @Test func validateOkAtMinLength() {
+        let validator = PlaceNameValidator()
+        if case .ok = validator.validate("abc") { } else { Issue.record("Expected ok") }
+    }
+
+    @Test func validateOkAtMaxLength() {
+        let validator = PlaceNameValidator()
+        let s = String(repeating: "a", count: 20)
+        if case .ok = validator.validate(s) { } else { Issue.record("Expected ok at max") }
+    }
+}

--- a/SpotTests/PostFlowViewModelTests.swift
+++ b/SpotTests/PostFlowViewModelTests.swift
@@ -1,0 +1,107 @@
+//
+//  PostFlowViewModelTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import CoreLocation
+import Testing
+import UIKit
+@testable import Spot
+
+struct PostFlowViewModelTests {
+
+    @Test func isEmailVerifiedWhenAuthViewModelNilReturnsFalse() {
+        let vm = PostFlowViewModel()
+        vm.authViewModel = nil
+        #expect(vm.isEmailVerified == false)
+    }
+
+    @Test func isEmailVerifiedWhenAuthViewModelNotVerifiedReturnsFalse() {
+        let vm = PostFlowViewModel()
+        let auth = AuthViewModel()
+        auth.isEmailVerified = false
+        vm.authViewModel = auth
+        #expect(vm.isEmailVerified == false)
+    }
+
+    @Test func isEmailVerifiedWhenAuthViewModelVerifiedReturnsTrue() {
+        let vm = PostFlowViewModel()
+        let auth = AuthViewModel()
+        auth.isEmailVerified = true
+        vm.authViewModel = auth
+        #expect(vm.isEmailVerified == true)
+    }
+
+    @Test func canProceedToNextStepStep1RequiresImages() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 1
+        vm.selectedImages = []
+        #expect(vm.canProceedToNextStep == false)
+        vm.selectedImages = [UIImage()]
+        #expect(vm.canProceedToNextStep == true)
+    }
+
+    @Test func canProceedToNextStepStep2RequiresLocation() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 2
+        vm.selectedLocation = nil
+        #expect(vm.canProceedToNextStep == false)
+        vm.selectedLocation = LocationData(
+            coordinate: CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0),
+            placeName: "Test",
+            address: nil,
+            isCustomName: false
+        )
+        #expect(vm.canProceedToNextStep == true)
+    }
+
+    @Test func canProceedToNextStepStep3RequiresVibe() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 3
+        vm.selectedVibe = ""
+        #expect(vm.canProceedToNextStep == false)
+        vm.selectedVibe = "Chill"
+        #expect(vm.canProceedToNextStep == true)
+    }
+
+    @Test func goBackAtStep1DoesNothing() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 1
+        vm.goBack()
+        #expect(vm.currentStep == 1)
+    }
+
+    @Test func goBackDecrementsStep() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 2
+        vm.goBack()
+        #expect(vm.currentStep == 1)
+        vm.currentStep = 3
+        vm.goBack()
+        #expect(vm.currentStep == 2)
+    }
+
+    @Test func goNextIncrementsStep() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 1
+        vm.goNext()
+        #expect(vm.currentStep == 2)
+        vm.goNext()
+        #expect(vm.currentStep == 3)
+    }
+
+    @Test func goNextAtLastStepDoesNotExceedTotalSteps() {
+        let vm = PostFlowViewModel()
+        vm.currentStep = 3
+        vm.goNext()
+        #expect(vm.currentStep == 3)
+    }
+
+    @Test func totalStepsIsThree() {
+        let vm = PostFlowViewModel()
+        #expect(vm.totalSteps == 3)
+    }
+}

--- a/SpotTests/SpotExtensionTests.swift
+++ b/SpotTests/SpotExtensionTests.swift
@@ -1,0 +1,23 @@
+//
+//  SpotExtensionTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct SpotExtensionTests {
+
+    @Test func safeIdWithId() {
+        let spot = Spot(id: "spot123", userId: nil)
+        #expect(spot.safeId == "spot123")
+    }
+
+    @Test func safeIdWithoutId() {
+        let spot = Spot(id: nil, userId: nil)
+        #expect(spot.safeId == "nil")
+    }
+}

--- a/SpotTests/SpotTests.swift
+++ b/SpotTests/SpotTests.swift
@@ -2,16 +2,17 @@
 //  SpotTests.swift
 //  SpotTests
 //
-//  Created by Edward Wynman on 7/10/25.
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
 //
 
 import Testing
 @testable import Spot
 
+/// Root test suite - individual logic tests live in GeoHashTests, StringNormalizerTests, etc.
 struct SpotTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func spotModuleLoads() {
+        #expect(GeoHash.encode(latitude: 0, longitude: 0, precision: 1).count == 1)
     }
-
 }

--- a/SpotTests/StringNormalizerTests.swift
+++ b/SpotTests/StringNormalizerTests.swift
@@ -1,0 +1,46 @@
+//
+//  StringNormalizerTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct StringNormalizerTests {
+
+    @Test func normalizedLowercases() {
+        #expect(StringNormalizer.normalized("HELLO") == "helo")
+    }
+
+    @Test func normalizedRemovesDiacritics() {
+        let result = StringNormalizer.normalized("café")
+        #expect(result.contains("e"))
+        #expect(!result.contains("é"))
+    }
+
+    @Test func normalizedMapsLeetChars() {
+        #expect(StringNormalizer.normalized("h3ll0") == "helo")
+        #expect(StringNormalizer.normalized("p@ss") == "pas")
+        #expect(StringNormalizer.normalized("te$t") == "test")
+    }
+
+    @Test func normalizedRemovesNonAlphanumeric() {
+        #expect(StringNormalizer.normalized("hello world") == "heloworld")
+        #expect(StringNormalizer.normalized("a_b_c") == "abc")
+    }
+
+    @Test func normalizedCollapsesRepeats() {
+        #expect(StringNormalizer.normalized("heeeeello") == "helo")
+    }
+
+    @Test func normalizedEmptyString() {
+        #expect(StringNormalizer.normalized("") == "")
+    }
+
+    @Test func normalizedWhitespaceOnly() {
+        #expect(StringNormalizer.normalized("   ") == "")
+    }
+}

--- a/SpotTests/URLConfigurationTests.swift
+++ b/SpotTests/URLConfigurationTests.swift
@@ -1,0 +1,44 @@
+//
+//  URLConfigurationTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct URLConfigurationTests {
+
+    @Test func isAllowedUniversalLinkHostForKnownHost() {
+        let config = URLConfiguration.shared
+        #expect(config.isAllowedUniversalLinkHost("spotapp.online"))
+    }
+
+    @Test func isAllowedUniversalLinkHostForLocalhost() {
+        let config = URLConfiguration.shared
+        #expect(config.isAllowedUniversalLinkHost("localhost"))
+    }
+
+    @Test func isAllowedUniversalLinkHostForUnknownHost() {
+        let config = URLConfiguration.shared
+        #expect(!config.isAllowedUniversalLinkHost("evil.com"))
+    }
+
+    @Test func shareURLForSpotId() {
+        let config = URLConfiguration.shared
+        let url = config.shareURL(for: "abc123")
+        #expect(url.contains("/s/abc123"))
+    }
+
+    @Test func customScheme() {
+        let config = URLConfiguration.shared
+        #expect(config.customScheme == "spotapp")
+    }
+
+    @Test func shareURLBase() {
+        let config = URLConfiguration.shared
+        #expect(config.shareURLBase.contains("spotapp"))
+    }
+}

--- a/SpotTests/UsernameValidatorTests.swift
+++ b/SpotTests/UsernameValidatorTests.swift
@@ -1,0 +1,76 @@
+//
+//  UsernameValidatorTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct UsernameValidatorTests {
+
+    @Test func validateTooShort() {
+        let validator = UsernameValidator()
+        if case .tooShort = validator.validate("ab") { } else { Issue.record("Expected tooShort") }
+    }
+
+    @Test func validateTooLong() {
+        let validator = UsernameValidator()
+        let long = String(repeating: "a", count: 21)
+        if case .tooLong = validator.validate(long) { } else { Issue.record("Expected tooLong") }
+    }
+
+    @Test func validateOk() {
+        let validator = UsernameValidator()
+        if case .ok = validator.validate("validuser123") { } else { Issue.record("Expected ok") }
+    }
+
+    @Test func validateReserved() {
+        let validator = UsernameValidator()
+        if case .reserved = validator.validate("admin") { } else { Issue.record("Expected reserved") }
+    }
+
+    @Test func validateInvalidCharsLeadingDot() {
+        let validator = UsernameValidator()
+        if case .invalidChars = validator.validate(".user") { } else { Issue.record("Expected invalidChars") }
+    }
+
+    @Test func validateInvalidCharsTrailingDash() {
+        let validator = UsernameValidator()
+        if case .invalidChars = validator.validate("user-") { } else { Issue.record("Expected invalidChars") }
+    }
+
+    @Test func validateInvalidCharsConsecutive() {
+        let validator = UsernameValidator()
+        if case .invalidChars = validator.validate("user__name") { } else { Issue.record("Expected invalidChars") }
+    }
+
+    @Test func validateInvalidCharsDisallowedChars() {
+        let validator = UsernameValidator()
+        if case .invalidChars = validator.validate("user name") { } else { Issue.record("Expected invalidChars") }
+    }
+
+    @Test func validateBlockedExact() {
+        let validator = UsernameValidator()
+        if case .blocked = validator.validate("fuck") { } else { Issue.record("Expected blocked") }
+    }
+
+    @Test func validateBlockedReverseExact() {
+        let validator = UsernameValidator()
+        if case .blocked(let term) = validator.validate("kcuf") {
+            #expect(term == "reverse_exact")
+        } else { Issue.record("Expected blocked reverse_exact") }
+    }
+
+    @Test func validateOkAtMinLength() {
+        let validator = UsernameValidator()
+        if case .ok = validator.validate("abc") { } else { Issue.record("Expected ok") }
+    }
+
+    @Test func normalizedRemovesSeparators() {
+        let validator = UsernameValidator()
+        if case .ok = validator.validate("valid.user-name") { } else { Issue.record("Expected ok with separators") }
+    }
+}

--- a/SpotTests/VibeTagValidatorTests.swift
+++ b/SpotTests/VibeTagValidatorTests.swift
@@ -1,0 +1,59 @@
+//
+//  VibeTagValidatorTests.swift
+//  SpotTests
+//
+//  Created By: Wynman, Edward
+//  Date: 03/02/2025
+//
+
+import Testing
+@testable import Spot
+
+struct VibeTagValidatorTests {
+
+    @Test func validateTooShort() {
+        let validator = VibeTagValidator()
+        if case .tooShort = validator.validate("a") { } else { Issue.record("Expected tooShort") }
+    }
+
+    @Test func validateTooLong() {
+        let validator = VibeTagValidator()
+        let long = String(repeating: "x", count: 31)
+        if case .tooLong = validator.validate(long) { } else { Issue.record("Expected tooLong") }
+    }
+
+    @Test func validateOkValidTag() {
+        let validator = VibeTagValidator()
+        if case .ok(let s) = validator.validate("Chill Spot") {
+            #expect(s == "Chill Spot")
+        } else { Issue.record("Expected ok") }
+    }
+
+    @Test func validateTrimsWhitespace() {
+        let validator = VibeTagValidator()
+        if case .ok(let s) = validator.validate("  Hidden Gem  ") {
+            #expect(s == "Hidden Gem")
+        } else { Issue.record("Expected ok") }
+    }
+
+    @Test func validateBlockedExact() {
+        let validator = VibeTagValidator()
+        if case .blocked = validator.validate("fuck") { } else { Issue.record("Expected blocked") }
+    }
+
+    @Test func validateBlockedContains() {
+        let validator = VibeTagValidator()
+        if case .blocked = validator.validate("xxxfuckxxx") { } else { Issue.record("Expected blocked") }
+    }
+
+    @Test func validateOkAtMinLength() {
+        let validator = VibeTagValidator()
+        if case .ok = validator.validate("abc") { } else { Issue.record("Expected ok at min") }
+    }
+
+    @Test func validateOkAtMaxLength() {
+        let validator = VibeTagValidator()
+        let s = String(repeating: "x", count: 20)
+        if case .ok = validator.validate(s) { } else { Issue.record("Expected ok at max") }
+    }
+}

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,13 @@
+# SYSTEM INSTRUCTIONS (DO NOT IGNORE)
+
+You must follow these rules when generating or modifying code:
+
+1. Architecture is strictly component-based.
+2. Do not create large procedural files when a component can be created instead.
+3. Every newly created file must begin with:
+
+   Created By: Wynman, Edward  
+   Date: MM/DD/YYYY
+
+4. The date format must always be MM/DD/YYYY.
+5. Do not omit the file header under any circumstances.


### PR DESCRIPTION
## Summary

Refactors the Swift app to a **component-based MVVM** architecture: views only compose components and bind to ViewModels; business logic, state, and data access live in ViewModels and Services.

## Goals

- **Views** = declarative UI only (no networking, transformation, or business logic).
- **ViewModels** = state + presentation logic; talk to Services/Repositories.
- **Services** = networking / persistence.
- **Models** = data only.
- Views depend only on ViewModels, not on Services.

## Changes

### New ViewModels

| File | Purpose |
|------|--------|
| `FeedViewModel.swift` | Extracted from HomepageView; owns feed state (`spots`, `mapSpots`, `isLoading`, `hasMore`, `deletingSpotIds`), `validSpots` / `validMapSpots`, first-item PerfMetrics, and feed actions (`loadInitialSpots`, `loadMoreSpots`, `refreshFeed`, `delete`, etc.). Uses FeedRepository and SpotService. |
| `HomepageViewModel.swift` | Homepage UI state and actions (tabs, sheets, toasts, rules/upload flow). |
| `MapViewModel.swift` | Map state and loading: `visibleSpots`, `isLoadingAllSpots`, `loadAllSpots()` via SpotService. Removes direct Service use from MapView. |

### ViewModel Refactors

- **ProfileViewModel** – Uses `ProfileService.fetchProfile(for: userId)` instead of Firestore; publishes `username`, `profileImageURL`, `spots`, `isPrivateProfile`, `isProProfile`, `isFollowingUser`, `hasRequestedFollow`, `canViewContent`, `isLoading`, `error`, `deletingSpotIds`, `followRequestsCount`; adds `loadUser(userId:)`, `deleteSpot(_:)`, follow-request listener, and follow/unfollow/request/cancel actions.
- **ProfileView** – Uses only ProfileViewModel for data and actions; no direct ProfileService/SpotService or in-view `loadUser` / `deleteSpotFromProfile`.

### Extracted Components

Moved into `Spot/Views/Components/` (each in its own file with standard header):

- `FeedMapTabBarView.swift` – Feed/Map tab bar (binding + tab labels).
- `TabNavigationView.swift` – Tab bar + `TabItemView`.
- `FeedContentView.swift` – Feed list/map/skeletons; takes spots, callbacks, optional `onFirstItemAppeared`; no filtering or PerfMetrics in the view.
- `RefreshControl.swift`, `LoadingView.swift`, `EmptyFeedView.swift`, `SpotsListView.swift`.
- `SpotMapMarker.swift` – `SpotAnnotation` + `SpotMapMarker`.

### Map & Feed

- **MapView** – Uses MapViewModel for `visibleSpots` and `loadAllSpots()`; no direct SpotService in the view.
- **HomepageView** – After merging main, follows main’s structure (feed-only content, top bar, toasts via `@State` and `.onReceive(NotificationCenter.default.publisher(for: .spotDidPostSuccess))`).

## Architecture Rules

- **Views** – SwiftUI (and MapKit/UIKit where needed). No Firebase or direct Service/Repository access.
- **ViewModels** – Own Services/Repositories; publish state and expose actions.
- **Components** – Receive only data, `Binding`s, and closures; no ViewModel types in the API unless it’s a display model.

## Merge Note

Main was merged into this branch and **conflicts were resolved in favor of main**. Current `HomepageView` matches main’s layout (feed-only screen; `MainTabView` / `BottomTabNavigationView` for tabs). New ViewModels and extracted components remain available for the tabbed flow.