### PR TITLE
Fix posting issues with auth and loading

### DIFF
--- a/Spot/Services/Auth/AuthViewModel.swift
+++ b/Spot/Services/Auth/AuthViewModel.swift
@@ -457,10 +457,13 @@ class AuthViewModel: ObservableObject {
         guard let user = Auth.auth().currentUser else { return false }
         do {
             try await user.reload()
-            let verified = user.isEmailVerified
+            // Read from currentUser after reload so we never use a stale in-memory snapshot.
+            guard let refreshed = Auth.auth().currentUser else { return false }
+            let verified = refreshed.isEmailVerified
             if verified { SpotLogger.log(AuthViewModelLogs.emailVerified) }
             await MainActor.run { self.isEmailVerified = verified }
-            if verified, let uid = user.uid as String? {
+            if verified {
+                let uid = refreshed.uid
                 // Persist server-side marker for analytics and visibility
                 try? await Firestore.firestore().collection("users").document(uid).setData(["isVerified": true], merge: true)
             }

--- a/Spot/Views/PostFlow/PostFlowView.swift
+++ b/Spot/Views/PostFlow/PostFlowView.swift
@@ -7,9 +7,9 @@ struct PostFlowView: View {
     @StateObject private var viewModel = PostFlowViewModel()
     @AppStorage("hasAcceptedPostingRules") private var hasAcceptedPostingRules: Bool = false
     @State private var showRulesSheet: Bool = false
-    /// `true` while we await a fresh `isEmailVerified` value from Firebase so we
-    /// never flash the "verification required" error on a stale cached token.
     @State private var isVerifyingEmail: Bool = true
+    @State private var showVerifyEmailAlert: Bool = false
+    @State private var showConfirmEmailSheet: Bool = false
 
     var onPostSuccess: ((Spot) -> Void)?
 
@@ -18,29 +18,42 @@ struct PostFlowView: View {
             ZStack(alignment: .top) {
                 VStack(spacing: 0) {
                     if isVerifyingEmail {
-                        Spacer()
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(Constants.Colors.primary)
-                        Spacer()
-                    } else if !authVM.isEmailVerified {
-                        VStack(spacing: 12) {
-                            Text("Email verification required to post")
-                                .font(FontManager.primaryText())
-                                .foregroundColor(Constants.Colors.primary)
-                            Button(action: { dismiss() }) {
-                                Text("Close")
-                                    .font(FontManager.buttonText())
-                                    .foregroundColor(Constants.Colors.buttonText)
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Constants.Colors.primary)
-                                    .cornerRadius(20)
-                            }
-                            .buttonStyle(PlainButtonStyle())
+                        ZStack {
+                            Constants.Colors.background
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(Constants.Colors.primary)
+                                .controlSize(.large)
                         }
-                        .padding(16)
-                        .background(Constants.Colors.background)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if !authVM.isEmailVerified {
+                        VStack(spacing: 0) {
+                            Spacer()
+                            VStack(spacing: 16) {
+                                Text("Verify your email to post")
+                                    .font(FontManager.sectionHeader())
+                                    .foregroundColor(Constants.Colors.primary)
+                                    .multilineTextAlignment(.center)
+                                Text("We sent a link to your inbox. After you verify, tap \"I've verified\" on the next screen.")
+                                    .font(FontManager.primaryText())
+                                    .foregroundColor(.gray)
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal, 24)
+                                Button(action: { showConfirmEmailSheet = true }) {
+                                    Text("Open verification")
+                                        .font(FontManager.buttonText())
+                                        .foregroundColor(Constants.Colors.buttonText)
+                                        .padding()
+                                        .frame(maxWidth: .infinity)
+                                        .background(Constants.Colors.primary)
+                                        .cornerRadius(20)
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .padding(.horizontal, 24)
+                            }
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                     } else {
                         ProgressIndicatorView(currentStep: viewModel.currentStep, totalSteps: viewModel.totalSteps)
 
@@ -72,7 +85,7 @@ struct PostFlowView: View {
                         )
                     }
                 }
-                .frame(maxHeight: .infinity, alignment: .top)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
                 VStack(spacing: 8) {
                     if viewModel.isUploading {
@@ -101,18 +114,40 @@ struct PostFlowView: View {
                 }
             }
         }
-        .onAppear {
+        .task {
             viewModel.authViewModel = authVM
             viewModel.onPostSuccess = onPostSuccess
             viewModel.onShouldDismiss = { dismiss() }
-            Task {
-                _ = await authVM.checkVerificationStatus()
-                isVerifyingEmail = false
+            isVerifyingEmail = true
+            _ = await authVM.checkVerificationStatus()
+            isVerifyingEmail = false
+            if authVM.isEmailVerified {
                 showRulesIfNeeded()
+            } else {
+                showVerifyEmailAlert = true
             }
         }
         .onChange(of: authVM.isEmailVerified) { _, newValue in
-            if newValue { showRulesIfNeeded() }
+            if newValue {
+                showVerifyEmailAlert = false
+                showRulesIfNeeded()
+            }
+        }
+        .alert("Verify your email", isPresented: $showVerifyEmailAlert) {
+            Button("Open verification") {
+                showConfirmEmailSheet = true
+            }
+            Button("Not now", role: .cancel) {}
+        } message: {
+            Text("You need a verified email to post. Check your inbox for the link we sent you.")
+        }
+        .sheet(isPresented: $showConfirmEmailSheet, onDismiss: {
+            Task {
+                _ = await authVM.checkVerificationStatus()
+            }
+        }) {
+            ConfirmEmailView()
+                .environmentObject(authVM)
         }
         .sheet(isPresented: $showRulesSheet) {
             PostingRulesView(onAgree: {


### PR DESCRIPTION
## Changes
### PostFlowView.swift
- .task instead of .onAppear + Task – Runs the verification check when the Post tab loads (and when the view is recreated after switching tabs), with a single loading phase.
- Verified – After checkVerificationStatus(), if authVM.isEmailVerified is true, the normal post flow runs and posting rules run as before.
- Not verified – A system alert explains they need to verify; Open verification opens ConfirmEmailView in a sheet (same pattern as PostingRulesView). Not now only dismisses the alert. The tab still shows a short “Verify your email to post” block with Open verification so they’re not stuck if they dismiss the alert.
- onChange(of: authVM.isEmailVerified) – When verification flips to true (e.g. after the sheet flow), the alert is cleared and posting rules are shown if needed.

### AuthViewModel.swift
- After user.reload(), isEmailVerified is read from Auth.auth().currentUser so the flag isn’t taken from a stale User instance. - - The Firestore isVerified write uses refreshed.uid (same as before, without the odd as String? cast).

## Testing

## Checklist
- [x] Added Unit Tests For New Code
- [x] Confirmed no new warnings introduced
- [x] Updated docs