### PR TITLE
Fix signup UX when email is already registered

### DIFF
--- a/Spot/Models/Logs/SignupViewLogs.swift
+++ b/Spot/Models/Logs/SignupViewLogs.swift
@@ -9,16 +9,19 @@ import Foundation
 
 enum SignupViewLogs: SpotLog {
     case usernameBlocked
+    case emailAlreadyRegistered
 
     var tag: String { "SignupView" }
     var level: LogLevel {
         switch self {
         case .usernameBlocked: return .debug
+        case .emailAlreadyRegistered: return .info
         }
     }
     var message: String {
         switch self {
         case .usernameBlocked: return "Username blocked"
+        case .emailAlreadyRegistered: return "Signup blocked: email already registered"
         }
     }
 }

--- a/Spot/Services/AuthInputNormalizer.swift
+++ b/Spot/Services/AuthInputNormalizer.swift
@@ -49,4 +49,19 @@ enum AuthErrorClassifier {
     static func isEmailInUse(error: Error) -> Bool {
         isEmailInUse(error.localizedDescription)
     }
+
+    /// Detects the "email already registered" case for a Supabase email
+    /// sign-up response. With email-enumeration protection enabled, Supabase
+    /// does not throw for an existing email: it returns HTTP 200 with no
+    /// session and an empty `identities` array (and sends no confirmation
+    /// email). Callers must treat this as an existing account instead of
+    /// routing the user to the email-verification screen.
+    ///
+    /// - Parameters:
+    ///   - hasSession: Whether the sign-up response contained a session.
+    ///   - identityCount: Number of identities on the returned user
+    ///     (pass `0` when `identities` is `nil`).
+    static func isExistingAccountSignup(hasSession: Bool, identityCount: Int) -> Bool {
+        !hasSession && identityCount == 0
+    }
 }

--- a/Spot/Views/Auth/SignupView.swift
+++ b/Spot/Views/Auth/SignupView.swift
@@ -270,6 +270,32 @@ struct SignupView: View {
                     ]
                 )
 
+                // Supabase does not throw when an email is already registered
+                // (email-enumeration protection). Instead it returns HTTP 200
+                // with no session and an empty `identities` array, and it does
+                // NOT send a confirmation email. Detect that here so the user
+                // isn't stranded on the verification screen waiting for a code
+                // that will never arrive.
+                let isExistingAccount = AuthErrorClassifier.isExistingAccountSignup(
+                    hasSession: response.session != nil,
+                    identityCount: response.user.identities?.count ?? 0
+                )
+                if isExistingAccount {
+                    SpotLogger.log(SignupViewLogs.emailAlreadyRegistered)
+                    await MainActor.run {
+                        AnalyticsService.shared.trackAuthEvent(
+                            Constants.Analytics.authEmailInUse,
+                            parameters: ["action": "detected", "surface": "signup"]
+                        )
+                        self.isLoading = false
+                        self.showToast(
+                            "An account with this email already exists. Try logging in or resetting your password.",
+                            isError: true
+                        )
+                    }
+                    return
+                }
+
                 await MainActor.run {
                     AnalyticsService.shared.setUserId(response.user.id.uuidString)
                     AnalyticsService.shared.logEvent("user_signup", parameters: [

--- a/SpotTests/AuthInputNormalizerTests.swift
+++ b/SpotTests/AuthInputNormalizerTests.swift
@@ -84,6 +84,24 @@ struct AuthErrorClassifierTests {
     @Test func emptyMessageIsNotEmailInUse() {
         #expect(AuthErrorClassifier.isEmailInUse("") == false)
     }
+
+    // MARK: - Existing-account sign-up detection
+
+    @Test func existingAccountWhenNoSessionAndNoIdentities() {
+        // Supabase repeated-signup obfuscation: HTTP 200, no session, empty identities.
+        #expect(AuthErrorClassifier.isExistingAccountSignup(hasSession: false, identityCount: 0) == true)
+    }
+
+    @Test func newSignupWithIdentityIsNotExistingAccount() {
+        // A genuine new email signup (confirm-email on) returns one identity, no session.
+        #expect(AuthErrorClassifier.isExistingAccountSignup(hasSession: false, identityCount: 1) == false)
+    }
+
+    @Test func autoConfirmedSessionIsNotExistingAccount() {
+        // Auto-confirm flows return a session; never treat as existing account.
+        #expect(AuthErrorClassifier.isExistingAccountSignup(hasSession: true, identityCount: 0) == false)
+        #expect(AuthErrorClassifier.isExistingAccountSignup(hasSession: true, identityCount: 1) == false)
+    }
 }
 
 struct EmailInUseTypeTests {

--- a/SpotTests/DataPlaneGuardTests.swift
+++ b/SpotTests/DataPlaneGuardTests.swift
@@ -38,7 +38,7 @@ struct DataPlaneGuardTests {
     ]
 
     @Test func spotSources_doNotContainLegacyFirebaseDataPlane() throws {
-        let swiftFiles = try enumerateSwiftFiles(under: Self.spotSourcesRoot)
+        let swiftFiles = try Self.enumerateSwiftFiles(under: Self.spotSourcesRoot)
         #expect(!swiftFiles.isEmpty, "Expected Swift sources under Spot/")
 
         var violations: [String] = []
@@ -58,10 +58,10 @@ struct DataPlaneGuardTests {
             if contents.contains("import Firebase"),
                !Self.firebaseObservabilityAllowlist.contains(filename) {
                 let firebaseImports = contents
-                    .components(separatedBy: .newlines)
+                    .components(separatedBy: CharacterSet.newlines)
                     .filter { $0.contains("import Firebase") }
                 for line in firebaseImports {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    let trimmed = line.trimmingCharacters(in: CharacterSet.whitespaces)
                     let allowed = trimmed == "import FirebaseCore"
                         || trimmed == "import FirebaseAnalytics"
                         || trimmed == "import FirebaseCrashlytics"
@@ -80,7 +80,7 @@ struct DataPlaneGuardTests {
 
             See docs/engineering/data-plane.md
             """
-            Issue.record(message)
+            Issue.record(Comment(rawValue: message))
         }
     }
 


### PR DESCRIPTION
## Summary
- Signing up with an already-registered email left the user stranded on the OTP screen waiting for a verification code that never arrives.
- Root cause: with Supabase email-enumeration protection enabled, `auth.signUp` for an existing email does **not** throw. It returns HTTP 200 with no session and an empty `identities` array, and sends **no** confirmation email. The old code hit the success path and routed to the verification screen anyway.
- Confirmed against live auth logs: new emails log `user_confirmation_requested` + `mail.send`; repeat signups log `user_repeated_signup` with no `mail.send`. So email delivery is healthy — this was purely a client-side detection bug.

## Changes
- `SignupView` now detects the repeated-signup response and shows an actionable error ("An account with this email already exists. Try logging in or resetting your password.") instead of navigating to the OTP screen.
- Added `AuthErrorClassifier.isExistingAccountSignup(hasSession:identityCount:)` as a pure, unit-testable helper.
- Added `SignupViewLogs.emailAlreadyRegistered` structured log + `Auth.EmailInUse` analytics event.
- Fixed pre-existing compile errors in `SpotTests/DataPlaneGuardTests.swift` (committed broken in #21) that were blocking the entire `SpotTests` target from building: static-method call, `.newlines`/`.whitespaces` inference, and `Issue.record(String)` -> `Issue.record(Comment)`.

## Test plan
- [x] `xcodebuild -scheme Spot build` succeeds
- [x] `xcodebuild -scheme SpotTests test` -> TEST SUCCEEDED
- [x] New unit tests cover existing-account, genuine new signup, and auto-confirm cases
- [ ] Manual: sign up with an already-registered email -> see clear error, no OTP screen
- [ ] Manual: sign up with a fresh email -> still receives code and reaches OTP screen

Made with [Cursor](https://cursor.com)