### PR TITLE
Request notification permissions after skipping onboarding

### DIFF
--- a/Spot/Views/Components/BottomTabNavigationView.swift
+++ b/Spot/Views/Components/BottomTabNavigationView.swift
@@ -159,7 +159,7 @@ struct BottomTabNavigationView: View {
                 targetRect: currentTourTargetRect,
                 onPrimary: handleOnboardingPrimaryAction,
                 onBack: handleOnboardingBack,
-                onSkip: firstRunOnboarding.skip
+                onSkip: handleOnboardingSkip
             )
         }
         .onPreferenceChange(CoachFramesPrefKey.self) { coachFrames = $0 }
@@ -267,6 +267,15 @@ struct BottomTabNavigationView: View {
         showNotificationPermissionPrompt = true
     }
 
+    private func handleOnboardingSkip() {
+        firstRunOnboarding.skip()
+        // After onboarding is skipped, request notification permissions
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            requestNotificationPermissionsAfterOnboarding()
+        }
+    }
+    
     private func handleOnboardingBack() {
         if firstRunOnboarding.currentStep == .mapTab {
             selectedTab = 0

--- a/docs/engineering/notifications.md
+++ b/docs/engineering/notifications.md
@@ -11,11 +11,13 @@ Spot implements a local notification system for social events, specifically foll
 
 ### Permission Request Flow
 
-1. User completes the first-run onboarding tour (all steps through `.finale`)
+1. User completes the first-run onboarding tour (all steps through `.finale`) **OR** skips the tour
 2. After 600ms delay, `BottomTabNavigationView` checks notification permission status
 3. If status is `.notDetermined`, presents `NotificationPermissionView` sheet
 4. User grants or denies permissions through the system dialog
 5. Permission status is tracked in `PermissionManager.notificationStatus`
+
+**Important**: Notification permissions are requested regardless of whether the user completes or skips onboarding, ensuring all users have the opportunity to enable notifications.
 
 ### Notification Service
 
@@ -195,10 +197,17 @@ Navigation events are posted via `NotificationCenter.default.post()`. Consumers 
 
 ### Manual Testing
 
-1. **Permission Grant**:
+1. **Permission Grant After Completing Onboarding**:
    - Sign up for a new account
    - Complete onboarding tour through all steps
    - After finale, notification permission sheet should appear
+   - Grant permissions → verify `PermissionManager.notificationStatus == .authorized`
+
+2. **Permission Grant After Skipping Onboarding**:
+   - Sign up for a new account
+   - Start onboarding tour
+   - Tap "Skip" button on any step
+   - After 600ms, notification permission sheet should appear
    - Grant permissions → verify `PermissionManager.notificationStatus == .authorized`
 
 2. **Follow Request Accepted Notification**:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Request Notification Permissions After Skipping Onboarding

## Overview

This PR fixes a missing case where users who **skip** the onboarding tour were not being prompted for notification permissions. Now, notification permissions are requested regardless of whether the user completes or skips the onboarding.

## Problem

Previously, notification permission requests were only triggered when the user completed the onboarding tour by reaching the `.finale` step. Users who tapped "Skip" during onboarding would never be prompted for notification permissions, resulting in missed opportunities to enable notifications for social events.

## Solution

Added a new `handleOnboardingSkip()` method that:
1. Calls `firstRunOnboarding.skip()` to mark onboarding as skipped
2. Schedules notification permission request after 600ms delay
3. Only prompts if notification status is `.notDetermined`

This ensures consistent behavior for both completion paths:
- ✅ **Complete tour** → Request notification permissions
- ✅ **Skip tour** → Request notification permissions

## Changes

### Code Changes

**`Spot/Views/Components/BottomTabNavigationView.swift`**:
- Added `handleOnboardingSkip()` method
- Updated `SpotFirstRunOnboardingOverlay` to use new skip handler instead of directly calling `firstRunOnboarding.skip`
- Skip handler follows the same pattern as the finale completion handler

### Documentation Updates

**`docs/engineering/notifications.md`**:
- Updated "Permission Request Flow" section to clarify both paths trigger the prompt
- Added "Permission Grant After Skipping Onboarding" test case
- Emphasized that all users receive the notification permission opportunity

## Testing

### Manual Test Cases

1. **Skip from Welcome Step**:
   - Sign up → Start onboarding → Skip on welcome screen
   - Verify notification permission prompt appears after 600ms

2. **Skip from Mid-Tour**:
   - Sign up → Start tour → Advance a few steps → Skip
   - Verify notification permission prompt appears after 600ms

3. **Complete Tour (Regression)**:
   - Sign up → Complete entire tour to finale
   - Verify notification permission prompt still appears (existing behavior preserved)

4. **Permission Already Granted**:
   - User who previously granted permissions → Skip onboarding on new device/install
   - Verify no duplicate prompt (guard checks `.notDetermined` status)

## Related PRs

This builds on PR #23 which implemented the initial notification permission system.

## Files Changed

- `Spot/Views/Components/BottomTabNavigationView.swift` - Add skip handler
- `docs/engineering/notifications.md` - Update documentation

## Checklist

- [x] Notification permissions requested after completing onboarding
- [x] Notification permissions requested after skipping onboarding
- [x] Guard prevents duplicate prompts if already determined
- [x] Documentation updated
- [x] Consistent 600ms delay for both paths
- [ ] Manual testing on device

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f23e5-6241-727b-be79-6d0079617995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f23e5-6241-727b-be79-6d0079617995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

