### PR TITLE
Add GitHub Actions CI/CD pipeline for unit tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
 
 **What it does:**
 - Runs full unit test suite using the `SpotTests` scheme
-- Uses macOS 14 runners with Xcode 16.1
+- Uses macOS 14 runners with Xcode 16.2 (includes Swift 6.1 for dependency compatibility)
 - Boots an iPhone simulator and executes tests
 - Enables code coverage collection
 - Uploads test results and coverage reports as artifacts

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
 
 **What it does:**
 - Runs full unit test suite using the `SpotTests` scheme
-- Uses macOS 14 runners with Xcode 15.2
+- Uses macOS 14 runners with Xcode 16.1
 - Boots an iPhone simulator and executes tests
 - Enables code coverage collection
 - Uploads test results and coverage reports as artifacts

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,54 @@
+# GitHub Actions CI/CD
+
+This directory contains GitHub Actions workflows for the Spot iOS app.
+
+## Workflows
+
+### `ci.yml` - Continuous Integration
+
+**Triggers:**
+- Pull requests to `main`
+- Pushes to `main`
+
+**What it does:**
+- Runs full unit test suite using the `SpotTests` scheme
+- Uses macOS 14 runners with Xcode 15.2
+- Boots an iPhone simulator and executes tests
+- Enables code coverage collection
+- Uploads test results and coverage reports as artifacts
+
+**Test output:**
+- Test results are formatted with `xcbeautify` for readable output
+- Test results (`.xcresult` bundles) are uploaded as artifacts for 7 days
+- Code coverage reports are uploaded as artifacts for 7 days
+
+## Requirements
+
+The workflow expects:
+- A valid `SpotTests` scheme in the Xcode project
+- Tests that can run on iOS Simulator
+- No manual provisioning profiles required for unit tests
+
+## Local Testing
+
+To run the same tests locally that CI runs:
+
+```bash
+# Get first available iPhone simulator
+SIM_ID=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed -E 's/.*\(([0-9A-F-]+)\).*/\1/')
+
+# Run unit tests
+xcodebuild \
+  -scheme SpotTests \
+  -destination "id=$SIM_ID" \
+  -enableCodeCoverage YES \
+  test | xcbeautify
+```
+
+## Future Enhancements
+
+Consider adding:
+- UI test workflow (separate from unit tests due to longer runtime)
+- Build and archive workflow for release candidates
+- SwiftLint or other static analysis tools
+- Danger for automated PR checks

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
 
 **What it does:**
 - Runs full unit test suite using the `SpotTests` scheme
-- Uses macOS 14 runners with Xcode 16.2 (includes Swift 6.1 for dependency compatibility)
+- Uses macOS 15 runners with Xcode 16.3 (includes Swift 6.1 required by swift-crypto@4.5.0)
 - Boots an iPhone simulator and executes tests
 - Enables code coverage collection
 - Uploads test results and coverage reports as artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: macos-14
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+      
+      - name: Show Xcode version
+        run: xcodebuild -version
+      
+      - name: List available simulators
+        run: xcrun simctl list devices available
+      
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+      
+      - name: Run Unit Tests
+        run: |
+          set -o pipefail
+          
+          # Get first available iPhone simulator
+          SIM_ID=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed -E 's/.*\(([0-9A-F-]+)\).*/\1/')
+          echo "Using simulator: $SIM_ID"
+          
+          # Boot the simulator
+          xcrun simctl boot "$SIM_ID" || true
+          
+          # Run unit tests only (SpotTests scheme)
+          xcodebuild \
+            -scheme SpotTests \
+            -destination "id=$SIM_ID" \
+            -enableCodeCoverage YES \
+            test | xcbeautify
+        
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
+          retention-days: 7
+      
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/ProfileData
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   unit-tests:
     name: Run Unit Tests
-    runs-on: macos-14
+    runs-on: macos-15
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      - name: Select Xcode version (16.3+ for Swift 6.1)
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
       
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
       
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
       
       - name: Show Xcode version
         run: xcodebuild -version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

This PR sets up a GitHub Actions CI/CD pipeline to ensure code quality by running unit tests automatically on pull requests and merges to `main`.

## What's Added

### `.github/workflows/ci.yml`
A comprehensive CI workflow that:
- **Triggers on**: Pull requests to `main` and pushes to `main`
- **Runs**: Full unit test suite via the `SpotTests` scheme
- **Environment**: macOS 14 with Xcode 15.2
- **Features**:
  - Automatic simulator setup and boot
  - Swift Package Manager caching for faster builds
  - Code coverage collection enabled
  - Pretty test output via `xcbeautify`
  - Uploads test results and coverage reports as artifacts (7-day retention)

### `.github/workflows/README.md`
Documentation covering:
- Workflow descriptions and triggers
- Local testing instructions
- Requirements and future enhancement ideas

## Testing

The workflow will automatically run on this PR. You can verify it works by checking the "Actions" tab once merged.

To test locally with the same configuration:
```bash
SIM_ID=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed -E 's/.*\(([0-9A-F-]+)\).*/\1/')
xcodebuild -scheme SpotTests -destination "id=$SIM_ID" -enableCodeCoverage YES test | xcbeautify
```

## Notes

- The workflow uses the `SpotTests` scheme which runs unit tests only (not UI tests) for faster feedback
- Swift Package Manager dependencies are cached to speed up subsequent runs
- Test artifacts are retained for 7 days for debugging failed test runs
- The workflow is compatible with the branch protection rules that can be configured in GitHub settings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f287a-db2c-73d1-afe6-3ced5e52de87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f287a-db2c-73d1-afe6-3ced5e52de87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

