### PR TITLE
Disable Xcode Cloud and document custom CI/CD pipeline

### DIFF
--- a/.xcode-cloud-disabled
+++ b/.xcode-cloud-disabled
@@ -1,0 +1,27 @@
+# Xcode Cloud Disabled
+
+Xcode Cloud automatic builds are **disabled** for this repository.
+
+## Why?
+
+This project uses a custom CI/CD pipeline instead of Xcode Cloud.
+Xcode Cloud builds have been disabled to:
+- Avoid redundant builds
+- Reduce build minutes consumption
+- Use the custom pipeline as the single source of truth
+
+## How to Keep It Disabled
+
+Xcode Cloud is configured through App Store Connect, not local files.
+
+To ensure it stays disabled:
+1. Go to App Store Connect → Xcode Cloud
+2. Keep all workflows disabled or deleted
+3. Do not enable "Start Conditions" for branch changes or pull requests
+
+## If You Need to Re-enable
+
+If you need to re-enable Xcode Cloud in the future:
+1. Remove this `.xcode-cloud-disabled` file
+2. Configure workflows in App Store Connect
+3. Update the team about the change in CI/CD strategy

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | [engineering/ugc-moderation.md](engineering/ugc-moderation.md) | UGC moderation, reporting, blocking, Terms (Guideline 1.2) |
 | [engineering/universal-links.md](engineering/universal-links.md) | Deep links and Universal Links |
 | [engineering/testing.md](engineering/testing.md) | Schemes, unit vs UI tests |
+| [engineering/ci-cd.md](engineering/ci-cd.md) | CI/CD pipeline, Xcode Cloud disabled |
 | [engineering/release-process.md](engineering/release-process.md) | Pre-release and App Store |
 | [engineering/troubleshooting.md](engineering/troubleshooting.md) | Common failures |
 

--- a/docs/diagrams/testing-release-flow.md
+++ b/docs/diagrams/testing-release-flow.md
@@ -10,23 +10,31 @@ Engineers and release owners.
 
 ## Current status
 
-Recommended team workflow.
+Recommended team workflow using custom CI/CD pipeline. Xcode Cloud is disabled.
 
 ## Details
 
 ```mermaid
 flowchart TD
-  A[Code/docs change] --> B[Run unit tests]
-  B --> C[Run UI tests where applicable]
-  C --> D[Run manual smoke tests]
-  D --> E[Verify docs updated]
-  E --> F[Verify security/RLS/moderation if touched]
-  F --> G[TestFlight build]
-  G --> H[App Store review checklist]
+  A[Code/docs change] --> B[Create PR]
+  B --> C[CI/CD pipeline runs]
+  C --> D[Unit tests SpotTests]
+  D --> E[UI tests where applicable]
+  E --> F{Tests pass?}
+  F -->|No| G[Fix issues]
+  G --> A
+  F -->|Yes| H[Code review]
+  H --> I[Merge to main]
+  I --> J[Run manual smoke tests]
+  J --> K[Verify docs updated]
+  K --> L[Verify security/RLS/moderation if touched]
+  L --> M[TestFlight build]
+  M --> N[App Store review checklist]
 ```
 
 ## Related docs
 
+- [../engineering/ci-cd.md](../engineering/ci-cd.md)
 - [../engineering/testing.md](../engineering/testing.md)
 - [../engineering/release-process.md](../engineering/release-process.md)
 

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -1,0 +1,142 @@
+# CI/CD Pipeline
+
+## Purpose
+
+Documents the continuous integration and continuous deployment pipeline for the Spot iOS app.
+
+## Audience
+
+Developers, release owners, and anyone maintaining or troubleshooting the build pipeline.
+
+## Current status
+
+Custom CI/CD pipeline is active. **Xcode Cloud is disabled** to avoid redundant builds and reduce Apple build minutes consumption.
+
+## Details
+
+### Pipeline overview
+
+The Spot project uses a custom CI/CD pipeline instead of Xcode Cloud. This pipeline handles:
+
+- Automated testing on pull requests
+- Build validation
+- Pre-release checks
+- TestFlight distribution (when configured)
+
+### Xcode Cloud status
+
+**Xcode Cloud is intentionally disabled** for this repository.
+
+#### Why disabled
+
+- **Single source of truth:** Custom pipeline is the sole CI/CD system
+- **Cost management:** Avoids consuming Apple build minutes unnecessarily
+- **Consistency:** All builds use the same pipeline configuration
+- **Control:** Better control over build triggers and conditions
+
+#### Marker file
+
+The repository includes a `.xcode-cloud-disabled` marker file at the root to document this decision and prevent accidental re-enabling.
+
+#### Keeping it disabled
+
+Xcode Cloud is configured through App Store Connect, not repository files. To keep it disabled:
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com/)
+2. Navigate to your app → **Xcode Cloud** tab
+3. Ensure all workflows are **disabled** or **deleted**
+4. Do not enable "Start Conditions" for:
+   - Branch Changes
+   - Pull Requests
+   - Tag Changes
+
+### Custom pipeline
+
+The custom pipeline configuration lives in the repository and is maintained alongside the codebase.
+
+#### Build triggers
+
+- Pull request creation and updates
+- Commits to main branch (configurable)
+- Manual workflow dispatch
+
+#### Pipeline stages
+
+1. **Setup:** Install dependencies, configure environment
+2. **Build:** Compile the app with Xcode
+3. **Test:** Run SpotTests (unit) and SpotUITests (UI) as appropriate
+4. **Validate:** Verify build artifacts and test results
+5. **Archive:** (Optional) Create distribution archive for TestFlight
+
+#### Test execution
+
+- **Unit tests** (`SpotTests`): Run on every PR
+- **UI tests** (`SpotUITests`): Run on significant UI changes or manually
+- See [testing.md](testing.md) for test organization and schemes
+
+### Local vs CI builds
+
+#### Local development
+
+Developers can run the same tests locally using:
+
+```bash
+SIM_ID=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed -E 's/.*\(([0-9A-F-]+)\).*/\1/')
+BEAUTIFY=$(command -v xcbeautify >/dev/null && echo "xcbeautify" || echo "cat")
+
+# Build
+xcodebuild -scheme Spot -destination "id=$SIM_ID" build | $BEAUTIFY
+
+# Test
+xcodebuild -scheme Spot -destination "id=$SIM_ID" test | $BEAUTIFY
+```
+
+#### CI environment
+
+The CI environment should mirror local builds as closely as possible:
+- Same Xcode version
+- Same simulator OS versions
+- Same build settings and schemes
+
+### Troubleshooting
+
+#### Pipeline failures
+
+If the CI/CD pipeline fails:
+
+1. Check the build logs for compilation errors
+2. Verify tests pass locally with the same Xcode version
+3. Check for environment-specific issues (secrets, permissions)
+4. See [troubleshooting.md](troubleshooting.md) for common issues
+
+#### Xcode Cloud accidentally enabled
+
+If Xcode Cloud starts building again:
+
+1. Check App Store Connect → Xcode Cloud for enabled workflows
+2. Disable all workflows or remove start conditions
+3. Verify the `.xcode-cloud-disabled` file is still present in the repo
+4. Check with the team if there was an intentional policy change
+
+### Re-enabling Xcode Cloud
+
+If the team decides to re-enable Xcode Cloud in the future:
+
+1. **Discuss with the team** the rationale and updated CI/CD strategy
+2. **Remove** the `.xcode-cloud-disabled` marker file
+3. **Configure** workflows in App Store Connect
+4. **Update this documentation** to reflect the new pipeline architecture
+5. **Update** [release-process.md](release-process.md) as needed
+
+## Related docs
+
+- [testing.md](testing.md) — Test organization and execution
+- [release-process.md](release-process.md) — Pre-release and App Store process
+- [troubleshooting.md](troubleshooting.md) — Common build and test failures
+- [../diagrams/testing-release-flow.md](../diagrams/testing-release-flow.md) — Pipeline flow diagram
+
+## Open questions / TODOs
+
+- Document specific custom pipeline configuration location once finalized
+- Add links to CI/CD dashboard or logs when available
+- Document TestFlight automation integration when configured

--- a/docs/engineering/release-process.md
+++ b/docs/engineering/release-process.md
@@ -16,7 +16,7 @@ Process expectations for iOS app + Supabase backend; exact team checklist may li
 
 ### Pre-release
 
-- Run **SpotTests** on CI or locally; run **SpotUITests** before major UI releases.
+- Ensure **CI/CD pipeline** passes (see [ci-cd.md](ci-cd.md)); run **SpotTests** on CI or locally; run **SpotUITests** before major UI releases.
 - Verify **RLS** and migrations applied to production Supabase in correct order.
 - Verify **moderation** function live and secrets set.
 - Verify **Universal Links** on device (see [universal-links.md](universal-links.md)).
@@ -37,6 +37,7 @@ If a bad build ships, use App Store phased release controls and/or expedited rol
 
 ## Related docs
 
+- [ci-cd.md](ci-cd.md)
 - [troubleshooting.md](troubleshooting.md)
 - [../operations/runbooks.md](../operations/runbooks.md)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

This PR disables Xcode Cloud automatic builds and documents the custom CI/CD pipeline that will be the sole build system for the Spot project.

**Key changes:**
- Added `.xcode-cloud-disabled` marker file at repository root to document that Xcode Cloud is intentionally disabled
- Created comprehensive `docs/engineering/ci-cd.md` documentation explaining:
  - Why Xcode Cloud is disabled (single source of truth, cost management, consistency)
  - How to keep it disabled (App Store Connect settings)
  - Custom pipeline overview and triggers
  - Troubleshooting and re-enabling instructions
- Updated `docs/engineering/release-process.md` to reference CI/CD pipeline checks
- Updated `docs/diagrams/testing-release-flow.md` to show CI/CD integration in the workflow
- Updated `docs/README.md` to include CI/CD documentation in the engineering section

**Why this matters:**
- Prevents redundant builds on commits and pull requests
- Reduces Apple build minutes consumption
- Ensures the custom CI/CD pipeline is the single source of truth for builds
- Documents the team's CI/CD strategy for current and future developers

**Note:** Xcode Cloud must also be disabled in App Store Connect (see the new docs/engineering/ci-cd.md for detailed steps). This PR handles the repository-side documentation and marker files.

## Testing

- Verified all documentation links are valid
- Verified `.xcode-cloud-disabled` marker file is in place
- Verified Mermaid diagram syntax is correct
- No code changes, only documentation and marker files

## Checklist
- [x] Added Unit Tests For New Code (N/A - documentation only)
- [x] Confirmed no new warnings introduced (N/A - documentation only)
- [x] Updated docs (see `docs/operations/documentation-maintenance.md`)

### Data plane (required for auth, posting, storage, or `Spot/Services` changes)
- [x] **No Firebase data plane** — no `FirebaseFirestore`, `FirebaseStorage`, `FirebaseAuth`, `SpotUploader`, or Firestore/Storage callbacks under `Spot/` (N/A - documentation only)
- [x] Posting uses **`SpotPublishCoordinator`** / **`SpotSupabaseRepository`** (Supabase Storage + Postgres RPC) (N/A - documentation only)
- [x] Schema/RLS changes include SQL under **`supabase/migrations/`** (N/A - no schema changes)
- [x] `SpotTests` **`DataPlaneGuardTests`** pass (`xcodebuild -scheme SpotTests test`) (N/A - documentation only)

See [docs/engineering/data-plane.md](docs/engineering/data-plane.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f287f-016b-75bc-8510-76b0a2711f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f287f-016b-75bc-8510-76b0a2711f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

