### PR TITLE
CI/CD: fix Firebase deploy signing/upload + add coverage % PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - main
 
+# Required so the "Comment PR with results" step can post/update PR comments.
+# Without pull-requests: write the github-script call fails with
+# "Resource not accessible by integration".
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validation:
     name: PR Validation
@@ -75,11 +82,26 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             test | xcbeautify
       
+      - name: Extract overall coverage
+        id: coverage
+        if: always()
+        run: |
+          if [ -d "TestResults.xcresult" ]; then
+            PCT=$(xcrun xccov view --report --json TestResults.xcresult | jq -r '.lineCoverage')
+            PCT_HUMAN=$(awk -v p="$PCT" 'BEGIN { printf "%.1f", (p * 100) }')
+            echo "Overall project line coverage: ${PCT_HUMAN}%"
+            echo "percent=${PCT_HUMAN}" >> "$GITHUB_OUTPUT"
+          else
+            echo "percent=unknown" >> "$GITHUB_OUTPUT"
+          fi
+      
       - name: Validate Code Coverage
+        id: coverage_validation
         if: github.event_name == 'pull_request'
         run: |
+          set -o pipefail
           echo "Validating code coverage on changed files..."
-          ./scripts/validate-coverage.sh TestResults.xcresult origin/${{ github.base_ref }} 80
+          ./scripts/validate-coverage.sh TestResults.xcresult origin/${{ github.base_ref }} 80 2>&1 | tee coverage-report.txt
       
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -116,16 +138,44 @@ jobs:
           script: |
             const fs = require('fs');
             
+            const testsOutcome = '${{ steps.tests.outcome }}';
+            const coverageOutcome = '${{ steps.coverage_validation.outcome }}';
+            const overallCoverage = '${{ steps.coverage.outputs.percent }}';
+            
+            const icon = (outcome) => outcome === 'success'
+              ? '✅'
+              : (outcome === 'skipped' || outcome === '' ? '➖' : '❌');
+            
             let comment = '## 🤖 PR Validation Results\n\n';
             
-            // Check if validation passed
-            const conclusion = '${{ steps.tests.outcome }}' === 'success' ? '✅' : '❌';
-            comment += `### Tests: ${conclusion}\n\n`;
+            comment += `### Tests: ${icon(testsOutcome)}\n\n`;
             
-            // Add coverage info note
             comment += '### Coverage\n';
-            comment += 'Coverage validation enforces 80% minimum on changed files.\n';
-            comment += 'See the [validation logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.\n\n';
+            if (overallCoverage && overallCoverage !== 'unknown' && overallCoverage !== '') {
+              comment += `**Overall project line coverage: ${overallCoverage}%**\n\n`;
+            } else {
+              comment += 'Overall coverage data was not available for this run.\n\n';
+            }
+            comment += `**Changed-files coverage check (80% minimum): ${icon(coverageOutcome)}**\n\n`;
+            
+            // Include the per-changed-file coverage breakdown when available.
+            try {
+              let report = fs.readFileSync('coverage-report.txt', 'utf8');
+              // Strip ANSI color codes emitted by the script.
+              report = report.replace(/\u001b\[[0-9;]*m/g, '').trim();
+              if (report.length > 0) {
+                if (report.length > 8000) {
+                  report = report.slice(0, 8000) + '\n... (truncated)';
+                }
+                comment += '<details><summary>Changed-file coverage details</summary>\n\n';
+                comment += '```\n' + report + '\n```\n\n';
+                comment += '</details>\n\n';
+              }
+            } catch (e) {
+              // No changed production files, or coverage report not generated.
+            }
+            
+            comment += 'See the [validation logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for full details.\n\n';
             
             comment += '---\n';
             comment += '*Automated checks validate tests, coverage, API stability, and documentation.*';

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,13 +215,27 @@ jobs:
       
       - name: Upload to Firebase App Distribution
         if: success()
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          groups: testers
-          file: ${{ runner.temp }}/export/Spot.ipa
-          releaseNotesFile: release_notes.txt
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          
+          # The wzieba Firebase action is a Docker container action (Linux-only) and cannot
+          # run on macOS runners, so we upload via the Firebase CLI instead. The CLI
+          # authenticates with the service account via GOOGLE_APPLICATION_CREDENTIALS.
+          CREDS_FILE="$RUNNER_TEMP/firebase-service-account.json"
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$CREDS_FILE"
+          export GOOGLE_APPLICATION_CREDENTIALS="$CREDS_FILE"
+          
+          npm install -g firebase-tools
+          
+          firebase appdistribution:distribute "$RUNNER_TEMP/export/Spot.ipa" \
+            --app "$FIREBASE_APP_ID" \
+            --groups testers \
+            --release-notes-file release_notes.txt
+          
+          rm -f "$CREDS_FILE"
       
       - name: Push build number update
         if: success() && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,19 +182,22 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:com.edwardwynman.Spot string ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS" 2>/dev/null \
             || /usr/libexec/PlistBuddy -c "Set :provisioningProfiles:com.edwardwynman.Spot ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS"
           
-          # Build and archive the app with manual signing (headless CI cannot use automatic signing).
+          # Archive WITHOUT code signing. Passing signing settings (CODE_SIGN_IDENTITY /
+          # PROVISIONING_PROFILE_SPECIFIER) on the xcodebuild command line applies them to
+          # EVERY target, including Swift Package dependencies (Firebase, Promises, GoogleUtilities,
+          # etc.) which do not support provisioning profiles and fail the archive.
+          # Instead we archive unsigned and sign only at export time, where ExportOptions scopes
+          # the provisioning profile to the app's bundle id.
           xcodebuild \
             -scheme Spot \
             -destination "generic/platform=iOS" \
             -archivePath $RUNNER_TEMP/Spot.xcarchive \
             -configuration Release \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM=55JK72KR4W \
-            CODE_SIGN_IDENTITY="Apple Development" \
-            PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_NAME}" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
             clean archive | xcbeautify
           
-          # Export IPA
+          # Export & sign the IPA (manual signing, scoped to the app via ExportOptions)
           xcodebuild \
             -exportArchive \
             -archivePath $RUNNER_TEMP/Spot.xcarchive \
@@ -221,9 +224,9 @@ jobs:
           releaseNotesFile: release_notes.txt
       
       - name: Push build number update
-        if: success()
+        if: success() && github.ref == 'refs/heads/main'
         run: |
-          git push origin main
+          git push origin HEAD:main
       
       - name: Create build summary
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,13 @@ jobs:
           
           npm install -g firebase-tools
           
+          PROJECT_ID=$(jq -r '.project_id' "$CREDS_FILE")
+          
+          # Ensure the "testers" group exists (distribute fails with 404 otherwise).
+          # Idempotent: ignore the error if the group already exists.
+          firebase appdistribution:group:create "Testers" testers --project "$PROJECT_ID" \
+            || echo "testers group already exists (or creation skipped); continuing"
+          
           firebase appdistribution:distribute "$RUNNER_TEMP/export/Spot.ipa" \
             --app "$FIREBASE_APP_ID" \
             --groups testers \


### PR DESCRIPTION
## Summary

Hardens the CI/CD workflows so both the Firebase deploy and PR validation actually work.

### Deploy to Firebase (`deploy.yml`)
- **Archive unsigned, sign at export.** Global `xcodebuild` signing settings were applied to every Swift Package target (Firebase, Promises, GoogleUtilities, …), which don't support provisioning profiles and failed the archive. Now archives with `CODE_SIGNING_ALLOWED=NO` and signs only at export via `ExportOptions` (scoped to the app bundle id).
- **Upload via Firebase CLI.** The previous `wzieba/Firebase-Distribution-Github-Action` is a Docker/Linux-only action and fails on the macOS runner. Replaced with `firebase-tools` authenticated via the service account.
- **Auto-create the `testers` group** (distribute previously 404'd because it didn't exist).
- **Guard the build-number push** so it only runs on `main` (safe manual dispatches on branches).

### PR validation (`ci.yml`)
- **Add `pull-requests: write` permission** — fixes the `Resource not accessible by integration` failure on the comment step.
- **Show coverage in the PR comment**: overall project line coverage %, the 80% changed-files check result, and a collapsible per-file breakdown.

## Test plan
- [x] Deploy workflow dispatched on this branch runs green end-to-end (archive → export → upload → distribute to `testers`).
- [ ] Confirm the PR validation comment appears on this PR with the coverage %.

Made with [Cursor](https://cursor.com)