### PR TITLE
Fix deploy pipeline duplicate Firebase build numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,11 @@ jobs:
   validation:
     name: PR Validation
     runs-on: macos-15
-    
+    # Skip automated bump commits pushed by deploy.yml ([skip ci]).
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]'))
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,34 +6,49 @@ on:
       - main
   workflow_dispatch:  # Allow manual triggers
 
+# Serialize deploys so concurrent runs cannot read the same build number.
+concurrency:
+  group: deploy-firebase-main
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     name: Build and Deploy to Firebase App Distribution
     runs-on: macos-15
     permissions:
       contents: write
-    
-    # Only run on merge commits (not on PR commits)
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !contains(github.event.head_commit.message, 'Merge pull request'))
-    
+
+    # Deploy on merges/direct pushes to main, but skip automated bump commits.
+    # Note: pushes made with GITHUB_TOKEN do not re-trigger workflows, but we still
+    # guard against bump commits in case a PAT is used later.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       !contains(github.event.head_commit.message, '[skip ci]') &&
+       !startsWith(github.event.head_commit.message, 'Bump build number to'))
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch full history for proper versioning
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      
+
+      - name: Sync with latest main
+        if: github.ref == 'refs/heads/main'
+        run: git pull --rebase origin main
+
       - name: Show Xcode version
         run: xcodebuild -version
-      
+
       - name: Install dependencies
         run: brew install xcbeautify
-      
+
       - name: Cache Swift Package Manager
         uses: actions/cache@v4
         with:
@@ -43,69 +58,58 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-      
+
       - name: Get current build number
         id: get_build_number
         run: |
-          # Extract current build number from project.pbxproj
           CURRENT_BUILD=$(grep -m 1 "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/')
+          if [ -z "$CURRENT_BUILD" ]; then
+            echo "Could not read CURRENT_PROJECT_VERSION from project.pbxproj"
+            exit 1
+          fi
           echo "Current build number: $CURRENT_BUILD"
-          
-          # Increment build number
-          NEW_BUILD=$((CURRENT_BUILD + 1))
-          echo "New build number: $NEW_BUILD"
-          
           echo "current_build=$CURRENT_BUILD" >> $GITHUB_OUTPUT
-          echo "new_build=$NEW_BUILD" >> $GITHUB_OUTPUT
-      
+
       - name: Increment build number
         id: increment_build
         run: |
-          NEW_BUILD=${{ steps.get_build_number.outputs.new_build }}
-          
-          # Update all occurrences of CURRENT_PROJECT_VERSION in project.pbxproj
-          # We need to update the main app target (not test targets)
-          
-          # Create a backup
-          cp Spot.xcodeproj/project.pbxproj Spot.xcodeproj/project.pbxproj.backup
-          
-          # Update build number for the main app target (first two occurrences)
-          # This preserves test target build numbers
-          awk -v new_build="$NEW_BUILD" '
-            /CURRENT_PROJECT_VERSION = [0-9]+;/ {
-              if (count < 2) {
-                sub(/CURRENT_PROJECT_VERSION = [0-9]+;/, "CURRENT_PROJECT_VERSION = " new_build ";")
-                count++
-              }
-            }
-            { print }
-          ' Spot.xcodeproj/project.pbxproj.backup > Spot.xcodeproj/project.pbxproj
-          
-          # Verify the change
+          ./scripts/increment-build-number.sh
+
+          NEW_BUILD=$(grep -m 1 "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/')
+          echo "New build number: $NEW_BUILD"
+          echo "new_build=$NEW_BUILD" >> $GITHUB_OUTPUT
+
           echo "Build numbers in project file:"
-          grep "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj
-          
-          # Commit the build number change
+          grep "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | head -4
+
           git add Spot.xcodeproj/project.pbxproj
           git commit -m "Bump build number to $NEW_BUILD [skip ci]"
-      
+
+      - name: Push build number update
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Push before build/upload so a failed deploy cannot leave main stale and
+          # cause the next run to reuse the same build number in Firebase.
+          git push origin HEAD:main
+
       - name: Extract release notes from merged PR
         id: release_notes
         run: |
           # Get the last merged PR info
           LAST_PR=$(gh pr list --state merged --limit 1 --json number,title,body,mergedAt --jq '.[0]')
-          
+
           if [ -z "$LAST_PR" ] || [ "$LAST_PR" = "null" ]; then
             echo "No recent PR found, using commit message"
-            NOTES="Build ${{ steps.get_build_number.outputs.new_build }}: ${{ github.event.head_commit.message }}"
+            NOTES="Build ${{ steps.increment_build.outputs.new_build }}: ${{ github.event.head_commit.message }}"
+            echo "$NOTES" > release_notes.txt
           else
             PR_NUMBER=$(echo "$LAST_PR" | jq -r '.number')
             PR_TITLE=$(echo "$LAST_PR" | jq -r '.title')
             PR_BODY=$(echo "$LAST_PR" | jq -r '.body' | head -c 500)
-            
+
             # Create release notes with proper formatting
             {
-              echo "Build ${{ steps.get_build_number.outputs.new_build }} - PR #${PR_NUMBER}: ${PR_TITLE}"
+              echo "Build ${{ steps.increment_build.outputs.new_build }} - PR #${PR_NUMBER}: ${PR_TITLE}"
               echo ""
               echo "${PR_BODY}"
               echo ""
@@ -113,19 +117,14 @@ jobs:
               echo "Date: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             } > release_notes.txt
           fi
-          
-          # Ensure file exists
-          if [ ! -f release_notes.txt ]; then
-            echo "Build ${{ steps.get_build_number.outputs.new_build }}" > release_notes.txt
-          fi
-          
+
           # Also output for GitHub
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           cat release_notes.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Install Apple Certificate and Provisioning Profile
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
@@ -134,36 +133,36 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           # The `secrets` context cannot be used in a step-level `if`, so guard here instead.
           if [ -z "$CERTIFICATE_BASE64" ]; then
             echo "❌ APPLE_CERTIFICATE_BASE64 is not set. Add the signing secrets before deploying."
             exit 1
           fi
-          
+
           # Create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
           PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          
+
           # Import certificate and provisioning profile from secrets
           echo -n "$CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
           echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-          
+
           # Create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          
+
           # Import certificate to keychain
           security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          
+
           # Allow codesign/productbuild to use the key without an interactive prompt (required for headless CI)
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          
+
           # Make the temporary keychain searchable so codesign can find the imported identity
           security list-keychain -d user -s $KEYCHAIN_PATH
-          
+
           # Install the provisioning profile under its UUID and expose its name for manual signing
           PROFILE_UUID=$(security cms -D -i "$PP_PATH" | plutil -extract UUID raw -)
           PROFILE_NAME=$(security cms -D -i "$PP_PATH" | plutil -extract Name raw -)
@@ -172,18 +171,18 @@ jobs:
           echo "Installed provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
           echo "PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
           echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
-      
+
       - name: Build app
         run: |
           set -euo pipefail
-          
+
           # Inject the resolved provisioning profile name into ExportOptions for manual signing.
           EXPORT_OPTIONS=$RUNNER_TEMP/ExportOptions.plist
           cp .github/workflows/ExportOptions.plist "$EXPORT_OPTIONS"
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:com.edwardwynman.Spot string ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS" 2>/dev/null \
             || /usr/libexec/PlistBuddy -c "Set :provisioningProfiles:com.edwardwynman.Spot ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS"
-          
+
           # Archive WITHOUT code signing. Passing signing settings (CODE_SIGN_IDENTITY /
           # PROVISIONING_PROFILE_SPECIFIER) on the xcodebuild command line applies them to
           # EVERY target, including Swift Package dependencies (Firebase, Promises, GoogleUtilities,
@@ -198,14 +197,14 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             clean archive | xcbeautify
-          
+
           # Export & sign the IPA (manual signing, scoped to the app via ExportOptions)
           xcodebuild \
             -exportArchive \
             -archivePath $RUNNER_TEMP/Spot.xcarchive \
             -exportPath $RUNNER_TEMP/export \
             -exportOptionsPlist "$EXPORT_OPTIONS" | xcbeautify
-          
+
           # Verify IPA was created
           if [ -f "$RUNNER_TEMP/export/Spot.ipa" ]; then
             echo "✅ IPA created successfully"
@@ -214,7 +213,7 @@ jobs:
             echo "❌ IPA creation failed"
             exit 1
           fi
-      
+
       - name: Upload to Firebase App Distribution
         if: success()
         env:
@@ -222,41 +221,36 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         run: |
           set -euo pipefail
-          
+
           # The wzieba Firebase action is a Docker container action (Linux-only) and cannot
           # run on macOS runners, so we upload via the Firebase CLI instead. The CLI
           # authenticates with the service account via GOOGLE_APPLICATION_CREDENTIALS.
           CREDS_FILE="$RUNNER_TEMP/firebase-service-account.json"
           printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$CREDS_FILE"
           export GOOGLE_APPLICATION_CREDENTIALS="$CREDS_FILE"
-          
+
           npm install -g firebase-tools
-          
+
           PROJECT_ID=$(jq -r '.project_id' "$CREDS_FILE")
-          
+
           # Ensure the "testers" group exists (distribute fails with 404 otherwise).
           # Idempotent: ignore the error if the group already exists.
           firebase appdistribution:group:create "Testers" testers --project "$PROJECT_ID" \
             || echo "testers group already exists (or creation skipped); continuing"
-          
+
           firebase appdistribution:distribute "$RUNNER_TEMP/export/Spot.ipa" \
             --app "$FIREBASE_APP_ID" \
             --groups testers \
             --release-notes-file release_notes.txt
-          
+
           rm -f "$CREDS_FILE"
-      
-      - name: Push build number update
-        if: success() && github.ref == 'refs/heads/main'
-        run: |
-          git push origin HEAD:main
-      
+
       - name: Create build summary
         if: always()
         run: |
           echo "## 🚀 Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Build Number**: ${{ steps.get_build_number.outputs.new_build }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Number**: ${{ steps.increment_build.outputs.new_build }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version**: 1.000" >> $GITHUB_STEP_SUMMARY
           echo "**Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -264,7 +258,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           cat release_notes.txt >> $GITHUB_STEP_SUMMARY || echo "No release notes" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-      
+
       - name: Clean up keychain and provisioning profile
         if: always()
         run: |

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -81,11 +81,12 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 7. **Version Commit:** Push build number update back to main
 
 **What it does:**
-- Automatically increments `CURRENT_PROJECT_VERSION` in Xcode project
+- Automatically increments `CURRENT_PROJECT_VERSION` in Xcode project via `scripts/increment-build-number.sh`
+- **Pushes the build number bump to `main` before building** (prevents duplicate Firebase build numbers when upload succeeds but a later step fails)
 - Builds signed IPA for distribution
 - Generates release notes from merged PR title and description
 - Uploads to Firebase App Distribution with testers group
-- Commits build number increment back to main (with [skip ci])
+- Skips re-deploy on bump commits (`Bump build number to … [skip ci]`)
 
 **Required secrets:**
 - `FIREBASE_APP_ID` - Firebase iOS App ID
@@ -297,17 +298,34 @@ If Xcode Cloud starts building again:
    - All tests pass
 3. PR is reviewed and merged to `main`
 4. **Deployment workflow triggers** (`deploy.yml`):
-   - Build number auto-increments (e.g., 6 → 7)
+   - Build number auto-increments (e.g., 7 → 8)
+   - **Build number is pushed to `main` before archive/upload** so a failed deploy cannot leave the repo stale and cause duplicate Firebase build numbers
    - Release notes generated from PR
    - App is built and signed
    - IPA uploaded to Firebase App Distribution
-   - Build number committed back to main
 5. Testers receive notification in Firebase App Distribution
 
 **Build versioning:**
 - Marketing version: `1.000` (manual updates for releases)
-- Build number: Auto-incremented on every deployment (current: `6`)
+- Build number: Auto-incremented on every deployment (current: `7`)
 - Format: `Version 1.000 (Build 7)`
+
+**Deploy safeguards:**
+- **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)
+- **Skip bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
+- **Skip CI on bumps:** `ci.yml` skips validation on `[skip ci]` commits
+- **Push before build:** The incremented build number is committed and pushed to `main` before archiving/uploading to Firebase
+
+**Troubleshooting duplicate Firebase build numbers**
+
+If multiple Firebase releases show the same build number (e.g. three `1.000 (7)` entries), the usual cause is deploy runs that **uploaded an IPA but failed to push** the incremented `CURRENT_PROJECT_VERSION` back to `main`. Each subsequent run then read the same build number from the repo and produced the same Firebase build.
+
+Common failure modes (July 2026):
+1. Missing `contents: write` permission on deploy — push failed with 403 after Firebase upload
+2. Manual `workflow_dispatch` runs from feature branches — upload succeeds but push to `main` is skipped
+3. Concurrent deploy runs before concurrency was added — both read the same `CURRENT_PROJECT_VERSION`
+
+The push-before-build ordering prevents new duplicates even when archive or Firebase upload fails later in the job.
 
 ### Future Enhancements
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Three Firebase App Distribution releases all show **build 7** (`1.000 (7)`), even though deploy is supposed to auto-increment on every run.

## Root cause (from GitHub Actions run history)

Three deploy runs all read **`CURRENT_PROJECT_VERSION = 6`** from `main` and uploaded **build 7** to Firebase:

| Run | Trigger | Result | Why build stayed at 6 on main |
|-----|---------|--------|-------------------------------|
| [28683608795](https://github.com/Ewynman/spot-ios-app/actions/runs/28683608795) | Manual dispatch on `fix/pr-comment-coverage` | Success | Push to `main` skipped (not on main branch) |
| [28684139457](https://github.com/Ewynman/spot-ios-app/actions/runs/28684139457) | Merge of #41 | Failed at push | `contents: write` missing → 403 on push **after** Firebase upload |
| [28684381686](https://github.com/Ewynman/spot-ios-app/actions/runs/28684381686) | Merge of #42 | Success | First run to push bump commit (`87e9621`) |

The pipeline incremented and built locally, uploaded to Firebase, but **only pushed the bump commit at the very end**. When push failed (or was skipped), `main` stayed at build 6 and the next run produced the same Firebase build number again.

## Fix

1. **Push build number bump before archive/upload** — if push fails, the job stops before building/uploading a duplicate
2. **Deploy concurrency group** — only one deploy at a time on `main`
3. **Skip bump commits** — `Bump build number to … [skip ci]` commits do not re-trigger deploy
4. **Honor `[skip ci]` in CI** — bump commits skip the full test suite
5. **Use `scripts/increment-build-number.sh`** — single source of truth for increment logic
6. **Remove inverted merge-commit skip** — the old `!contains(..., 'Merge pull request')` guard was incorrect

## Testing

- Verified against GitHub Actions logs for runs 28683608795, 28684139457, and 28684381686
- Workflow YAML changes only; no app code changes
- Updated `docs/engineering/ci-cd.md` with failure modes and new safeguards

## Checklist

- [x] Updated docs (`docs/engineering/ci-cd.md`)
- [x] No app/production code changes
- [x] CI workflow updated to skip `[skip ci]` bump commits
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f29ef-8924-7d49-b768-bdbed5dd104d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f29ef-8924-7d49-b768-bdbed5dd104d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

