### PR TITLE
Fix immediate crash on TestFlight/Firebase App Distribution launch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
 
 **Triggers:**
 - Pull requests to `main`
-- Pushes to `main`
+- Pushes to `main` (except `[skip ci]` commits)
 
 **What it does:**
 - Runs comprehensive PR validation including:
@@ -48,9 +48,52 @@ The workflow uses three validation scripts in `scripts/`:
 - Code coverage reports are uploaded as artifacts for 7 days
 - Validation results posted as PR comment with pass/fail status
 
+---
+
+### `deploy.yml` - Firebase App Distribution Deployment
+
+**Triggers:**
+- Merges to `main` (after CI passes)
+- Manual workflow dispatch
+
+**What it does:**
+- Automatically increments build number in `CURRENT_PROJECT_VERSION`
+- Pushes build number update to `main` before building (prevents duplicate Firebase build numbers)
+- Extracts release notes from merged PR (title + body)
+- Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
+- Installs Apple signing certificates and provisioning profiles
+- Archives and exports signed IPA for distribution
+- Uploads to Firebase App Distribution for the `testers` group
+- Creates deployment summary in GitHub Actions
+
+**Required GitHub Secrets:**
+- `GOOGLE_SERVICE_INFO_PLIST_BASE64` - Firebase GoogleService-Info.plist (base64 encoded)
+- `FIREBASE_APP_ID` - Firebase iOS App ID
+- `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials (JSON)
+- `APPLE_CERTIFICATE_BASE64` - Distribution certificate (.p12, base64 encoded)
+- `APPLE_CERTIFICATE_PASSWORD` - Certificate password
+- `PROVISIONING_PROFILE_BASE64` - Provisioning profile (base64 encoded)
+- `KEYCHAIN_PASSWORD` - Temporary keychain password (any secure random string)
+
+See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/firebase-distribution-setup.md) for detailed setup instructions.
+
+**Build versioning:**
+- Marketing version: `1.000` (manual updates)
+- Build number: Auto-incremented on every deploy (e.g., 7 → 8)
+
+**Important notes:**
+- GoogleService-Info.plist is required for Firebase initialization - without it, the app will crash on launch
+- Build number is committed and pushed before archiving to prevent duplicate Firebase builds
+- Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
+- Bump commits (`Bump build number to ... [skip ci]`) do not re-trigger CI or deploy workflows
+
+---
+
 ## Requirements
 
-The workflow expects:
+### CI Requirements
+
+The CI workflow expects:
 - A valid `SpotTests` scheme in the Xcode project
 - Tests that can run on iOS Simulator
 - No manual provisioning profiles required for unit tests
@@ -59,6 +102,17 @@ The workflow expects:
   - `validate-api-changes.sh`
   - `validate-documentation.sh`
   - `validate-coverage.sh`
+
+### Deploy Requirements
+
+The deploy workflow requires:
+- All seven GitHub secrets configured (see above)
+- Valid Apple Distribution certificate and provisioning profile
+- Firebase project with App Distribution enabled
+- `testers` group created in Firebase App Distribution
+- Valid `GoogleService-Info.plist` from Firebase Console
+
+---
 
 ## Local Testing
 
@@ -76,14 +130,39 @@ xcodebuild \
   test | xcbeautify
 ```
 
+---
+
+## Troubleshooting
+
+### "App crashes immediately on launch" after Firebase App Distribution download
+
+**Cause**: Missing `GOOGLE_SERVICE_INFO_PLIST_BASE64` secret in GitHub repository settings.
+
+**Solution**: 
+1. Download `GoogleService-Info.plist` from Firebase Console
+2. Convert to base64: `base64 -i GoogleService-Info.plist | pbcopy`
+3. Add as `GOOGLE_SERVICE_INFO_PLIST_BASE64` secret in GitHub repository settings
+4. Re-run the deployment workflow
+
+See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/firebase-distribution-setup.md) for full setup guide.
+
+### Duplicate Firebase build numbers
+
+**Cause**: Deploy workflow uploaded an IPA but failed to push the incremented build number back to `main`.
+
+**Solution**: The workflow now commits and pushes build numbers *before* archiving, preventing this issue. If you encounter duplicate builds from old deploys, they can be ignored - new deploys will use the correct incremented number.
+
+---
+
 ## Future Enhancements
 
 Consider adding:
+- ✅ Firebase App Distribution automation (completed)
+- ✅ Build number automation (completed)
+- ✅ Release notes generation (completed)
 - UI test workflow (separate from unit tests due to longer runtime)
-- Build and archive workflow for release candidates
-- **Firebase build automation** (step 2/3 of CI/CD roadmap)
-- **Build number automation** (step 2/3 of CI/CD roadmap)
-- **Release notes generation** from PR data (step 3/3 of CI/CD roadmap)
+- TestFlight upload option alongside Firebase
 - SwiftLint or other static analysis tools
 - Danger for additional automated PR checks
 - Coverage trending over time
+- Deployment notifications (Slack/Discord)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$GOOGLE_SERVICE_INFO_PLIST_BASE64" ]; then
+            echo "❌ GOOGLE_SERVICE_INFO_PLIST_BASE64 is not set. Firebase will fail to initialize."
+            echo "Add this secret to your GitHub repository settings with the base64-encoded GoogleService-Info.plist content."
+            exit 1
+          fi
+
+          # Decode and place GoogleService-Info.plist in the Spot directory
+          echo -n "$GOOGLE_SERVICE_INFO_PLIST_BASE64" | base64 --decode -o Spot/GoogleService-Info.plist
+
+          if [ -f "Spot/GoogleService-Info.plist" ]; then
+            echo "✅ GoogleService-Info.plist installed successfully"
+            # Verify it's valid XML/plist
+            plutil -lint Spot/GoogleService-Info.plist || {
+              echo "❌ GoogleService-Info.plist is not a valid plist file"
+              exit 1
+            }
+          else
+            echo "❌ GoogleService-Info.plist installation failed"
+            exit 1
+          fi
+
       - name: Install Apple Certificate and Provisioning Profile
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
@@ -266,3 +293,5 @@ jobs:
           if [ -n "${PROVISIONING_PROFILE_UUID:-}" ]; then
             rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"$PROVISIONING_PROFILE_UUID".mobileprovision || true
           fi
+          # Remove GoogleService-Info.plist to ensure it's not cached
+          rm -f Spot/GoogleService-Info.plist || true

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -75,10 +75,11 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 1. **Checkout:** Pull repository code with full history
 2. **Version Management:** Auto-increment build number
 3. **Release Notes:** Extract PR information for release notes
-4. **Code Signing:** Install certificates and provisioning profiles
-5. **Build:** Archive and export signed IPA
-6. **Deploy:** Upload to Firebase App Distribution
-7. **Version Commit:** Push build number update back to main
+4. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
+5. **Code Signing:** Install certificates and provisioning profiles
+6. **Build:** Archive and export signed IPA
+7. **Deploy:** Upload to Firebase App Distribution
+8. **Version Commit:** Push build number update back to main
 
 **What it does:**
 - Automatically increments `CURRENT_PROJECT_VERSION` in Xcode project via `scripts/increment-build-number.sh`
@@ -89,6 +90,7 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 - Skips re-deploy on bump commits (`Bump build number to … [skip ci]`)
 
 **Required secrets:**
+- `GOOGLE_SERVICE_INFO_PLIST_BASE64` - Firebase GoogleService-Info.plist file (base64 encoded)
 - `FIREBASE_APP_ID` - Firebase iOS App ID
 - `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials
 - `APPLE_CERTIFICATE_BASE64` - Distribution certificate (.p12 encoded)

--- a/docs/engineering/firebase-distribution-setup.md
+++ b/docs/engineering/firebase-distribution-setup.md
@@ -56,7 +56,40 @@ This is the Firebase iOS App ID from your Firebase project.
 
 ---
 
-### 3. APPLE_CERTIFICATE_BASE64
+### 3. GOOGLE_SERVICE_INFO_PLIST_BASE64
+
+**What it is**: Your Firebase configuration file (`GoogleService-Info.plist`) encoded in base64. This file is required for the app to initialize Firebase services (Analytics, Crashlytics, App Check).
+
+**How to get it**:
+
+#### Step 1: Download GoogleService-Info.plist
+
+1. Go to [Firebase Console](https://console.firebase.google.com/)
+2. Select project: `spot-a6a75`
+3. Click the gear icon → **Project settings**
+4. Scroll down to **Your apps** section
+5. Find the iOS app: `com.edwardwynman.Spot`
+6. Click **Download GoogleService-Info.plist**
+7. Save the file to your computer
+
+#### Step 2: Convert to Base64
+
+```bash
+cd ~/Downloads  # or wherever you saved the plist
+base64 -i GoogleService-Info.plist | pbcopy
+# The base64 string is now in your clipboard
+```
+
+#### Step 3: Add to GitHub Secrets
+
+- Secret name: `GOOGLE_SERVICE_INFO_PLIST_BASE64`
+- Secret value: Paste from clipboard (should be a long string of letters and numbers)
+
+**Why this is needed**: The app calls `FirebaseApp.configure()` on launch, which requires `GoogleService-Info.plist` to be present. Without this file, the app will crash immediately on startup. This file is excluded from the repository via `.gitignore` for security reasons, so it must be injected during the CI build process.
+
+---
+
+### 4. APPLE_CERTIFICATE_BASE64
 
 **What it is**: Your Apple Distribution certificate exported as a .p12 file and encoded in base64.
 
@@ -90,7 +123,7 @@ base64 -i Certificates.p12 | pbcopy
 
 ---
 
-### 4. APPLE_CERTIFICATE_PASSWORD
+### 5. APPLE_CERTIFICATE_PASSWORD
 
 **What it is**: The password you set when exporting the .p12 certificate.
 
@@ -101,7 +134,7 @@ base64 -i Certificates.p12 | pbcopy
 
 ---
 
-### 5. PROVISIONING_PROFILE_BASE64
+### 6. PROVISIONING_PROFILE_BASE64
 
 **What it is**: Your App Store distribution provisioning profile, encoded in base64.
 
@@ -128,7 +161,7 @@ base64 -i Spot_Distribution.mobileprovision | pbcopy
 
 ---
 
-### 6. KEYCHAIN_PASSWORD
+### 7. KEYCHAIN_PASSWORD
 
 **What it is**: A temporary password for the CI keychain (can be any secure string).
 
@@ -162,6 +195,7 @@ Before triggering a build, verify you have:
 
 - [ ] `FIREBASE_APP_ID` set to `1:415359921164:ios:66b52b0b2c5f0f2eb59229`
 - [ ] `FIREBASE_SERVICE_ACCOUNT_JSON` (full JSON from Firebase)
+- [ ] `GOOGLE_SERVICE_INFO_PLIST_BASE64` (base64-encoded GoogleService-Info.plist)
 - [ ] `APPLE_CERTIFICATE_BASE64` (base64-encoded .p12)
 - [ ] `APPLE_CERTIFICATE_PASSWORD` (your .p12 password)
 - [ ] `PROVISIONING_PROFILE_BASE64` (base64-encoded .mobileprovision)
@@ -181,6 +215,14 @@ Once all secrets are configured:
 ---
 
 ## Troubleshooting
+
+### "App crashes immediately on launch"
+
+- **Most common cause**: Missing `GOOGLE_SERVICE_INFO_PLIST_BASE64` secret
+- Verify the secret is set in GitHub repository settings
+- Verify the base64 encoding is correct (try re-encoding)
+- Check GitHub Actions logs for "GoogleService-Info.plist installation failed"
+- The app requires this file to initialize Firebase - without it, `FirebaseApp.configure()` will crash
 
 ### "No identity found" error
 

--- a/scripts/encode-google-service-info.sh
+++ b/scripts/encode-google-service-info.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# encode-google-service-info.sh
+#
+# Helper script to encode GoogleService-Info.plist for GitHub secrets
+#
+# Usage:
+#   ./scripts/encode-google-service-info.sh /path/to/GoogleService-Info.plist
+#
+# The base64-encoded string will be copied to your clipboard (macOS) or printed to stdout
+
+set -euo pipefail
+
+PLIST_PATH="${1:-}"
+
+if [ -z "$PLIST_PATH" ]; then
+  echo "❌ Error: Please provide the path to GoogleService-Info.plist"
+  echo ""
+  echo "Usage:"
+  echo "  ./scripts/encode-google-service-info.sh /path/to/GoogleService-Info.plist"
+  echo ""
+  echo "Example:"
+  echo "  ./scripts/encode-google-service-info.sh ~/Downloads/GoogleService-Info.plist"
+  exit 1
+fi
+
+if [ ! -f "$PLIST_PATH" ]; then
+  echo "❌ Error: File not found: $PLIST_PATH"
+  exit 1
+fi
+
+# Verify it's a valid plist
+if ! plutil -lint "$PLIST_PATH" > /dev/null 2>&1; then
+  echo "❌ Error: $PLIST_PATH is not a valid plist file"
+  exit 1
+fi
+
+echo "✅ Found valid GoogleService-Info.plist"
+echo ""
+
+# Encode to base64
+BASE64_STRING=$(base64 -i "$PLIST_PATH")
+
+# Try to copy to clipboard (macOS)
+if command -v pbcopy > /dev/null 2>&1; then
+  echo "$BASE64_STRING" | pbcopy
+  echo "✅ Base64 string copied to clipboard!"
+  echo ""
+  echo "Next steps:"
+  echo "1. Go to GitHub repository: Settings → Secrets and variables → Actions"
+  echo "2. Click 'New repository secret'"
+  echo "3. Name: GOOGLE_SERVICE_INFO_PLIST_BASE64"
+  echo "4. Value: Paste from clipboard (Cmd+V)"
+  echo "5. Click 'Add secret'"
+else
+  # No clipboard available, print to stdout
+  echo "✅ Base64 string:"
+  echo ""
+  echo "$BASE64_STRING"
+  echo ""
+  echo "Copy the string above and:"
+  echo "1. Go to GitHub repository: Settings → Secrets and variables → Actions"
+  echo "2. Click 'New repository secret'"
+  echo "3. Name: GOOGLE_SERVICE_INFO_PLIST_BASE64"
+  echo "4. Value: Paste the base64 string"
+  echo "5. Click 'Add secret'"
+fi
+
+echo ""
+echo "Documentation: docs/engineering/firebase-distribution-setup.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Fixed critical issue where the app crashes immediately on launch when installed from Firebase App Distribution (TestFlight), while working fine when built from Xcode.

**Root Cause:**
`AppDelegate.swift` initializes Firebase with `FirebaseApp.configure()` on launch, which requires `GoogleService-Info.plist` to be present. This file is `.gitignored` for security (correctly), but the deploy workflow wasn't injecting it before building. When the CI-built app tried to initialize Firebase, it crashed because the configuration file was missing.

**Solution:**
1. Added a new step in `deploy.yml` to inject `GoogleService-Info.plist` from GitHub secrets before building
2. Added cleanup step to remove the file after build (security)
3. Updated all documentation to reflect the new required secret
4. Added helper script to easily encode the plist file for GitHub secrets

**Files Changed:**
- `.github/workflows/deploy.yml` - Added GoogleService-Info.plist injection and cleanup steps
- `docs/engineering/ci-cd.md` - Added new secret to required secrets list and updated pipeline stages
- `docs/engineering/firebase-distribution-setup.md` - Added detailed setup instructions for the new secret with troubleshooting
- `.github/workflows/README.md` - Added deploy workflow documentation and troubleshooting section
- `scripts/encode-google-service-info.sh` - Helper script to encode plist for GitHub secrets

## Testing

**Pre-fix behavior:**
- ✅ App builds and runs successfully from Xcode (developer has local GoogleService-Info.plist)
- ❌ App crashes immediately when launched from Firebase App Distribution (no GoogleService-Info.plist in CI build)

**Post-fix behavior (expected after secret is added):**
- ✅ App builds and runs successfully from Xcode (unchanged)
- ✅ App launches successfully from Firebase App Distribution (GoogleService-Info.plist injected during CI build)

**Testing approach:**
This is a CI/CD pipeline fix that requires the repository maintainer to add the `GOOGLE_SERVICE_INFO_PLIST_BASE64` secret to GitHub settings before the next deployment. Once added:
1. Merge this PR to trigger the deploy workflow
2. Download the app from Firebase App Distribution
3. Launch the app - it should now open successfully without crashing

**Documentation verification:**
- ✅ All documentation updated to reflect the new required secret
- ✅ Step-by-step instructions provided in `firebase-distribution-setup.md`
- ✅ Troubleshooting section added for this specific issue
- ✅ Helper script provided for easy plist encoding

## Checklist

### Code Quality & Testing (Required)
- [x] Added Unit Tests For New Code (80% minimum coverage on changed files) - *N/A: CI/CD configuration change only*
- [x] All tests pass locally (`xcodebuild -scheme SpotTests test`) - *N/A: No production code changes*
- [x] No breaking API changes (or documented if intentional) - *No API changes*
- [x] Confirmed no new warnings introduced - *CI/CD configuration only*
- [x] Code follows existing patterns and style - *Follows existing deploy.yml patterns*

### Documentation (Required)
- [x] Updated docs (see `docs/operations/documentation-maintenance.md`)
- [x] Updated relevant product docs if user-facing behavior changed - *N/A: No user-facing changes, only fixes broken deployment*
- [x] Updated architecture/engineering docs if service/data layer changed - *Updated CI/CD docs*
- [x] Updated diagrams if flows changed significantly - *N/A: No flow changes*

### Data plane (required for auth, posting, storage, or `Spot/Services` changes)
- [x] **No Firebase data plane** — no `FirebaseFirestore`, `FirebaseStorage`, `FirebaseAuth`, `SpotUploader`, or Firestore/Storage callbacks under `Spot/` - *No changes to data plane*
- [x] Posting uses **`SpotPublishCoordinator`** / **`SpotSupabaseRepository`** (Supabase Storage + Postgres RPC) - *N/A: No posting changes*
- [x] Schema/RLS changes include SQL under **`supabase/migrations/`** - *N/A: No schema changes*
- [x] `SpotTests` **`DataPlaneGuardTests`** pass (`xcodebuild -scheme SpotTests test`) - *No production code changes*

---

## Next Steps for Repository Owner

⚠️ **Action Required:** Before the next deployment, add the following secret to GitHub repository settings:

### Quick Setup (Recommended)

Use the provided helper script for easy encoding:

```bash
# 1. Download GoogleService-Info.plist from Firebase Console
# 2. Run the helper script
./scripts/encode-google-service-info.sh ~/Downloads/GoogleService-Info.plist

# The base64 string will be copied to your clipboard automatically
```

Then add to GitHub:
1. Go to **Settings → Secrets and variables → Actions → New repository secret**
2. Name: `GOOGLE_SERVICE_INFO_PLIST_BASE64`
3. Value: Paste from clipboard (Cmd+V)
4. Click **Add secret**

### Manual Setup

If you prefer to do it manually:

1. Download `GoogleService-Info.plist` from [Firebase Console](https://console.firebase.google.com/) → Project Settings → Your Apps → iOS App
2. Convert to base64: `base64 -i GoogleService-Info.plist | pbcopy`
3. Add to **GitHub Settings → Secrets and variables → Actions → New repository secret**
   - Name: `GOOGLE_SERVICE_INFO_PLIST_BASE64`
   - Value: (paste the base64 string)

See `docs/engineering/firebase-distribution-setup.md` for detailed instructions.

Once this secret is added, future deployments will include the Firebase configuration file and the app will launch successfully from Firebase App Distribution.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2a00-926a-7215-93da-2c13dc0f47aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2a00-926a-7215-93da-2c13dc0f47aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

