### PR TITLE
CI/CD: clean Apple signing for Firebase Ad Hoc + TestFlight lanes

### DIFF
--- a/.github/workflows/ExportOptions-Firebase.plist
+++ b/.github/workflows/ExportOptions-Firebase.plist
@@ -2,8 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- Firebase App Distribution lane: Ad Hoc export signed with the Apple
+         Distribution certificate from FIREBASE_DEV_CERT and the Ad Hoc profile
+         from FIREBASE_PROVISIONING_PROFILE. -->
     <key>method</key>
-    <string>development</string>
+    <string>ad-hoc</string>
     <key>teamID</key>
     <string>55JK72KR4W</string>
     <key>uploadBitcode</key>
@@ -13,10 +16,10 @@
     <key>signingStyle</key>
     <string>manual</string>
     <key>signingCertificate</key>
-    <string>Apple Development</string>
+    <string>Apple Distribution</string>
     <!--
       provisioningProfiles is injected at build time by deploy.yml, because the
-      profile name is only known after decoding PROVISIONING_PROFILE_BASE64.
+      profile name is only known after decoding FIREBASE_PROVISIONING_PROFILE.
     -->
 </dict>
 </plist>

--- a/.github/workflows/ExportOptions-TestFlight.plist
+++ b/.github/workflows/ExportOptions-TestFlight.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- TestFlight lane: App Store export signed with the Apple Distribution
+         certificate from TESTFLIGHT_APPLE_CERT and the App Store Connect profile
+         from TESTFLIGHT_APPLE_PROFILE. -->
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>55JK72KR4W</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
+    <key>destination</key>
+    <string>export</string>
+    <!--
+      provisioningProfiles is injected at build time by testflight.yml, because the
+      profile name is only known after decoding TESTFLIGHT_APPLE_PROFILE.
+    -->
+</dict>
+</plist>

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -50,42 +50,90 @@ The workflow uses three validation scripts in `scripts/`:
 
 ---
 
-### `deploy.yml` - Firebase App Distribution Deployment
+### `deploy.yml` - Firebase App Distribution Deployment (Test ENV)
 
 **Triggers:**
-- Merges to `main` (after CI passes)
+- Merges/pushes to `main` (after CI passes)
 - Manual workflow dispatch
 
 **What it does:**
-- Automatically increments build number in `CURRENT_PROJECT_VERSION`
+- Automatically increments build number in `CURRENT_PROJECT_VERSION` (build number `+1` only)
 - Pushes build number update to `main` before building (prevents duplicate Firebase build numbers)
 - Extracts release notes from merged PR (title + body)
 - Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
-- Installs Apple signing certificates and provisioning profiles
-- Archives and exports signed IPA for distribution
+- Installs Apple signing assets into a temporary CI keychain (never the login keychain)
+- Archives unsigned, then exports a **signed Ad Hoc IPA** for distribution
 - Uploads to Firebase App Distribution for the `testers` group
 - Creates deployment summary in GitHub Actions
+
+**Signing assets (Firebase / Ad Hoc lane):**
+- Certificate: `FIREBASE_DEV_CERT` (base64-encoded **.p12**; despite the name this is the Apple **Distribution** cert used for CI)
+- Provisioning profile: `FIREBASE_PROVISIONING_PROFILE` (base64-encoded **.mobileprovision**, Ad Hoc)
+- Export options template: `ExportOptions-Firebase.plist` (`method = ad-hoc`)
 
 **Required GitHub Secrets:**
 - `GOOGLE_SERVICE_INFO_PLIST_BASE64` - Firebase GoogleService-Info.plist (base64 encoded)
 - `FIREBASE_APP_ID` - Firebase iOS App ID
-- `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials (JSON)
-- `APPLE_CERTIFICATE_BASE64` - Distribution certificate (.p12, base64 encoded)
-- `APPLE_CERTIFICATE_PASSWORD` - Certificate password
-- `PROVISIONING_PROFILE_BASE64` - Provisioning profile (base64 encoded)
-- `KEYCHAIN_PASSWORD` - Temporary keychain password (any secure random string)
+- `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials (raw JSON)
+- `FIREBASE_DEV_CERT` - Apple Distribution certificate (.p12, base64 encoded)
+- `APPLE_CERTIFICATE_PASSWORD` - Password used when exporting the .p12
+- `FIREBASE_PROVISIONING_PROFILE` - Ad Hoc provisioning profile (.mobileprovision, base64 encoded)
+- `KEYCHAIN_PASSWORD` - Temporary CI keychain password (any secure random string)
 
 See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/firebase-distribution-setup.md) for detailed setup instructions.
 
 **Build versioning:**
 - Marketing version: `1.000` (manual updates)
-- Build number: Auto-incremented on every deploy (e.g., 7 → 8)
+- Build number: Auto-incremented on every deploy (e.g., 9 → 10)
 
 **Important notes:**
 - GoogleService-Info.plist is required for Firebase initialization - without it, the app will crash on launch
 - Build number is committed and pushed before archiving to prevent duplicate Firebase builds
 - Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
 - Bump commits (`Bump build number to ... [skip ci]`) do not re-trigger CI or deploy workflows
+
+---
+
+### `testflight.yml` - App Store Connect / TestFlight Deployment
+
+**Triggers:**
+- Pushes to `release/**` branches
+- Manual workflow dispatch (from a `release/**` branch)
+
+**What it does:**
+- Derives the marketing version from the branch name (e.g. `release/1.1.0` → `MARKETING_VERSION=1.1.0`)
+- Uses `github.run_number` as the unique build number (the version itself is **not** auto-bumped)
+- Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
+- Installs Apple signing assets into a temporary CI keychain
+- Archives unsigned, then exports a **signed App Store IPA**
+- Uploads the IPA artifact, then uploads to App Store Connect / TestFlight via `xcrun altool`
+- Does **not** submit to App Store Review
+
+**Versioning examples:**
+- `release/1.1.0` run 101 → version `1.1.0`, build `101`
+- `release/1.1.0` run 102 → version `1.1.0`, build `102`
+
+**Signing assets (TestFlight / App Store lane):**
+- Certificate: `TESTFLIGHT_APPLE_CERT` (base64-encoded **.p12**, Apple Distribution)
+- Provisioning profile: `TESTFLIGHT_APPLE_PROFILE` (base64-encoded **.mobileprovision**, App Store Connect). *(The PRD calls this `TESTFLIGHT_PROVISIONING_PROFILE`, but the secret configured in the repo is `TESTFLIGHT_APPLE_PROFILE`; we reference the existing secret rather than renaming it.)*
+- Export options template: `ExportOptions-TestFlight.plist` (`method = app-store`)
+
+**Required GitHub Secrets:**
+- `GOOGLE_SERVICE_INFO_PLIST_BASE64`
+- `TESTFLIGHT_APPLE_CERT`
+- `APPLE_CERTIFICATE_PASSWORD`
+- `TESTFLIGHT_APPLE_PROFILE`
+- `KEYCHAIN_PASSWORD`
+
+**⚠️ App Store Connect API secrets required for upload (NOT yet configured):**
+
+The build/archive/export steps run without them, but the **TestFlight upload step fails with a clear message** until these are added:
+
+- `APP_STORE_CONNECT_API_KEY_ID` - the App Store Connect API Key ID
+- `APP_STORE_CONNECT_API_ISSUER_ID` - the Issuer ID (UUID)
+- `APP_STORE_CONNECT_API_KEY_P8_BASE64` - base64 of the `AuthKey_XXX.p8` file
+
+Create the key at App Store Connect → **Users and Access → Integrations → App Store Connect API**.
 
 ---
 
@@ -105,12 +153,18 @@ The CI workflow expects:
 
 ### Deploy Requirements
 
-The deploy workflow requires:
-- All seven GitHub secrets configured (see above)
-- Valid Apple Distribution certificate and provisioning profile
+The Firebase deploy workflow (`deploy.yml`) requires:
+- The Firebase-lane secrets configured (see above)
+- A valid Apple Distribution certificate (`FIREBASE_DEV_CERT`) and **Ad Hoc** provisioning profile (`FIREBASE_PROVISIONING_PROFILE`)
 - Firebase project with App Distribution enabled
 - `testers` group created in Firebase App Distribution
 - Valid `GoogleService-Info.plist` from Firebase Console
+
+The TestFlight workflow (`testflight.yml`) requires:
+- The TestFlight-lane secrets configured (see above)
+- A valid Apple Distribution certificate (`TESTFLIGHT_APPLE_CERT`) and **App Store Connect** provisioning profile (`TESTFLIGHT_APPLE_PROFILE`)
+- App Store Connect API secrets (`APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8_BASE64`) for the upload step
+- A `release/<version>` branch (e.g. `release/1.1.0`) so the version can be derived
 
 ---
 
@@ -160,8 +214,8 @@ Consider adding:
 - ✅ Firebase App Distribution automation (completed)
 - ✅ Build number automation (completed)
 - ✅ Release notes generation (completed)
+- ✅ TestFlight upload on `release/**` branches (`testflight.yml`; upload needs the App Store Connect API secrets)
 - UI test workflow (separate from unit tests due to longer runtime)
-- TestFlight upload option alongside Firebase
 - SwiftLint or other static analysis tools
 - Danger for additional automated PR checks
 - Coverage trending over time

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,16 +154,23 @@ jobs:
 
       - name: Install Apple Certificate and Provisioning Profile
         env:
-          CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          # Firebase lane signing assets (Apple Distribution cert + Ad Hoc profile).
+          # Despite the name, FIREBASE_DEV_CERT is the base64-encoded distribution
+          # .p12 used for CI signing (see docs/engineering/ci-cd.md).
+          CERTIFICATE_BASE64: ${{ secrets.FIREBASE_DEV_CERT }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.FIREBASE_PROVISIONING_PROFILE }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
 
           # The `secrets` context cannot be used in a step-level `if`, so guard here instead.
           if [ -z "$CERTIFICATE_BASE64" ]; then
-            echo "❌ APPLE_CERTIFICATE_BASE64 is not set. Add the signing secrets before deploying."
+            echo "❌ FIREBASE_DEV_CERT is not set. Add the Firebase signing secrets before deploying."
+            exit 1
+          fi
+          if [ -z "$PROVISIONING_PROFILE_BASE64" ]; then
+            echo "❌ FIREBASE_PROVISIONING_PROFILE is not set. Add the Ad Hoc provisioning profile before deploying."
             exit 1
           fi
 
@@ -172,11 +179,13 @@ jobs:
           PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-          # Import certificate and provisioning profile from secrets
+          # Import certificate and provisioning profile from secrets.
+          # FIREBASE_DEV_CERT is a base64-encoded .p12; FIREBASE_PROVISIONING_PROFILE
+          # is a base64-encoded .mobileprovision.
           echo -n "$CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
           echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
-          # Create temporary keychain
+          # Create a temporary CI keychain (never the login keychain)
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
@@ -185,7 +194,7 @@ jobs:
           security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
 
           # Allow codesign/productbuild to use the key without an interactive prompt (required for headless CI)
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
           # Make the temporary keychain searchable so codesign can find the imported identity
           security list-keychain -d user -s $KEYCHAIN_PATH
@@ -204,8 +213,9 @@ jobs:
           set -euo pipefail
 
           # Inject the resolved provisioning profile name into ExportOptions for manual signing.
+          # Firebase lane uses the Ad Hoc export options template.
           EXPORT_OPTIONS=$RUNNER_TEMP/ExportOptions.plist
-          cp .github/workflows/ExportOptions.plist "$EXPORT_OPTIONS"
+          cp .github/workflows/ExportOptions-Firebase.plist "$EXPORT_OPTIONS"
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:com.edwardwynman.Spot string ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS" 2>/dev/null \
             || /usr/libexec/PlistBuddy -c "Set :provisioningProfiles:com.edwardwynman.Spot ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,273 @@
+name: Deploy to TestFlight
+
+on:
+  push:
+    branches:
+      - 'release/**'
+  workflow_dispatch:  # Allow manual triggers from a release/** branch
+
+# Serialize release uploads so two pushes cannot race for the same run context.
+concurrency:
+  group: deploy-testflight-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    name: Build and Upload to App Store Connect / TestFlight
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version and build number
+        id: version
+        run: |
+          set -euo pipefail
+
+          # The release branch name controls the user-facing marketing version.
+          # Example: release/1.1.0 -> MARKETING_VERSION=1.1.0
+          # Only the build number auto-increments (via the unique run number).
+          BRANCH="${GITHUB_REF_NAME}"
+          VERSION="${BRANCH#release/}"
+
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}$'; then
+            echo "❌ Could not derive a valid marketing version from branch '$BRANCH'."
+            echo "Expected a branch like 'release/1.1.0' (release/MAJOR.MINOR.PATCH)."
+            exit 1
+          fi
+
+          # github.run_number is unique and monotonically increasing per workflow,
+          # which satisfies App Store Connect's "build number must be unique per version".
+          BUILD="${{ github.run_number }}"
+
+          echo "Marketing version: $VERSION"
+          echo "Build number: $BUILD"
+          echo "marketing_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install dependencies
+        run: brew install xcbeautify
+
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Install GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$GOOGLE_SERVICE_INFO_PLIST_BASE64" ]; then
+            echo "❌ GOOGLE_SERVICE_INFO_PLIST_BASE64 is not set. Firebase will fail to initialize."
+            echo "Add this secret to your GitHub repository settings with the base64-encoded GoogleService-Info.plist content."
+            exit 1
+          fi
+
+          echo -n "$GOOGLE_SERVICE_INFO_PLIST_BASE64" | base64 --decode -o Spot/GoogleService-Info.plist
+
+          if [ -f "Spot/GoogleService-Info.plist" ]; then
+            echo "✅ GoogleService-Info.plist installed successfully"
+            plutil -lint Spot/GoogleService-Info.plist || {
+              echo "❌ GoogleService-Info.plist is not a valid plist file"
+              exit 1
+            }
+          else
+            echo "❌ GoogleService-Info.plist installation failed"
+            exit 1
+          fi
+
+      - name: Install Apple Certificate and Provisioning Profile
+        env:
+          # TestFlight lane signing assets (Apple Distribution cert + App Store Connect profile).
+          # TESTFLIGHT_APPLE_CERT is a base64-encoded .p12; TESTFLIGHT_APPLE_PROFILE
+          # is a base64-encoded .mobileprovision. Do NOT use the Firebase Ad Hoc assets here.
+          # NOTE: The PRD lists this profile secret as TESTFLIGHT_PROVISIONING_PROFILE, but the
+          # secret actually configured in the repo is TESTFLIGHT_APPLE_PROFILE. Per the "do not
+          # rename secrets" rule we reference the existing name rather than renaming the secret.
+          CERTIFICATE_BASE64: ${{ secrets.TESTFLIGHT_APPLE_CERT }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.TESTFLIGHT_APPLE_PROFILE }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          # The `secrets` context cannot be used in a step-level `if`, so guard here instead.
+          if [ -z "$CERTIFICATE_BASE64" ]; then
+            echo "❌ TESTFLIGHT_APPLE_CERT is not set. Add the TestFlight signing secrets before deploying."
+            exit 1
+          fi
+          if [ -z "$PROVISIONING_PROFILE_BASE64" ]; then
+            echo "❌ TESTFLIGHT_APPLE_PROFILE is not set. Add the App Store Connect provisioning profile before deploying."
+            exit 1
+          fi
+
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # Create a temporary CI keychain (never the login keychain)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+
+          # Allow codesign to use the key without an interactive prompt (required for headless CI)
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Make the temporary keychain searchable so codesign can find the imported identity
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Install the provisioning profile under its UUID and expose its name for manual signing
+          PROFILE_UUID=$(security cms -D -i "$PP_PATH" | plutil -extract UUID raw -)
+          PROFILE_NAME=$(security cms -D -i "$PP_PATH" | plutil -extract Name raw -)
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"$PROFILE_UUID".mobileprovision
+          echo "Installed provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
+          echo "PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
+          echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
+      - name: Build and export production archive
+        env:
+          MARKETING_VERSION: ${{ steps.version.outputs.marketing_version }}
+          CURRENT_PROJECT_VERSION: ${{ steps.version.outputs.build_number }}
+        run: |
+          set -euo pipefail
+
+          # Inject the resolved provisioning profile name into ExportOptions for manual signing.
+          # TestFlight lane uses the App Store export options template.
+          EXPORT_OPTIONS=$RUNNER_TEMP/ExportOptions.plist
+          cp .github/workflows/ExportOptions-TestFlight.plist "$EXPORT_OPTIONS"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:com.edwardwynman.Spot string ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS" 2>/dev/null \
+            || /usr/libexec/PlistBuddy -c "Set :provisioningProfiles:com.edwardwynman.Spot ${PROVISIONING_PROFILE_NAME}" "$EXPORT_OPTIONS"
+
+          # Archive WITHOUT code signing. Passing signing settings on the xcodebuild
+          # command line applies them to every target, including Swift Package
+          # dependencies which do not support provisioning profiles and fail the archive.
+          # We archive unsigned and sign only at export time, where ExportOptions scopes
+          # the provisioning profile to the app's bundle id.
+          #
+          # MARKETING_VERSION comes from the release/** branch name; CURRENT_PROJECT_VERSION
+          # is the unique GitHub run number. These are safe to set globally (unlike signing).
+          xcodebuild \
+            -scheme Spot \
+            -destination "generic/platform=iOS" \
+            -archivePath $RUNNER_TEMP/Spot.xcarchive \
+            -configuration Release \
+            MARKETING_VERSION="$MARKETING_VERSION" \
+            CURRENT_PROJECT_VERSION="$CURRENT_PROJECT_VERSION" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            clean archive | xcbeautify
+
+          # Export & sign the IPA for App Store Connect (manual signing scoped via ExportOptions)
+          xcodebuild \
+            -exportArchive \
+            -archivePath $RUNNER_TEMP/Spot.xcarchive \
+            -exportPath $RUNNER_TEMP/export \
+            -exportOptionsPlist "$EXPORT_OPTIONS" | xcbeautify
+
+          if [ -f "$RUNNER_TEMP/export/Spot.ipa" ]; then
+            echo "✅ IPA created successfully (version $MARKETING_VERSION build $CURRENT_PROJECT_VERSION)"
+            ls -lh $RUNNER_TEMP/export/Spot.ipa
+          else
+            echo "❌ IPA creation failed"
+            exit 1
+          fi
+
+      - name: Upload build artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Spot-TestFlight-${{ steps.version.outputs.marketing_version }}-${{ steps.version.outputs.build_number }}
+          path: ${{ runner.temp }}/export/Spot.ipa
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Upload to App Store Connect / TestFlight
+        if: success()
+        env:
+          # TODO: These App Store Connect API secrets are NOT yet configured in the
+          # repository. Add them in GitHub → Settings → Secrets and variables → Actions
+          # for the TestFlight upload to succeed. Names follow the PRD's suggested naming:
+          #   APP_STORE_CONNECT_API_KEY_ID          - the Key ID (e.g. ABC123DEF4)
+          #   APP_STORE_CONNECT_API_ISSUER_ID       - the Issuer ID (a UUID)
+          #   APP_STORE_CONNECT_API_KEY_P8_BASE64   - base64 of the AuthKey_XXX.p8 file
+          # Create the key at App Store Connect → Users and Access → Integrations → App Store Connect API.
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          ASC_KEY_P8_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$ASC_KEY_ID" ] || [ -z "$ASC_ISSUER_ID" ] || [ -z "$ASC_KEY_P8_BASE64" ]; then
+            echo "❌ App Store Connect API credentials are missing."
+            echo ""
+            echo "The archive built and exported successfully (see the uploaded artifact),"
+            echo "but TestFlight upload requires App Store Connect API secrets that are not yet set."
+            echo ""
+            echo "Add these repository secrets to enable automatic TestFlight upload:"
+            echo "  - APP_STORE_CONNECT_API_KEY_ID"
+            echo "  - APP_STORE_CONNECT_API_ISSUER_ID"
+            echo "  - APP_STORE_CONNECT_API_KEY_P8_BASE64  (base64 of the AuthKey_XXX.p8)"
+            echo ""
+            echo "Create the key at App Store Connect → Users and Access → Integrations → App Store Connect API."
+            exit 1
+          fi
+
+          # altool looks for the private key at ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8
+          PRIVATE_KEYS_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$PRIVATE_KEYS_DIR"
+          echo -n "$ASC_KEY_P8_BASE64" | base64 --decode -o "$PRIVATE_KEYS_DIR/AuthKey_${ASC_KEY_ID}.p8"
+
+          # Upload to App Store Connect. This makes the build available in TestFlight
+          # after processing. It does NOT submit the build to App Store Review.
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export/Spot.ipa" \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID"
+
+          echo "✅ Uploaded to App Store Connect. The build will appear in TestFlight after processing."
+
+          # Remove the decoded private key
+          rm -f "$PRIVATE_KEYS_DIR/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Create build summary
+        if: always()
+        run: |
+          echo "## 🚀 TestFlight Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: ${{ steps.version.outputs.marketing_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Number**: ${{ steps.version.outputs.build_number }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Clean up keychain and provisioning profile
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+          if [ -n "${PROVISIONING_PROFILE_UUID:-}" ]; then
+            rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"$PROVISIONING_PROFILE_UUID".mobileprovision || true
+          fi
+          rm -f "$HOME/.appstoreconnect/private_keys"/AuthKey_*.p8 || true
+          # Remove GoogleService-Info.plist to ensure it's not cached
+          rm -f Spot/GoogleService-Info.plist || true

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -21,7 +21,18 @@ The Spot project uses GitHub Actions for continuous integration and deployment. 
 #### Workflows
 
 1. **`ci.yml`** - Pull Request validation (runs on PRs to main)
-2. **`deploy.yml`** - Firebase App Distribution deployment (runs on merge to main)
+2. **`deploy.yml`** - Firebase App Distribution deployment / Test ENV (runs on push/merge to main)
+3. **`testflight.yml`** - App Store Connect / TestFlight deployment (runs on push to `release/**`)
+
+**Three lanes at a glance:**
+
+| Lane | Trigger | Signing cert secret | Profile secret | Export method | Versioning |
+| --- | --- | --- | --- | --- | --- |
+| PR validation | `pull_request` → `main` | none | none | n/a (simulator tests) | n/a |
+| Firebase Test ENV | `push` → `main` | `FIREBASE_DEV_CERT` | `FIREBASE_PROVISIONING_PROFILE` | `ad-hoc` | build number `+1` |
+| TestFlight | `push` → `release/**` | `TESTFLIGHT_APPLE_CERT` | `TESTFLIGHT_APPLE_PROFILE` | `app-store` | version from branch, build = `run_number` |
+
+The Firebase and TestFlight signing assets are never swapped: the Ad Hoc profile is only used for Firebase, and the App Store Connect profile is only used for TestFlight. `APPLE_CERTIFICATE_PASSWORD` is the single password used to import both `.p12` files, and `KEYCHAIN_PASSWORD` is the temporary CI keychain password.
 
 #### Main workflow: `ci.yml`
 
@@ -92,13 +103,62 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 **Required secrets:**
 - `GOOGLE_SERVICE_INFO_PLIST_BASE64` - Firebase GoogleService-Info.plist file (base64 encoded)
 - `FIREBASE_APP_ID` - Firebase iOS App ID
-- `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials
-- `APPLE_CERTIFICATE_BASE64` - Distribution certificate (.p12 encoded)
-- `APPLE_CERTIFICATE_PASSWORD` - Certificate password
-- `PROVISIONING_PROFILE_BASE64` - Provisioning profile encoded
-- `KEYCHAIN_PASSWORD` - Temporary keychain password
+- `FIREBASE_SERVICE_ACCOUNT_JSON` - Firebase service account credentials (raw JSON)
+- `FIREBASE_DEV_CERT` - Apple Distribution certificate (.p12, base64 encoded). Despite the name, this is the distribution cert used for CI signing.
+- `APPLE_CERTIFICATE_PASSWORD` - Password used when exporting the .p12
+- `FIREBASE_PROVISIONING_PROFILE` - Ad Hoc provisioning profile (.mobileprovision, base64 encoded)
+- `KEYCHAIN_PASSWORD` - Temporary CI keychain password
+
+Export options template: `.github/workflows/ExportOptions-Firebase.plist` (`method = ad-hoc`, `signingCertificate = Apple Distribution`). The provisioning profile name is injected at build time after decoding `FIREBASE_PROVISIONING_PROFILE`.
 
 See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detailed setup instructions.
+
+---
+
+#### Deployment workflow: `testflight.yml`
+
+**Triggers:**
+- Push to a `release/**` branch
+- Manual workflow dispatch (from a `release/**` branch)
+
+**Environment:**
+- Runner: macOS 15
+- Requires: Apple signing assets, Firebase config, and App Store Connect API credentials for upload
+
+**Pipeline stages:**
+
+1. **Checkout:** Pull repository code with full history
+2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and set `CURRENT_PROJECT_VERSION` to `github.run_number`
+3. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
+4. **Code Signing:** Install `TESTFLIGHT_APPLE_CERT` + `TESTFLIGHT_APPLE_PROFILE` into a temporary keychain
+5. **Build:** Archive unsigned, then export an App Store `.ipa`
+6. **Artifact:** Upload the `.ipa` as a workflow artifact
+7. **Upload:** Send the `.ipa` to App Store Connect / TestFlight via `xcrun altool`
+8. **Summary + cleanup:** Emit a build summary and remove temporary keychain/profile/key files
+
+**Versioning rule:**
+- The release branch name controls the user-facing version. `release/1.1.0` → `MARKETING_VERSION = 1.1.0`.
+- Only the build number auto-increments, using the unique `github.run_number`:
+  - `release/1.1.0` run 101 → version `1.1.0`, build `101`
+  - `release/1.1.0` run 102 → version `1.1.0`, build `102`
+- The pipeline never bumps `1.1.0` → `1.2.0` automatically. To ship a new version, create a new `release/<version>` branch.
+- TestFlight upload does **not** submit the build to App Store Review.
+
+**Required secrets:**
+- `GOOGLE_SERVICE_INFO_PLIST_BASE64`
+- `TESTFLIGHT_APPLE_CERT` - Apple Distribution certificate (.p12, base64 encoded)
+- `APPLE_CERTIFICATE_PASSWORD` - Password used when exporting the .p12
+- `TESTFLIGHT_APPLE_PROFILE` - App Store Connect provisioning profile (.mobileprovision, base64 encoded). *(The PRD refers to this as `TESTFLIGHT_PROVISIONING_PROFILE`; the repo's actual secret is `TESTFLIGHT_APPLE_PROFILE`, and we reference the existing name instead of renaming it.)*
+- `KEYCHAIN_PASSWORD`
+
+**App Store Connect API secrets (TODO — not yet configured):** the upload step fails with a clear message until these exist. Names follow the PRD's suggested naming:
+- `APP_STORE_CONNECT_API_KEY_ID`
+- `APP_STORE_CONNECT_API_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_P8_BASE64` (base64 of the `AuthKey_XXX.p8`)
+
+Create the key at App Store Connect → **Users and Access → Integrations → App Store Connect API**.
+
+Export options template: `.github/workflows/ExportOptions-TestFlight.plist` (`method = app-store`, `signingCertificate = Apple Distribution`).
 
 ---
 
@@ -336,8 +396,8 @@ Planned or possible improvements to the CI/CD pipeline:
 - ✅ **Build and archive:** Automated Firebase App Distribution _(completed in Step 2)_
 - ✅ **Build number automation:** Auto-increment build numbers _(completed in Step 2)_
 - ✅ **Release notes generation:** Extract PR info into release notes _(completed in Step 2)_
+- ✅ **TestFlight distribution:** `testflight.yml` builds + uploads on `release/**` (upload needs the App Store Connect API secrets)
 - **UI tests workflow:** Separate job for SpotUITests (longer runtime, separate from unit tests)
-- **TestFlight distribution:** Add TestFlight upload option alongside Firebase
 - **Static analysis:** SwiftLint, SwiftFormat, or similar tools
 - **PR automation:** Danger for additional automated checks and comments
 - **Coverage trending:** Track coverage changes over time
@@ -374,4 +434,4 @@ If the team decides to re-enable Xcode Cloud in the future:
 - ~~Build number automation and release notes generation~~ _(completed: deploy.yml)_
 - Add SwiftLint or SwiftFormat for code style consistency (on roadmap)
 - Configure required status checks in GitHub branch protection (should be enabled for production)
-- Consider adding TestFlight distribution alongside Firebase
+- Add the App Store Connect API secrets (`APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8_BASE64`) so the TestFlight upload step in `testflight.yml` can complete

--- a/docs/engineering/firebase-distribution-setup.md
+++ b/docs/engineering/firebase-distribution-setup.md
@@ -89,9 +89,9 @@ base64 -i GoogleService-Info.plist | pbcopy
 
 ---
 
-### 4. APPLE_CERTIFICATE_BASE64
+### 4. FIREBASE_DEV_CERT
 
-**What it is**: Your Apple Distribution certificate exported as a .p12 file and encoded in base64.
+**What it is**: Your Apple Distribution certificate exported as a **.p12** file and encoded in base64. Despite the `DEV` in the name, this is the **distribution** certificate used for CI signing of the Firebase Ad Hoc build.
 
 **How to get it**:
 
@@ -118,14 +118,14 @@ base64 -i Certificates.p12 | pbcopy
 
 #### Step 3: Add to GitHub Secrets
 
-- Secret name: `APPLE_CERTIFICATE_BASE64`
+- Secret name: `FIREBASE_DEV_CERT`
 - Secret value: Paste from clipboard (should be a long string of letters and numbers)
 
 ---
 
 ### 5. APPLE_CERTIFICATE_PASSWORD
 
-**What it is**: The password you set when exporting the .p12 certificate.
+**What it is**: The password you set when exporting the .p12 certificate. The same password is used to import both the Firebase (`FIREBASE_DEV_CERT`) and TestFlight (`TESTFLIGHT_APPLE_CERT`) `.p12` files, so export both with the same password.
 
 **How to get it**: This is the password you chose in Step 1 above.
 
@@ -134,17 +134,17 @@ base64 -i Certificates.p12 | pbcopy
 
 ---
 
-### 6. PROVISIONING_PROFILE_BASE64
+### 6. FIREBASE_PROVISIONING_PROFILE
 
-**What it is**: Your App Store distribution provisioning profile, encoded in base64.
+**What it is**: Your **Ad Hoc** distribution provisioning profile for `com.edwardwynman.Spot`, encoded in base64. Ad Hoc profiles include your registered test devices, which is what Firebase App Distribution installs to.
 
 **How to get it**:
 
 #### Step 1: Download Provisioning Profile
 
 1. Go to [Apple Developer Portal](https://developer.apple.com/account/resources/profiles/list)
-2. Find your distribution profile for `com.edwardwynman.Spot`
-3. Download it (will be named something like `Spot_Distribution.mobileprovision`)
+2. Find your **Ad Hoc** profile for `com.edwardwynman.Spot`
+3. Download it (will be named something like `Spot_AdHoc.mobileprovision`)
 
 #### Step 2: Convert to Base64
 
@@ -156,14 +156,14 @@ base64 -i Spot_Distribution.mobileprovision | pbcopy
 
 #### Step 3: Add to GitHub Secrets
 
-- Secret name: `PROVISIONING_PROFILE_BASE64`
+- Secret name: `FIREBASE_PROVISIONING_PROFILE`
 - Secret value: Paste from clipboard
 
 ---
 
 ### 7. KEYCHAIN_PASSWORD
 
-**What it is**: A temporary password for the CI keychain (can be any secure string).
+**What it is**: A temporary password for the CI keychain (can be any secure string). This is **not** an Apple Developer password.
 
 **How to get it**: Generate a random password or use a password generator.
 
@@ -196,10 +196,18 @@ Before triggering a build, verify you have:
 - [ ] `FIREBASE_APP_ID` set to `1:415359921164:ios:66b52b0b2c5f0f2eb59229`
 - [ ] `FIREBASE_SERVICE_ACCOUNT_JSON` (full JSON from Firebase)
 - [ ] `GOOGLE_SERVICE_INFO_PLIST_BASE64` (base64-encoded GoogleService-Info.plist)
-- [ ] `APPLE_CERTIFICATE_BASE64` (base64-encoded .p12)
-- [ ] `APPLE_CERTIFICATE_PASSWORD` (your .p12 password)
-- [ ] `PROVISIONING_PROFILE_BASE64` (base64-encoded .mobileprovision)
+- [ ] `FIREBASE_DEV_CERT` (base64-encoded Apple Distribution .p12)
+- [ ] `APPLE_CERTIFICATE_PASSWORD` (your .p12 export password)
+- [ ] `FIREBASE_PROVISIONING_PROFILE` (base64-encoded Ad Hoc .mobileprovision)
 - [ ] `KEYCHAIN_PASSWORD` (any secure random string)
+
+For the TestFlight lane (`testflight.yml`), additionally configure:
+
+- [ ] `TESTFLIGHT_APPLE_CERT` (base64-encoded Apple Distribution .p12)
+- [ ] `TESTFLIGHT_APPLE_PROFILE` (base64-encoded App Store Connect .mobileprovision)
+- [ ] `APP_STORE_CONNECT_API_KEY_ID` (App Store Connect API Key ID) — required for upload
+- [ ] `APP_STORE_CONNECT_API_ISSUER_ID` (Issuer ID / UUID) — required for upload
+- [ ] `APP_STORE_CONNECT_API_KEY_P8_BASE64` (base64 of `AuthKey_XXX.p8`) — required for upload
 
 ---
 
@@ -226,14 +234,14 @@ Once all secrets are configured:
 
 ### "No identity found" error
 
-- Verify `APPLE_CERTIFICATE_BASE64` is correctly encoded
+- Verify `FIREBASE_DEV_CERT` (Firebase lane) or `TESTFLIGHT_APPLE_CERT` (TestFlight lane) is correctly encoded
 - Verify `APPLE_CERTIFICATE_PASSWORD` is correct
 - Ensure the certificate is a **Distribution** certificate (not Development)
 
 ### "No matching provisioning profile found"
 
-- Verify `PROVISIONING_PROFILE_BASE64` is correctly encoded
-- Ensure the profile is for **App Store** distribution
+- Verify `FIREBASE_PROVISIONING_PROFILE` (Firebase / Ad Hoc) or `TESTFLIGHT_APPLE_PROFILE` (TestFlight / App Store Connect) is correctly encoded
+- Ensure the Firebase profile is **Ad Hoc** and the TestFlight profile is **App Store Connect**
 - Ensure the profile includes your Team ID: `55JK72KR4W`
 - Ensure the profile is for Bundle ID: `com.edwardwynman.Spot`
 

--- a/docs/engineering/release-process.md
+++ b/docs/engineering/release-process.md
@@ -23,7 +23,9 @@ Process expectations for iOS app + Supabase backend; exact team checklist may li
 
 ### TestFlight
 
-- Increment build number, archive with distribution cert.
+- Cut a `release/<version>` branch (e.g. `release/1.1.0`) and push it. The `testflight.yml` workflow derives `MARKETING_VERSION` from the branch name and uses the GitHub run number as the build number, then archives with the distribution cert and uploads to App Store Connect / TestFlight. See [ci-cd.md](ci-cd.md).
+- To ship a new version, create a new `release/<version>` branch; pushes to the same branch keep the version and only bump the build number.
+- The upload step requires the App Store Connect API secrets (`APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8_BASE64`).
 - Smoke: auth, feed, map drawer, post happy path, deep link, Pro purchase in sandbox.
 
 ### App Store


### PR DESCRIPTION
## Summary

Implements the three-lane iOS CI/CD pipeline from the PRD using the existing GitHub secret naming (no secrets renamed).

- **PR validation (`ci.yml`)** — unchanged; runs unit tests on simulator, no signing secrets required.
- **Firebase Test ENV (`deploy.yml`, push to `main`)** — migrated to the clean signing setup:
  - Certificate `FIREBASE_DEV_CERT` (base64 `.p12`) imported with `APPLE_CERTIFICATE_PASSWORD` into a temporary CI keychain.
  - Profile `FIREBASE_PROVISIONING_PROFILE` (Ad Hoc) installed by UUID.
  - Export switched to **Ad Hoc** via new `ExportOptions-Firebase.plist`.
  - Build number still only `+1` per push to `main`; uploads the Ad Hoc `.ipa` to Firebase App Distribution.
- **TestFlight (`testflight.yml`, push to `release/**`)** — new lane:
  - `MARKETING_VERSION` derived from the branch name (`release/1.1.0` → `1.1.0`).
  - Build number = `github.run_number` (only the build auto-increments; version never bumps automatically).
  - Signs with `TESTFLIGHT_APPLE_CERT` + `TESTFLIGHT_APPLE_PROFILE`, exports **App Store** `.ipa` via `ExportOptions-TestFlight.plist`, uploads via `xcrun altool`.
  - Does **not** submit to App Store Review.

Temporary keychains/certs/profiles/keys are cleaned up at job end. No certs, profiles, keys, service accounts, or plists are committed.

## Notes / follow-ups

- **App Store Connect API secrets are missing.** The TestFlight upload step fails with a clear message until these are added (names per the PRD's suggestion): `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8_BASE64`. Build/archive/export still run and the `.ipa` is uploaded as a workflow artifact.
- **Secret name discrepancy:** the PRD lists `TESTFLIGHT_PROVISIONING_PROFILE`, but the repo's actual secret is `TESTFLIGHT_APPLE_PROFILE`. Per the "do not rename secrets" rule the workflow references the existing name.

## Test plan

- [ ] PR validation (`ci.yml`) passes on this PR.
- [ ] After merge, push to `main` produces a Firebase App Distribution build (build number +1).
- [ ] Pushing a `release/x.y.z` branch produces an App Store archive; TestFlight upload succeeds once the App Store Connect API secrets are added.

Made with [Cursor](https://cursor.com)