### PR TITLE
Add profile Spots empty states

### DIFF
--- a/Spot/Services/PaywallRouter.swift
+++ b/Spot/Services/PaywallRouter.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// UserInfo key for `Notification.Name.mainTabReselectSame` — `Int` tab index (matches `BottomTabNavigationView` cases: 0 Home … 4 Profile).
+/// Main-tab notification values (matches `BottomTabNavigationView` cases: 0 Home … 4 Profile).
 enum SpotMainTabNotification {
     static let userInfoTabIndexKey = "tabIndex"
+    static let postTabIndex = 2
 }
 
 /// `userInfo` keys for `Notification.Name.homeFeedLocallyRemove`.
@@ -22,6 +23,8 @@ extension Notification.Name {
     static let spotStoreKitProEntitlementReady = Notification.Name("SpotStoreKitProEntitlementReady")
     /// Posted when the user taps the already-selected main tab so that tab can scroll to top / pop to root / reset local chrome.
     static let mainTabReselectSame = Notification.Name("SpotMainTabReselectSame")
+    /// Requests a programmatic switch to the main tab identified by `SpotMainTabNotification.userInfoTabIndexKey`.
+    static let selectMainTab = Notification.Name("SpotSelectMainTab")
     /// Remove feed rows immediately after block/report (see `SpotHomeFeedNotification`).
     static let homeFeedLocallyRemove = Notification.Name("SpotHomeFeedLocallyRemove")
     

--- a/Spot/Views/Components/BottomTabNavigationView.swift
+++ b/Spot/Views/Components/BottomTabNavigationView.swift
@@ -168,6 +168,11 @@ struct BottomTabNavigationView: View {
         .onChange(of: authVM.userId) { _, _ in evaluateFirstRunOnboarding() }
         .onChange(of: authVM.likedSpots) { _, _ in evaluateFirstRunOnboarding() }
         .onChange(of: authVM.bookmarkedSpots) { _, _ in evaluateFirstRunOnboarding() }
+        .onReceive(NotificationCenter.default.publisher(for: .selectMainTab)) { output in
+            guard let tab = output.userInfo?[SpotMainTabNotification.userInfoTabIndexKey] as? Int,
+                  (0...4).contains(tab) else { return }
+            selectTab(tab)
+        }
         .sheet(isPresented: $showTourLocationPrePrompt) {
             LocationPermissionView(
                 authDestination: .signup,

--- a/Spot/Views/Profile/ProfileView.swift
+++ b/Spot/Views/Profile/ProfileView.swift
@@ -416,11 +416,13 @@ struct ProfileView: View {
                                 .transition(.opacity)
                                 .zIndex(1)
                             } else {
-                                if viewModel.spots.isEmpty {
-                                    profileSpotsEmptyState
-                                } else {
-                                    SpotsGridView(spots: viewModel.spots) { tapped in
-                                        selectedSpot = tapped
+                                Group {
+                                    if viewModel.spots.isEmpty {
+                                        profileSpotsEmptyState
+                                    } else {
+                                        SpotsGridView(spots: viewModel.spots) { tapped in
+                                            selectedSpot = tapped
+                                        }
                                     }
                                 }
                                 .zIndex(0)

--- a/Spot/Views/Profile/ProfileView.swift
+++ b/Spot/Views/Profile/ProfileView.swift
@@ -8,6 +8,45 @@
 import SwiftUI
 import MapKit
 
+enum ProfileSpotsEmptyState: Equatable {
+    case ownProfile
+    case otherProfile
+    case privateProfile
+
+    static func resolve(isOwnProfile: Bool, canViewContent: Bool) -> Self {
+        if isOwnProfile {
+            return .ownProfile
+        }
+        return canViewContent ? .otherProfile : .privateProfile
+    }
+
+    var title: String {
+        switch self {
+        case .ownProfile:
+            return "Share your first Spot"
+        case .otherProfile:
+            return "No Spots yet"
+        case .privateProfile:
+            return "This account is private"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .ownProfile:
+            return "Start your collection by sharing a place you love."
+        case .otherProfile:
+            return "They haven't shared any Spots yet."
+        case .privateProfile:
+            return "Follow this user to see the Spots they share."
+        }
+    }
+
+    var showsPostButton: Bool {
+        self == .ownProfile
+    }
+}
+
 struct ProfileView: View {
     var userId: String?
     var fromNavigationPush: Bool = false
@@ -33,6 +72,10 @@ struct ProfileView: View {
     @Environment(\.dismiss) private var dismiss
 
     private let tabs = ["Spots", "Map"]
+
+    private var isOwnProfile: Bool {
+        userId == nil || userId == authVM.userId
+    }
 
     var body: some View {
         let content = profileContent
@@ -373,8 +416,12 @@ struct ProfileView: View {
                                 .transition(.opacity)
                                 .zIndex(1)
                             } else {
-                                SpotsGridView(spots: viewModel.spots) { tapped in
-                                    selectedSpot = tapped
+                                if viewModel.spots.isEmpty {
+                                    profileSpotsEmptyState
+                                } else {
+                                    SpotsGridView(spots: viewModel.spots) { tapped in
+                                        selectedSpot = tapped
+                                    }
                                 }
                                 .zIndex(0)
                             }
@@ -675,6 +722,56 @@ struct ProfileView: View {
             guard (output.userInfo?[SpotMainTabNotification.userInfoTabIndexKey] as? Int) == 4 else { return }
             resetProfileTabToRoot()
         }
+    }
+
+    private var profileSpotsEmptyState: some View {
+        let state = ProfileSpotsEmptyState.resolve(
+            isOwnProfile: isOwnProfile,
+            canViewContent: viewModel.canViewContent
+        )
+
+        return VStack(spacing: 16) {
+            Image(systemName: state == .privateProfile ? "lock.fill" : "mappin.slash")
+                .font(.system(size: 44, weight: .light))
+                .foregroundColor(Constants.Colors.primary.opacity(0.55))
+
+            Text(state.title)
+                .font(FontManager.sectionHeader())
+                .foregroundColor(Constants.Colors.primary)
+
+            Text(state.message)
+                .font(FontManager.primaryText())
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+
+            if state.showsPostButton {
+                Button {
+                    NotificationCenter.default.post(
+                        name: .selectMainTab,
+                        object: nil,
+                        userInfo: [
+                            SpotMainTabNotification.userInfoTabIndexKey:
+                                SpotMainTabNotification.postTabIndex
+                        ]
+                    )
+                } label: {
+                    Text("Post a Spot")
+                        .font(FontManager.buttonText())
+                        .foregroundColor(Constants.Colors.buttonText)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .background(Constants.Colors.primary)
+                        .cornerRadius(20)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .accessibilityIdentifier("profile.postFirstSpotButton")
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 36)
+        .frame(maxWidth: .infinity, minHeight: 240, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("profile.spotsEmptyState")
     }
 
     /// Root Profile tab re-tap: return to the main profile surface (not used when embedded from Home/Map/Search).

--- a/SpotTests/ProfileSpotsEmptyStateTests.swift
+++ b/SpotTests/ProfileSpotsEmptyStateTests.swift
@@ -1,0 +1,47 @@
+//
+//  ProfileSpotsEmptyStateTests.swift
+//  SpotTests
+//
+
+import Testing
+@testable import Spot
+
+struct ProfileSpotsEmptyStateTests {
+
+    @Test func ownProfilePromptsUserToShareFirstSpot() {
+        let state = ProfileSpotsEmptyState.resolve(
+            isOwnProfile: true,
+            canViewContent: true
+        )
+
+        #expect(state == .ownProfile)
+        #expect(state.title == "Share your first Spot")
+        #expect(state.showsPostButton)
+    }
+
+    @Test func emptyPublicProfileDoesNotShowPostingAction() {
+        let state = ProfileSpotsEmptyState.resolve(
+            isOwnProfile: false,
+            canViewContent: true
+        )
+
+        #expect(state == .otherProfile)
+        #expect(state.title == "No Spots yet")
+        #expect(state.showsPostButton == false)
+    }
+
+    @Test func hiddenPrivateProfileExplainsWhySpotsAreUnavailable() {
+        let state = ProfileSpotsEmptyState.resolve(
+            isOwnProfile: false,
+            canViewContent: false
+        )
+
+        #expect(state == .privateProfile)
+        #expect(state.title == "This account is private")
+        #expect(state.showsPostButton == false)
+    }
+
+    @Test func postingActionTargetsPostTab() {
+        #expect(SpotMainTabNotification.postTabIndex == 2)
+    }
+}

--- a/docs/product/profiles-and-social.md
+++ b/docs/product/profiles-and-social.md
@@ -18,6 +18,8 @@ Implementation spread across `Spot/Views/Profile`, `ProfileViewModel`, `ProfileS
 
 A **profile** shows a user’s identity, Spots, collections/bookmarks as implemented, and social actions (follow, etc.).
 
+When a profile has no visible Spots, the Spots area explains the empty state. On the current user's own profile, it also offers a **Post a Spot** action that opens the Post tab. Other users' empty profiles do not show that action, and private profiles explain that following is required to view their Spots.
+
 ### Public vs private
 
 Some profiles or content may be **private** to non-followers or pending requests. Visibility is enforced with **Supabase RLS**; the client reflects “unavailable” or limited UI when appropriate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- Show a clear empty state in the profile Spots area.
- Prompt users viewing their own empty profile to post their first Spot and route the CTA to the Post tab.
- Show non-actionable empty or private-profile messaging when viewing another user.
- Document the profile behavior and cover the state resolver with unit tests.

## Testing
- `git diff --check` passes.
- Verified the new empty-state identifiers, resolver usage, and tab-routing notification are present in production and test sources.
- Xcode/Swift tests were not run because this Linux runner has neither `xcodebuild` nor `swift` installed.

## Checklist

### Code Quality & Testing (Required)
- [x] Added Unit Tests For New Code (80% minimum coverage on changed files)
- [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`) — unavailable on Linux runner
- [x] No breaking API changes (or documented if intentional)
- [ ] Confirmed no new warnings introduced — requires Xcode build
- [x] Code follows existing patterns and style

### Documentation (Required)
- [x] Updated docs (see `docs/operations/documentation-maintenance.md`)
- [x] Updated relevant product docs if user-facing behavior changed
- [x] Updated architecture/engineering docs if service/data layer changed (not applicable)
- [x] Updated diagrams if flows changed significantly (not applicable)

### Data plane (required for auth, posting, storage, or `Spot/Services` changes)
- [x] **No Firebase data plane** — no `FirebaseFirestore`, `FirebaseStorage`, `FirebaseAuth`, `SpotUploader`, or Firestore/Storage callbacks under `Spot/`
- [x] Posting uses **`SpotPublishCoordinator`** / **`SpotSupabaseRepository`** (existing flow unchanged)
- [x] Schema/RLS changes include SQL under **`supabase/migrations/`** (not applicable; no schema changes)
- [ ] `SpotTests` **`DataPlaneGuardTests`** pass (`xcodebuild -scheme SpotTests test`) — unavailable on Linux runner

See [docs/engineering/data-plane.md](docs/engineering/data-plane.md).

---

## Automated Validation

The following checks run automatically on every PR:

✅ **Code Coverage**: Enforces 80% minimum coverage on all changed production files  
✅ **API Stability**: Detects potential breaking changes to public APIs  
✅ **Documentation**: Validates documentation updates for significant changes  
✅ **Unit Tests**: All tests must pass before merge

See validation results in the PR checks above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa3dd-7e17-7ee0-add7-84d14f662a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa3dd-7e17-7ee0-add7-84d14f662a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

