### PR TITLE
Redesign authentication and preserve sessions across reinstalls

### DIFF
--- a/Spot/Models/Logs/AuthCredentialStoreLogs.swift
+++ b/Spot/Models/Logs/AuthCredentialStoreLogs.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum AuthCredentialStoreLogs: SpotLog {
+    case saveFailed
+    case loadFailed
+    case deleteFailed
+
+    var tag: String { "AuthCredentialStore" }
+    var level: LogLevel { .error }
+
+    var message: String {
+        switch self {
+        case .saveFailed: return "Failed to save authentication recovery data"
+        case .loadFailed: return "Failed to load authentication recovery data"
+        case .deleteFailed: return "Failed to delete authentication recovery data"
+        }
+    }
+}

--- a/Spot/Models/Logs/AuthViewModelLogs.swift
+++ b/Spot/Models/Logs/AuthViewModelLogs.swift
@@ -25,6 +25,7 @@ enum AuthViewModelLogs: SpotLog {
     case changeEmailVerifySent
     case emailChangeRequiresReauth
     case changeEmailError
+    case usernameAvailabilityCheckFailed
     case userBlocked
     case userUnblocked
 
@@ -48,6 +49,7 @@ enum AuthViewModelLogs: SpotLog {
         case .changeEmailVerifySent: return .info
         case .emailChangeRequiresReauth: return .debug
         case .changeEmailError: return .error
+        case .usernameAvailabilityCheckFailed: return .error
         case .userBlocked: return .info
         case .userUnblocked: return .info
         }
@@ -71,6 +73,7 @@ enum AuthViewModelLogs: SpotLog {
         case .changeEmailVerifySent: return "Change email verification sent"
         case .emailChangeRequiresReauth: return "Email change requires reauthentication"
         case .changeEmailError: return "Email change error"
+        case .usernameAvailabilityCheckFailed: return "Username availability check failed"
         case .userBlocked: return "User blocked"
         case .userUnblocked: return "User unblocked"
         }

--- a/Spot/Models/Logs/AuthViewModelLogs.swift
+++ b/Spot/Models/Logs/AuthViewModelLogs.swift
@@ -13,6 +13,7 @@ enum AuthViewModelLogs: SpotLog {
     case authStateSignedOut
     case authUserDeletedRemotely
     case signOutFailed
+    case sessionRefreshFailed
     case refreshBlockedUsersFailed
     case refreshUserFlagsFailed
     case proStatusUpdated
@@ -37,6 +38,7 @@ enum AuthViewModelLogs: SpotLog {
         case .authStateSignedOut: return .debug
         case .authUserDeletedRemotely: return .info
         case .signOutFailed: return .error
+        case .sessionRefreshFailed: return .error
         case .refreshBlockedUsersFailed: return .error
         case .refreshUserFlagsFailed: return .error
         case .proStatusUpdated: return .info
@@ -61,6 +63,7 @@ enum AuthViewModelLogs: SpotLog {
         case .authStateSignedOut: return "Auth state changed: no user"
         case .authUserDeletedRemotely: return "Auth user deleted remotely; clearing local session"
         case .signOutFailed: return "Failed to sign out"
+        case .sessionRefreshFailed: return "Failed to refresh expired session"
         case .refreshBlockedUsersFailed: return "Failed to refresh blocked users"
         case .refreshUserFlagsFailed: return "Failed to refresh user flags"
         case .proStatusUpdated: return "Pro status updated"

--- a/Spot/Models/Logs/FreshInstallDetectorLogs.swift
+++ b/Spot/Models/Logs/FreshInstallDetectorLogs.swift
@@ -9,25 +9,22 @@ import Foundation
 
 enum FreshInstallDetectorLogs: SpotLog {
     case reinstallWithKeychainUser
-    case autoSignOutFailed
     case reinstallWithoutKeychainUser
-    case clearedAllCaches
+    case resetInstallScopedCaches
 
     var tag: String { "FreshInstallDetector" }
     var level: LogLevel {
         switch self {
         case .reinstallWithKeychainUser: return .info
-        case .autoSignOutFailed: return .error
         case .reinstallWithoutKeychainUser: return .info
-        case .clearedAllCaches: return .info
+        case .resetInstallScopedCaches: return .info
         }
     }
     var message: String {
         switch self {
-        case .reinstallWithKeychainUser: return "Reinstall detected with keychain user: auto sign out"
-        case .autoSignOutFailed: return "Failed to auto sign out on fresh install"
+        case .reinstallWithKeychainUser: return "Reinstall detected with keychain user: retained local session"
         case .reinstallWithoutKeychainUser: return "Reinstall without keychain user: no action needed"
-        case .clearedAllCaches: return "Cleared all caches and session data"
+        case .resetInstallScopedCaches: return "Reset install-scoped caches without clearing authentication"
         }
     }
 }

--- a/Spot/Services/Auth/AppleSignInNonce.swift
+++ b/Spot/Services/Auth/AppleSignInNonce.swift
@@ -1,0 +1,18 @@
+import CryptoKit
+import Foundation
+import Security
+
+enum AppleSignInNonce {
+    static func make() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess, "Unable to generate a secure Apple sign-in nonce.")
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func sha256(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}

--- a/Spot/Services/Auth/AuthCredentialStores.swift
+++ b/Spot/Services/Auth/AuthCredentialStores.swift
@@ -31,7 +31,7 @@ protocol AuthDataStoring {
     func delete()
 }
 
-/// Stores only an account hint in synchronizable Keychain storage.
+/// Stores only an account hint in device-local Keychain storage.
 /// Passwords, OTPs, Supabase tokens, and Apple identity tokens must never be stored here.
 final class AuthAccountHintStore {
     static let shared = AuthAccountHintStore()
@@ -106,7 +106,7 @@ final class AuthKeychainDataStore: AuthDataStoring {
     static let accountHint = AuthKeychainDataStore(
         service: "com.edwardwynman.Spot.account-hint",
         account: "last-account",
-        synchronizable: true
+        synchronizable: false
     )
     static let verificationRecovery = AuthKeychainDataStore(
         service: "com.edwardwynman.Spot.verification-recovery",
@@ -125,11 +125,26 @@ final class AuthKeychainDataStore: AuthDataStoring {
     }
 
     func save(_ data: Data) {
-        delete()
-        var query = baseQuery
-        query[kSecValueData as String] = data
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        SecItemAdd(query as CFDictionary, nil)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: synchronizable
+            ? kSecAttrAccessibleAfterFirstUnlock
+            : kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, attributes as CFDictionary)
+        guard updateStatus == errSecItemNotFound else {
+            if updateStatus != errSecSuccess {
+                log(.saveFailed, status: updateStatus)
+            }
+            return
+        }
+
+        var addQuery = baseQuery
+        attributes.forEach { addQuery[$0.key] = $0.value }
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess {
+            log(.saveFailed, status: addStatus)
+        }
     }
 
     func load() -> Data? {
@@ -137,14 +152,21 @@ final class AuthKeychainDataStore: AuthDataStoring {
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else {
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            if status != errSecItemNotFound {
+                log(.loadFailed, status: status)
+            }
             return nil
         }
         return result as? Data
     }
 
     func delete() {
-        SecItemDelete(baseQuery as CFDictionary)
+        let status = SecItemDelete(baseQuery as CFDictionary)
+        if status != errSecSuccess, status != errSecItemNotFound {
+            log(.deleteFailed, status: status)
+        }
     }
 
     private var baseQuery: [String: Any] {
@@ -154,5 +176,9 @@ final class AuthKeychainDataStore: AuthDataStoring {
             kSecAttrAccount as String: account,
             kSecAttrSynchronizable as String: synchronizable
         ]
+    }
+
+    private func log(_ event: AuthCredentialStoreLogs, status: OSStatus) {
+        SpotLogger.log(event, details: ["status": status])
     }
 }

--- a/Spot/Services/Auth/AuthCredentialStores.swift
+++ b/Spot/Services/Auth/AuthCredentialStores.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Security
+
+enum AuthAccountProvider: String, Codable, Equatable {
+    case apple
+    case email
+}
+
+struct AuthAccountHint: Codable, Equatable {
+    let email: String?
+    let displayLabel: String
+    let provider: AuthAccountProvider
+    let lastSignedInAt: Date
+
+    var maskedEmail: String? {
+        guard let email, let at = email.firstIndex(of: "@") else { return email }
+        let name = email[..<at]
+        let domain = email[at...]
+        return String(name.prefix(min(2, name.count))) + "••••" + String(domain)
+    }
+}
+
+struct AuthVerificationRecovery: Codable, Equatable {
+    let email: String
+    let startedAt: Date
+}
+
+protocol AuthDataStoring {
+    func save(_ data: Data)
+    func load() -> Data?
+    func delete()
+}
+
+/// Stores only an account hint in synchronizable Keychain storage.
+/// Passwords, OTPs, Supabase tokens, and Apple identity tokens must never be stored here.
+final class AuthAccountHintStore {
+    static let shared = AuthAccountHintStore()
+
+    private let keychain: AuthDataStoring
+
+    init(keychain: AuthDataStoring = AuthKeychainDataStore.accountHint) {
+        self.keychain = keychain
+    }
+
+    func save(_ hint: AuthAccountHint) {
+        guard let data = try? JSONEncoder().encode(hint) else { return }
+        keychain.save(data)
+    }
+
+    func load() -> AuthAccountHint? {
+        guard let data = keychain.load() else { return nil }
+        return try? JSONDecoder().decode(AuthAccountHint.self, from: data)
+    }
+
+    func clear() {
+        keychain.delete()
+    }
+}
+
+/// Persists the minimum state needed to resume signup verification after relaunch.
+/// This item is device-local and expires automatically; the OTP and password are never persisted.
+final class AuthVerificationRecoveryStore {
+    static let shared = AuthVerificationRecoveryStore()
+
+    private let keychain: AuthDataStoring
+    private let lifetime: TimeInterval
+    private let now: () -> Date
+
+    init(
+        keychain: AuthDataStoring = AuthKeychainDataStore.verificationRecovery,
+        lifetime: TimeInterval = 72 * 60 * 60,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.keychain = keychain
+        self.lifetime = lifetime
+        self.now = now
+    }
+
+    func save(email: String) {
+        let normalized = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty,
+              let data = try? JSONEncoder().encode(
+                AuthVerificationRecovery(email: normalized, startedAt: now())
+              )
+        else { return }
+        keychain.save(data)
+    }
+
+    func load() -> AuthVerificationRecovery? {
+        guard let data = keychain.load(),
+              let recovery = try? JSONDecoder().decode(AuthVerificationRecovery.self, from: data)
+        else { return nil }
+        guard now().timeIntervalSince(recovery.startedAt) <= lifetime else {
+            clear()
+            return nil
+        }
+        return recovery
+    }
+
+    func clear() {
+        keychain.delete()
+    }
+}
+
+final class AuthKeychainDataStore: AuthDataStoring {
+    static let accountHint = AuthKeychainDataStore(
+        service: "com.edwardwynman.Spot.account-hint",
+        account: "last-account",
+        synchronizable: true
+    )
+    static let verificationRecovery = AuthKeychainDataStore(
+        service: "com.edwardwynman.Spot.verification-recovery",
+        account: "pending-signup",
+        synchronizable: false
+    )
+
+    private let service: String
+    private let account: String
+    private let synchronizable: Bool
+
+    init(service: String, account: String, synchronizable: Bool) {
+        self.service = service
+        self.account = account
+        self.synchronizable = synchronizable
+    }
+
+    func save(_ data: Data) {
+        delete()
+        var query = baseQuery
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func load() -> Data? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else {
+            return nil
+        }
+        return result as? Data
+    }
+
+    func delete() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: synchronizable
+        ]
+    }
+}

--- a/Spot/Services/Auth/AuthViewModel.swift
+++ b/Spot/Services/Auth/AuthViewModel.swift
@@ -10,6 +10,12 @@ import UIKit
 import Supabase
 import AuthenticationServices
 
+enum UsernameAvailabilityOutcome: Equatable {
+    case available
+    case taken
+    case unavailable
+}
+
 class AuthViewModel: ObservableObject {
     @Published var isAuthenticated: Bool = false
     @Published var isLoading: Bool = true
@@ -36,6 +42,7 @@ class AuthViewModel: ObservableObject {
     private var supabaseAuthTask: Task<Void, Never>?
 
     init() {
+        restoreVerificationRecovery()
         #if DEBUG
         if SpotLaunchConfiguration.uiTestAuthBootstrap == .loggedIn {
             Task { @MainActor in
@@ -90,13 +97,14 @@ class AuthViewModel: ObservableObject {
         switch event {
         case .initialSession, .signedIn, .tokenRefreshed, .userUpdated:
             guard let session else {
-                clearSignedOutState()
+                clearSignedOutState(preservePendingVerification: awaitingEmailVerification)
                 return
             }
             if session.isExpired {
                 return
             }
             let user = session.user
+            AuthVerificationRecoveryStore.shared.clear()
             SpotLogger.log(AuthViewModelLogs.authStateSignedIn, details: ["uid": user.id.uuidString])
 
             let isNewLogin = previousUserId == nil && userId == nil
@@ -107,6 +115,7 @@ class AuthViewModel: ObservableObject {
             isEmailVerified = user.emailConfirmedAt != nil
             awaitingEmailVerification = false
             verificationEmailMaskSource = user.email ?? verificationEmailMaskSource
+            saveAccountHint(for: user)
 
             AnalyticsService.shared.setUserId(user.id.uuidString)
 
@@ -142,16 +151,18 @@ class AuthViewModel: ObservableObject {
     }
 
     @MainActor
-    private func clearSignedOutState() {
+    private func clearSignedOutState(preservePendingVerification: Bool = false) {
         AnalyticsService.shared.setUserId(nil)
         SpotAuthBridge.setSessionUser(id: nil, email: nil)
         userId = nil
         isAuthenticated = false
         isLoading = false
         isEmailVerified = false
-        awaitingEmailVerification = false
-        emailResendAvailableAt = nil
-        verificationEmailMaskSource = ""
+        if !preservePendingVerification {
+            awaitingEmailVerification = false
+            emailResendAvailableAt = nil
+            verificationEmailMaskSource = ""
+        }
         likedSpots = []
         bookmarkedSpots = []
         blockedUsers = []
@@ -162,6 +173,35 @@ class AuthViewModel: ObservableObject {
         currentUserUsername = nil
         previousUserId = nil
         PreAuthTermsAgreementStore.shared.reset()
+    }
+
+    private func restoreVerificationRecovery() {
+        guard let recovery = AuthVerificationRecoveryStore.shared.load() else { return }
+        pendingVerificationEmail = recovery.email
+        verificationEmailMaskSource = recovery.email
+        awaitingEmailVerification = true
+    }
+
+    private func saveAccountHint(for user: User) {
+        let provider: AuthAccountProvider =
+            user.appMetadata["provider"]?.stringValue?.lowercased() == "apple" ? .apple : .email
+        let username = user.userMetadata["username"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let email = user.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let displayLabel: String
+        if let username, !username.isEmpty {
+            displayLabel = "@\(username)"
+        } else {
+            displayLabel = email?.split(separator: "@").first.map(String.init) ?? "Your Spot account"
+        }
+        AuthAccountHintStore.shared.save(
+            AuthAccountHint(
+                email: email,
+                displayLabel: displayLabel,
+                provider: provider,
+                lastSignedInAt: Date()
+            )
+        )
     }
 
     /// Feed, deep links, and privacy cache — call after sign-out or account deletion.
@@ -224,10 +264,12 @@ class AuthViewModel: ObservableObject {
     @MainActor func signOut() {
         Task {
             do {
-                try await supabase.auth.signOut()
+                try await supabase.auth.signOut(scope: .local)
             } catch {
                 SpotLogger.log(AuthViewModelLogs.signOutFailed, details: ["error": error.localizedDescription])
             }
+            TokenService.shared.clearTokens()
+            AuthVerificationRecoveryStore.shared.clear()
             await teardownSessionCaches()
             await MainActor.run {
                 self.clearSignedOutState()
@@ -533,6 +575,7 @@ class AuthViewModel: ObservableObject {
         verificationEmailMaskSource = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         pendingAvatarAfterVerification = avatar
         emailResendAvailableAt = nil
+        AuthVerificationRecoveryStore.shared.save(email: email)
     }
 
     func clearEmailVerificationPending() {
@@ -540,6 +583,7 @@ class AuthViewModel: ObservableObject {
         pendingVerificationEmail = nil
         pendingAvatarAfterVerification = nil
         emailResendAvailableAt = nil
+        AuthVerificationRecoveryStore.shared.clear()
     }
 
     /// Verifies the 6-digit code from the signup email, establishes the session, uploads pending avatar, syncs profile.
@@ -676,17 +720,25 @@ class AuthViewModel: ObservableObject {
     }
 
     // MARK: - Username Availability
-    func isUsernameAvailable(_ username: String) async -> Bool {
+    func usernameAvailability(_ username: String) async -> UsernameAvailabilityOutcome {
         struct Params: Encodable { let p_username: String }
         do {
             let available: Bool = try await supabase
                 .rpc("is_username_available", params: Params(p_username: username))
                 .execute()
                 .value
-            return available
+            return available ? .available : .taken
         } catch {
-            return false
+            SpotLogger.log(
+                AuthViewModelLogs.usernameAvailabilityCheckFailed,
+                details: ["error": error.localizedDescription]
+            )
+            return .unavailable
         }
+    }
+
+    func isUsernameAvailable(_ username: String) async -> Bool {
+        await usernameAvailability(username) == .available
     }
 
     // MARK: - Account Deletion

--- a/Spot/Services/Auth/AuthViewModel.swift
+++ b/Spot/Services/Auth/AuthViewModel.swift
@@ -40,6 +40,7 @@ class AuthViewModel: ObservableObject {
     @Published var currentUserUsername: String?
 
     private var supabaseAuthTask: Task<Void, Never>?
+    private var sessionRefreshTask: Task<Void, Never>?
 
     init() {
         restoreVerificationRecovery()
@@ -55,6 +56,7 @@ class AuthViewModel: ObservableObject {
 
     deinit {
         supabaseAuthTask?.cancel()
+        sessionRefreshTask?.cancel()
     }
 
     private var previousUserId: String?
@@ -101,8 +103,11 @@ class AuthViewModel: ObservableObject {
                 return
             }
             if session.isExpired {
+                refreshExpiredSessionIfNeeded()
                 return
             }
+            sessionRefreshTask?.cancel()
+            sessionRefreshTask = nil
             let user = session.user
             AuthVerificationRecoveryStore.shared.clear()
             SpotLogger.log(AuthViewModelLogs.authStateSignedIn, details: ["uid": user.id.uuidString])
@@ -142,6 +147,7 @@ class AuthViewModel: ObservableObject {
 
         case .userDeleted:
             SpotLogger.log(AuthViewModelLogs.authUserDeletedRemotely)
+            AuthAccountHintStore.shared.clear()
             clearSignedOutState()
             Task { await teardownSessionCaches() }
 
@@ -180,6 +186,29 @@ class AuthViewModel: ObservableObject {
         pendingVerificationEmail = recovery.email
         verificationEmailMaskSource = recovery.email
         awaitingEmailVerification = true
+    }
+
+    @MainActor
+    private func refreshExpiredSessionIfNeeded() {
+        guard sessionRefreshTask == nil else { return }
+        isLoading = true
+        sessionRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.sessionRefreshTask = nil }
+            do {
+                _ = try await supabase.auth.refreshSession()
+            } catch {
+                SpotLogger.log(
+                    AuthViewModelLogs.sessionRefreshFailed,
+                    details: ["error": error.localizedDescription]
+                )
+                TokenService.shared.clearTokens()
+                await self.teardownSessionCaches()
+                self.clearSignedOutState(
+                    preservePendingVerification: self.awaitingEmailVerification
+                )
+            }
+        }
     }
 
     private func saveAccountHint(for user: User) {
@@ -230,11 +259,12 @@ class AuthViewModel: ObservableObject {
 
     /// Completes native Apple auth by exchanging the Apple identity token with Supabase.
     /// Optionally persists the full name into auth metadata when Apple provides it (first consent only).
-    func signInWithApple(idToken: String, fullName: PersonNameComponents?) async throws {
+    func signInWithApple(idToken: String, nonce: String, fullName: PersonNameComponents?) async throws {
         _ = try await supabase.auth.signInWithIdToken(
             credentials: .init(
                 provider: .apple,
-                idToken: idToken
+                idToken: idToken,
+                nonce: nonce
             )
         )
 
@@ -762,9 +792,17 @@ class AuthViewModel: ObservableObject {
         }
     }
 
-    func deleteAccount(appleIDToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func deleteAccount(
+        appleIDToken: String,
+        nonce: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         runAccountDeletion(completion: completion) { done in
-            AuthService.shared.deleteAccount(appleIDToken: appleIDToken, completion: done)
+            AuthService.shared.deleteAccount(
+                appleIDToken: appleIDToken,
+                nonce: nonce,
+                completion: done
+            )
         }
     }
 
@@ -779,6 +817,7 @@ class AuthViewModel: ObservableObject {
                     defer { self.accountDeletionInProgress = false }
                     switch result {
                     case .success:
+                        AuthAccountHintStore.shared.clear()
                         self.clearSignedOutState()
                         await self.teardownSessionCaches()
                         completion(.success(()))

--- a/Spot/Services/Auth/AuthViewModel.swift
+++ b/Spot/Services/Auth/AuthViewModel.swift
@@ -120,7 +120,7 @@ class AuthViewModel: ObservableObject {
             isEmailVerified = user.emailConfirmedAt != nil
             awaitingEmailVerification = false
             verificationEmailMaskSource = user.email ?? verificationEmailMaskSource
-            saveAccountHint(for: user)
+            saveAccountHint(for: session)
 
             AnalyticsService.shared.setUserId(user.id.uuidString)
 
@@ -211,7 +211,8 @@ class AuthViewModel: ObservableObject {
         }
     }
 
-    private func saveAccountHint(for user: User) {
+    private func saveAccountHint(for session: Session) {
+        let user = session.user
         let provider: AuthAccountProvider =
             user.appMetadata["provider"]?.stringValue?.lowercased() == "apple" ? .apple : .email
         let username = user.userMetadata["username"]?.stringValue?

--- a/Spot/Services/AuthService.swift
+++ b/Spot/Services/AuthService.swift
@@ -171,39 +171,20 @@ class AuthService {
         let cleanIdentifier = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
         Task {
             do {
-                let emailToUse: String
-                if cleanIdentifier.contains("@") {
-                    emailToUse = AuthInputNormalizer.normalizeEmailLegacy(cleanIdentifier)
-                } else {
-                    guard let resolved = try await resolveEmail(forUsername: cleanIdentifier) else {
-                        throw NSError(
-                            domain: "AuthService",
-                            code: 404,
-                            userInfo: [NSLocalizedDescriptionKey: "No account found for that username."]
-                        )
-                    }
-                    emailToUse = resolved
+                guard cleanIdentifier.contains("@") else {
+                    throw NSError(
+                        domain: "AuthService",
+                        code: 400,
+                        userInfo: [NSLocalizedDescriptionKey: "Enter the email address for your account."]
+                    )
                 }
+                let emailToUse = AuthInputNormalizer.normalizeEmailLegacy(cleanIdentifier)
                 _ = try await supabase.auth.signIn(email: emailToUse, password: password)
                 await MainActor.run { completion(.success(())) }
             } catch {
                 await MainActor.run { completion(.failure(error)) }
             }
         }
-    }
-
-    private func resolveEmail(forUsername username: String) async throws -> String? {
-        let normalized = AuthInputNormalizer.normalizeUsernameLowerLegacy(username)
-        guard !normalized.isEmpty else { return nil }
-        struct Params: Encodable { let p_username: String }
-        let email: String? = try await supabase
-            .rpc("resolve_login_email", params: Params(p_username: normalized))
-            .execute()
-            .value
-        if let email, !email.isEmpty {
-            return AuthInputNormalizer.normalizeEmailLegacy(email)
-        }
-        return nil
     }
 
     // MARK: - Reauthentication / Account management (callback style for existing VM)
@@ -265,10 +246,14 @@ class AuthService {
         }
     }
 
-    func deleteAccount(appleIDToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func deleteAccount(
+        appleIDToken: String,
+        nonce: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         Task {
             do {
-                try await reauthenticate(withAppleIDToken: appleIDToken)
+                try await reauthenticate(withAppleIDToken: appleIDToken, nonce: nonce)
                 try await performAccountDeletionAfterReauth(reauthMethod: "apple")
                 await MainActor.run { completion(.success(())) }
             } catch {
@@ -277,13 +262,15 @@ class AuthService {
         }
     }
 
-    private func reauthenticate(withAppleIDToken idToken: String) async throws {
+    private func reauthenticate(withAppleIDToken idToken: String, nonce: String) async throws {
         let userBefore = try await supabase.auth.user()
         _ = try await supabase.auth.signInWithIdToken(
-            credentials: .init(provider: .apple, idToken: idToken)
+            credentials: .init(provider: .apple, idToken: idToken, nonce: nonce)
         )
         let userAfter = try await supabase.auth.user()
         guard userAfter.id == userBefore.id else {
+            try? await supabase.auth.signOut(scope: .local)
+            AuthAccountHintStore.shared.clear()
             throw NSError(
                 domain: "AuthService",
                 code: -2,

--- a/Spot/Services/AuthService.swift
+++ b/Spot/Services/AuthService.swift
@@ -84,7 +84,7 @@ class AuthService {
     // MARK: - Sign Out
 
     func signOut() async throws {
-        try await supabase.auth.signOut()
+        try await supabase.auth.signOut(scope: .local)
     }
 
     // MARK: - Legacy/Callback API (to satisfy existing callers)
@@ -114,7 +114,7 @@ class AuthService {
                 let exists = !rows.isEmpty
                 if !exists {
                     SpotLogger.log(AuthServiceLogs.missingUserProfileRow, details: ["userId": uid])
-                    try? await supabase.auth.signOut()
+                    try? await supabase.auth.signOut(scope: .local)
                 }
                 completion(exists)
             } catch {

--- a/Spot/Utils/FreshInstallDetector.swift
+++ b/Spot/Utils/FreshInstallDetector.swift
@@ -12,8 +12,9 @@ class FreshInstallDetector {
     static let shared = FreshInstallDetector()
     private init() {}
 
-    /// Detects if this is a fresh install and clears a persisted Supabase session.
-    /// Returns true if a session was cleared due to fresh install.
+    /// Detects a first launch after installation while preserving any valid
+    /// device-local Supabase session that survived in Keychain.
+    /// Returns true when a new installation was detected.
     @MainActor func handleFreshInstall() async -> Bool {
         let userDefaults = UserDefaults.standard
         let isFirstRun = !userDefaults.bool(forKey: Constants.UserDefaultsKeys.firstRun)
@@ -21,19 +22,15 @@ class FreshInstallDetector {
         if isFirstRun {
             userDefaults.set(true, forKey: Constants.UserDefaultsKeys.firstRun)
             userDefaults.set(true, forKey: Constants.UserDefaultsKeys.promptPermsOnNextLogin)
+            resetInstallScopedCaches()
 
             if (try? await supabase.auth.session) != nil {
                 SpotLogger.log(FreshInstallDetectorLogs.reinstallWithKeychainUser)
                 Task { @MainActor in
-                    AnalyticsService.shared.trackAuthEvent(Constants.Analytics.authReinstall, parameters: ["had_keychain_user": true, "action": "auto_sign_out"])
-                }
-
-                do {
-                    try await supabase.auth.signOut()
-                    clearAllCaches()
-                    return true
-                } catch {
-                    SpotLogger.log(FreshInstallDetectorLogs.autoSignOutFailed, details: ["error": error.localizedDescription])
+                    AnalyticsService.shared.trackAuthEvent(
+                        Constants.Analytics.authReinstall,
+                        parameters: ["had_keychain_user": true, "action": "retained"]
+                    )
                 }
             } else {
                 SpotLogger.log(FreshInstallDetectorLogs.reinstallWithoutKeychainUser)
@@ -41,6 +38,7 @@ class FreshInstallDetector {
                     AnalyticsService.shared.trackAuthEvent(Constants.Analytics.authReinstall, parameters: ["had_keychain_user": false, "action": "none"])
                 }
             }
+            return true
         }
 
         return false
@@ -56,7 +54,7 @@ class FreshInstallDetector {
         return shouldPrompt
     }
 
-    @MainActor private func clearAllCaches() {
+    @MainActor private func resetInstallScopedCaches() {
         FeedRepository.shared.reset()
         DeepLinkState.shared.clearUserSession()
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.notificationsRequested)
@@ -64,6 +62,6 @@ class FreshInstallDetector {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.lastKnownLocationStatus)
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.lastKnownNotificationStatus)
 
-        SpotLogger.log(FreshInstallDetectorLogs.clearedAllCaches)
+        SpotLogger.log(FreshInstallDetectorLogs.resetInstallScopedCaches)
     }
 }

--- a/Spot/Views/Auth/AuthUIComponents.swift
+++ b/Spot/Views/Auth/AuthUIComponents.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct AuthWordmark: View {
+    var body: some View {
+        Text("SPOT")
+            .font(FontManager.logoTitle())
+            .tracking(5)
+            .foregroundColor(Constants.Colors.primary)
+            .accessibilityLabel("Spot")
+    }
+}
+
+struct AuthScreenHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 32, weight: .bold, design: .serif))
+                .foregroundColor(Constants.Colors.primary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(subtitle)
+                .font(.callout)
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct AuthPrimaryButton: View {
+    let title: String
+    var isLoading = false
+    var isEnabled = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                if isLoading {
+                    ProgressView()
+                        .tint(Constants.Colors.buttonText)
+                }
+                Text(title)
+                    .font(.callout.weight(.semibold))
+            }
+            .foregroundColor(Constants.Colors.buttonText)
+            .frame(maxWidth: .infinity)
+            .frame(height: 54)
+            .background(Constants.Colors.primary)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled || isLoading)
+        .opacity(isEnabled ? 1 : 0.45)
+    }
+}
+
+struct AuthSecondaryButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.callout.weight(.semibold))
+                .foregroundColor(Constants.Colors.primary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(Constants.Colors.welcomeSurface)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Constants.Colors.primary.opacity(0.35), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct AuthDivider: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            Rectangle()
+                .fill(Constants.Colors.welcomeLine.opacity(0.55))
+                .frame(height: 1)
+            Text("or")
+                .font(.footnote)
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+            Rectangle()
+                .fill(Constants.Colors.welcomeLine.opacity(0.55))
+                .frame(height: 1)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+struct AuthLegalFooter: View {
+    var body: some View {
+        (
+            Text("By continuing, you agree to Spot’s ")
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+            + Text("[Terms of Use](\(Constants.Legal.termsURLString))")
+                .foregroundColor(Constants.Colors.primary)
+            + Text(" and acknowledge our ")
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+            + Text("[Privacy Policy](\(Constants.Legal.privacyURLString)).")
+                .foregroundColor(Constants.Colors.primary)
+        )
+        .font(.caption2)
+        .multilineTextAlignment(.center)
+        .tint(Constants.Colors.primary)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview("Auth controls") {
+    VStack(spacing: 16) {
+        AuthWordmark()
+        AuthScreenHeader(title: "Welcome back", subtitle: "Glad to see you again.")
+        AuthPrimaryButton(title: "Continue", action: {})
+        AuthSecondaryButton(title: "Use another account", action: {})
+        AuthDivider()
+        AuthLegalFooter()
+    }
+    .padding(28)
+    .background(Constants.Colors.background)
+}

--- a/Spot/Views/Auth/ConfirmEmailView.swift
+++ b/Spot/Views/Auth/ConfirmEmailView.swift
@@ -11,7 +11,7 @@ struct ConfirmEmailView: View {
     @State private var showToast: String?
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 20) {
             HStack {
                 Button {
                     authVM.clearEmailVerificationPending()
@@ -29,15 +29,26 @@ struct ConfirmEmailView: View {
             .padding(.horizontal, 16)
             .padding(.top, 8)
 
-            Text("Enter verification code")
-                .font(FontManager.sectionHeader())
-                .foregroundColor(Constants.Colors.primary)
+            AuthWordmark()
+                .padding(.top, 4)
 
-            Text("We sent a 6-digit code to \(authVM.maskedEmail). Enter it below to confirm your account.")
-                .font(FontManager.primaryText())
-                .foregroundColor(.gray)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
+            AuthScreenHeader(
+                title: "Check your email",
+                subtitle: "We sent a 6-digit code to \(authVM.maskedEmail)."
+            )
+            .padding(.horizontal, 28)
+
+            Label(
+                "You’ll only need this code when creating your account.",
+                systemImage: "envelope.badge"
+            )
+            .font(.footnote)
+            .foregroundColor(Constants.Colors.welcomeMutedText)
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Constants.Colors.accent.opacity(0.55))
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.horizontal, 28)
 
             HStack(spacing: 8) {
                 ForEach(0..<6, id: \.self) { index in
@@ -65,8 +76,8 @@ struct ConfirmEmailView: View {
                     .foregroundColor(Constants.Colors.primary)
                     .tint(Constants.Colors.primary)
                     .frame(width: 44, height: 52)
-                    .background(Constants.Colors.background)
-                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(Constants.Colors.primary, lineWidth: 1))
+                    .background(Constants.Colors.welcomeSurface)
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(Constants.Colors.primary.opacity(0.25), lineWidth: 1))
                     .focused($focusedIndex, equals: index)
                     .onChange(of: otpDigits[index]) { oldValue, newValue in
                         if newValue.isEmpty && !oldValue.isEmpty && index > 0 {
@@ -76,6 +87,7 @@ struct ConfirmEmailView: View {
                 }
             }
             .padding(.top, 8)
+            .accessibilityIdentifier("auth.confirmEmail.otp")
 
             if let errorMessage {
                 Text(errorMessage)
@@ -94,12 +106,13 @@ struct ConfirmEmailView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Constants.Colors.primary)
-                    .cornerRadius(20)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(PlainButtonStyle())
             .disabled(isVerifying || otpCode.count != 6)
             .padding(.horizontal, 32)
             .padding(.top, 8)
+            .accessibilityIdentifier("auth.confirmEmail.verifyButton")
 
             TimelineView(.periodic(from: .now, by: 1)) { _ in
                 Button {
@@ -117,12 +130,28 @@ struct ConfirmEmailView: View {
                 }
                 .disabled(!authVM.canResendVerification() || isResending)
                 .buttonStyle(PlainButtonStyle())
+                .accessibilityIdentifier("auth.confirmEmail.resendButton")
             }
+
+            AuthDivider()
+                .padding(.horizontal, 32)
+
+            Button {
+                authVM.clearEmailVerificationPending()
+                dismiss()
+            } label: {
+                Text("Use a different email")
+                    .font(.callout.weight(.medium))
+                    .foregroundColor(Constants.Colors.primary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("auth.confirmEmail.useDifferentEmail")
 
             Spacer()
         }
-        .background(Color(hex: "F5F3EF").ignoresSafeArea())
+        .background(Constants.Colors.background.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
+        .accessibilityIdentifier("auth.confirmEmail.screen")
         .onAppear { focusedIndex = 0 }
         .overlay(alignment: .top) {
             if let msg = showToast {

--- a/Spot/Views/Auth/LoginView.swift
+++ b/Spot/Views/Auth/LoginView.swift
@@ -29,6 +29,9 @@ struct LoginView: View {
         if text.contains("email not confirmed") || text.contains("email_not_confirmed") {
             return "Verify your email to finish creating your account."
         }
+        if text.contains("enter the email") {
+            return "Enter the email address for your account."
+        }
         if text.contains("username") || text.contains("no account found") {
             return "No account found for that username."
         }

--- a/Spot/Views/Auth/LoginView.swift
+++ b/Spot/Views/Auth/LoginView.swift
@@ -9,22 +9,30 @@ import SwiftUI
 import Supabase
 
 struct LoginView: View {
-    @State private var loginIdentifier = ""
+    @State private var loginIdentifier: String
     @State private var password = ""
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var resetMessage: String?
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject private var authVM: AuthViewModel
+
+    init(initialIdentifier: String = "") {
+        _loginIdentifier = State(initialValue: initialIdentifier)
+    }
 
     private func handleLoginError(_ error: Error) -> String {
         let text = error.localizedDescription.lowercased()
         if text.contains("network") || text.contains("internet") {
             return "Network error. Please check your connection."
         }
+        if text.contains("email not confirmed") || text.contains("email_not_confirmed") {
+            return "Verify your email to finish creating your account."
+        }
         if text.contains("username") || text.contains("no account found") {
             return "No account found for that username."
         }
-        return "Incorrect email/username or password."
+        return "Incorrect email or password."
     }
 
     var body: some View {
@@ -32,7 +40,8 @@ struct LoginView: View {
             ZStack {
                 Constants.Colors.background.ignoresSafeArea()
 
-                VStack(spacing: 24) {
+                ScrollView {
+                VStack(spacing: 22) {
                     // Custom Back Button
                     HStack {
                         CustomBackButton {
@@ -43,26 +52,35 @@ struct LoginView: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
 
-                    Text("Log In")
-                        .font(FontManager.sectionHeader())
-                        .foregroundColor(Constants.Colors.primary)
-                        .padding(.top, 40)
+                    AuthWordmark()
+                        .padding(.top, 4)
+
+                    AuthScreenHeader(
+                        title: "Log in",
+                        subtitle: "Welcome back! Glad to see you again."
+                    )
+                    .padding(.horizontal, 28)
 
                     // Fields with labels (match Settings style)
                     VStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Email or Username")
+                            Text("Email")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
-                            CustomTextField(placeholder: "Email or Username", text: $loginIdentifier)
+                            CustomTextField(placeholder: "you@example.com", text: $loginIdentifier, systemImage: "envelope")
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
+                                .keyboardType(.emailAddress)
+                                .textContentType(.emailAddress)
+                                .accessibilityIdentifier("auth.login.emailField")
                         }
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Password")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
-                            CustomSecureField(placeholder: "Password", text: $password)
+                            CustomSecureField(placeholder: "Enter your password", text: $password, systemImage: "lock")
+                                .textContentType(.password)
+                                .accessibilityIdentifier("auth.login.passwordField")
                         }
                     }
                     .padding(.horizontal, 32)
@@ -81,7 +99,7 @@ struct LoginView: View {
                             Task {
                                 do {
                                     try await AuthService.shared.resetPassword(email: trimmed)
-                                    SpotLogger.log(LoginViewLogs.passwordResetRequested, details: ["email": trimmed])
+                                    SpotLogger.log(LoginViewLogs.passwordResetRequested)
                                     await MainActor.run { resetMessage = "Password reset link sent. Check your email." }
                                 } catch {
                                     SpotLogger.log(LoginViewLogs.passwordResetError, details: ["error": error.localizedDescription])
@@ -89,7 +107,7 @@ struct LoginView: View {
                                 }
                             }
                         }) {
-                            Text("Forgot Password?")
+                            Text("Forgot password?")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
                         }
@@ -131,22 +149,31 @@ struct LoginView: View {
                                 await MainActor.run {
                                     isLoading = false
                                     errorMessage = handleLoginError(error)
+                                    let raw = error.localizedDescription.lowercased()
+                                    if raw.contains("email not confirmed") || raw.contains("email_not_confirmed") {
+                                        authVM.beginEmailVerificationPending(email: loginIdentifier, avatar: nil)
+                                        dismiss()
+                                    }
                                     SpotLogger.log(LoginViewLogs.loginFailed, details: ["error": error.localizedDescription])
                                 }
                             }
                         }
                     }) {
-                        Text(isLoading ? "Logging In..." : "Login")
+                        Text(isLoading ? "Logging in..." : "Log in")
                             .font(FontManager.buttonText())
                             .foregroundColor(Constants.Colors.buttonText)
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(Constants.Colors.primary)
-                            .cornerRadius(20)
+                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
                     .buttonStyle(PlainButtonStyle())
                     .disabled(isLoading)
                     .padding(.horizontal, 32)
+                    .accessibilityIdentifier("auth.login.submitButton")
+
+                    AuthDivider()
+                        .padding(.horizontal, 32)
 
                     ThemedAppleSignInButton(
                         onSuccess: {
@@ -156,7 +183,8 @@ struct LoginView: View {
                         onError: { message in
                             errorMessage = message
                             SpotLogger.log(LoginViewLogs.loginFailed, details: ["error": message])
-                        }
+                        },
+                        height: 48
                     )
                     .padding(.horizontal, 32)
 
@@ -186,18 +214,25 @@ struct LoginView: View {
                             .foregroundColor(Constants.Colors.primary)
 
                         NavigationLink(destination: SignupView()) {
-                            Text("Sign Up")
+                            Text("Create an account")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
                                 .buttonStyle(PlainButtonStyle())
                         }
                     }
 
-                    Spacer()
+                    Spacer(minLength: 24)
+                }
                 }
             }
         }
         .navigationBarBackButtonHidden(true)
+        .accessibilityIdentifier("auth.login.screen")
+        .onAppear {
+            if loginIdentifier.isEmpty {
+                loginIdentifier = AuthAccountHintStore.shared.load()?.email ?? ""
+            }
+        }
     }
 }
 

--- a/Spot/Views/Auth/SignupView.swift
+++ b/Spot/Views/Auth/SignupView.swift
@@ -312,7 +312,7 @@ struct SignupView: View {
                         )
                         self.isLoading = false
                         self.showToast(
-                            "An account with this email already exists. Try logging in or resetting your password.",
+                            "We couldn’t create this account. Try logging in or resetting your password.",
                             isError: true
                         )
                     }

--- a/Spot/Views/Auth/SignupView.swift
+++ b/Spot/Views/Auth/SignupView.swift
@@ -13,14 +13,12 @@ struct SignupView: View {
     @State private var email = ""
     @State private var username = ""
     @State private var password = ""
-    @State private var confirmPassword = ""
-    @State private var agreedToTerms = false
     @State private var isPrivate = false
 
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var passwordError: String?
-    @State private var confirmPasswordError: String?
+    @State private var usernameAvailability: UsernameAvailabilityOutcome?
     @State private var toastMessage: String?
     @State private var toastIsError: Bool = true
     @State private var showLogin = false
@@ -32,7 +30,8 @@ struct SignupView: View {
             ZStack {
                 Constants.Colors.background.ignoresSafeArea()
 
-                VStack(spacing: 24) {
+                ScrollView {
+                VStack(spacing: 22) {
                     // Custom Back Button
                     HStack {
                         CustomBackButton {
@@ -43,47 +42,53 @@ struct SignupView: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
 
-                    Text("Sign Up")
-                        .font(FontManager.sectionHeader())
-                        .foregroundColor(Constants.Colors.primary)
-                        .padding(.top, 40)
+                    AuthWordmark()
+                        .padding(.top, 4)
+
+                    AuthScreenHeader(
+                        title: "Create your\nSpot account",
+                        subtitle: "Let’s get you set up."
+                    )
+                    .padding(.horizontal, 28)
 
                     VStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Email")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
-                            CustomTextField(placeholder: "Email", text: $email)
+                            CustomTextField(placeholder: "you@example.com", text: $email, systemImage: "envelope")
+                                .keyboardType(.emailAddress)
+                                .textContentType(.emailAddress)
+                                .accessibilityIdentifier("auth.signup.emailField")
                         }
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Username")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
-                            CustomTextField(placeholder: "Username", text: $username)
+                            CustomTextField(placeholder: "your.username", text: $username, systemImage: "person")
+                                .textContentType(.username)
+                                .accessibilityIdentifier("auth.signup.usernameField")
+                                .task(id: username) {
+                                    await checkUsernameAvailability()
+                                }
+                            if let usernameAvailability {
+                                usernameAvailabilityMessage(usernameAvailability)
+                            }
                         }
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Password")
                                 .font(FontManager.primaryText())
                                 .foregroundColor(Constants.Colors.primary)
-                            CustomSecureField(placeholder: "Password", text: $password)
+                            CustomSecureField(placeholder: "Create a password", text: $password, systemImage: "lock")
+                                .textContentType(.newPassword)
+                                .accessibilityIdentifier("auth.signup.passwordField")
                             if let passwordError {
                                 Text(passwordError)
                                     .font(.system(size: 12))
                                     .foregroundColor(.red)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
-                        }
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Confirm Password")
-                                .font(FontManager.primaryText())
-                                .foregroundColor(Constants.Colors.primary)
-                            CustomSecureField(placeholder: "Confirm password", text: $confirmPassword)
-                            if let confirmPasswordError {
-                                Text(confirmPasswordError)
-                                    .font(.system(size: 12))
-                                    .foregroundColor(.red)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                            passwordRequirements
                         }
                         HStack {
                             Button(action: { isPrivate.toggle() }) {
@@ -100,51 +105,8 @@ struct SignupView: View {
                     }
                     .padding(.horizontal, 32)
 
-                    HStack(alignment: .center, spacing: 6) {
-                        Button(action: {
-                            agreedToTerms.toggle()
-                        }) {
-                            Image(systemName: agreedToTerms ? "checkmark.square.fill" : "square")
-                                .foregroundColor(Constants.Colors.primary)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-
-                        Text("I agree to the ")
-                            .font(FontManager.primaryText())
-                            .foregroundColor(Constants.Colors.primary)
-
-                        Button(action: { UIApplication.shared.open(Constants.Legal.termsURL) }) {
-                            Text("Terms & Conditions")
-                                .font(FontManager.primaryText())
-                                .fontWeight(.semibold)
-                                .foregroundColor(Constants.Colors.primary)
-                                .underline()
-                        }
-                        .buttonStyle(PlainButtonStyle())
-
-                        Text("and")
-                            .font(FontManager.primaryText())
-                            .foregroundColor(Constants.Colors.primary)
-
-                        Button(action: { UIApplication.shared.open(Constants.Legal.privacyURL) }) {
-                            Text("Privacy Policy")
-                                .font(FontManager.primaryText())
-                                .fontWeight(.semibold)
-                                .foregroundColor(Constants.Colors.primary)
-                                .underline()
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 32)
-
                     Button(action: {
                         passwordError = nil
-                        confirmPasswordError = nil
-                        guard agreedToTerms else {
-                            showToast("Please agree to the Terms of Service.", isError: true)
-                            return
-                        }
 
                         guard !email.isEmpty, !username.isEmpty, !password.isEmpty else {
                             showToast("Please fill in all fields.", isError: true)
@@ -169,11 +131,6 @@ struct SignupView: View {
                             showToast("That username isn’t allowed", isError: true); return
                         }
 
-                        guard password == confirmPassword else {
-                            confirmPasswordError = "Passwords do not match."
-                            return
-                        }
-
                         switch PasswordValidator.validate(password) {
                         case .ok:
                             break
@@ -190,7 +147,7 @@ struct SignupView: View {
                         // here just captures the credentials and metadata.
                         validateAndSignUp()
                     }) {
-                        Text(isLoading ? "Signing Up..." : "Sign Up")
+                        Text(isLoading ? "Creating account..." : "Continue")
                             .font(FontManager.buttonText())
                             .foregroundColor(Constants.Colors.buttonText)
                             .frame(maxWidth: .infinity)
@@ -202,6 +159,20 @@ struct SignupView: View {
                     .disabled(isLoading)
                     .padding(.horizontal, 32)
                     .padding(.top, 8)
+                    .accessibilityIdentifier("auth.signup.continueButton")
+
+                    AuthDivider()
+                        .padding(.horizontal, 32)
+
+                    ThemedAppleSignInButton(
+                        onSuccess: { dismiss() },
+                        onError: { message in showToast(message, isError: true) },
+                        height: 48
+                    )
+                    .padding(.horizontal, 32)
+
+                    AuthLegalFooter()
+                        .padding(.horizontal, 32)
 
                     HStack(spacing: 4) {
                         Text("Already have an account?")
@@ -218,7 +189,8 @@ struct SignupView: View {
                         .buttonStyle(PlainButtonStyle())
                     }
 
-                    Spacer()
+                    Spacer(minLength: 20)
+                }
                 }
 
                 .navigationDestination(isPresented: $showLogin) {
@@ -237,18 +209,69 @@ struct SignupView: View {
         .accessibilityIdentifier("onboarding.signupScreen")
     }
 
+    private func checkUsernameAvailability() async {
+        let candidate = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard case .ok = UsernameValidator().validate(candidate) else {
+            await MainActor.run { usernameAvailability = nil }
+            return
+        }
+        try? await Task.sleep(nanoseconds: 450_000_000)
+        guard !Task.isCancelled else { return }
+        let outcome = await authVM.usernameAvailability(candidate)
+        guard !Task.isCancelled else { return }
+        await MainActor.run { usernameAvailability = outcome }
+    }
+
+    @ViewBuilder
+    private func usernameAvailabilityMessage(_ outcome: UsernameAvailabilityOutcome) -> some View {
+        switch outcome {
+        case .available:
+            Label("Username is available", systemImage: "checkmark.circle.fill")
+                .foregroundColor(Constants.Colors.mapFilterMatch)
+        case .taken:
+            Label("That username is taken", systemImage: "xmark.circle.fill")
+                .foregroundColor(.red)
+        case .unavailable:
+            Label("We couldn’t check that username. Try again.", systemImage: "arrow.clockwise.circle")
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+        }
+    }
+
+    private var passwordRequirements: some View {
+        let checks: [(String, Bool)] = [
+            ("At least 8 characters", password.count >= 8),
+            ("A letter and a number", password.rangeOfCharacter(from: .letters) != nil && password.rangeOfCharacter(from: .decimalDigits) != nil),
+            ("One symbol", password.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) != nil)
+        ]
+        return VStack(alignment: .leading, spacing: 4) {
+            ForEach(checks, id: \.0) { label, isMet in
+                Label(label, systemImage: isMet ? "checkmark.circle.fill" : "circle")
+                    .font(.caption2)
+                    .foregroundColor(isMet ? Constants.Colors.mapFilterMatch : Constants.Colors.welcomeMutedText)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     private func validateAndSignUp() {
         Task {
             let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
-            let available = await authVM.isUsernameAvailable(trimmedUsername)
-            if !available {
+            let outcome = await authVM.usernameAvailability(trimmedUsername)
+            await MainActor.run { usernameAvailability = outcome }
+            switch outcome {
+            case .available:
+                await MainActor.run { self.signUpWithSupabase() }
+            case .taken:
                 await MainActor.run {
                     self.isLoading = false
-                    self.showToast("Username is already taken", isError: true)
+                    self.showToast("That username is taken. Try another.", isError: true)
                 }
-                return
+            case .unavailable:
+                await MainActor.run {
+                    self.isLoading = false
+                    self.showToast("We couldn’t check that username. Try again.", isError: true)
+                }
             }
-            await MainActor.run { self.signUpWithSupabase() }
         }
     }
 
@@ -304,10 +327,16 @@ struct SignupView: View {
                 }
 
                 await MainActor.run {
-                    authVM.beginEmailVerificationPending(email: cleanEmail, avatar: nil)
+                    if response.session == nil {
+                        authVM.beginEmailVerificationPending(email: cleanEmail, avatar: nil)
+                    } else {
+                        authVM.clearEmailVerificationPending()
+                    }
                     self.isLoading = false
                     self.errorMessage = nil
-                    self.showToast("Check your email for the verification code.", isError: false)
+                    if response.session == nil {
+                        self.showToast("Check your email for the verification code.", isError: false)
+                    }
                     self.dismiss()
                 }
             } catch {
@@ -335,38 +364,54 @@ struct SignupView: View {
 struct CustomTextField: View {
     var placeholder: String
     @Binding var text: String
+    var systemImage: String? = nil
 
     var body: some View {
-        TextField(placeholder, text: $text)
-            .padding()
-            .background(Constants.Colors.background)
-            .cornerRadius(10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Constants.Colors.primary, lineWidth: 1)
-            )
-            .font(FontManager.primaryText())
-            .foregroundColor(Constants.Colors.primary)
-            .autocapitalization(.none)
-            .textInputAutocapitalization(.never)
+        HStack(spacing: 10) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundColor(Constants.Colors.welcomeMutedText)
+            }
+            TextField(placeholder, text: $text)
+                .font(.callout)
+                .foregroundColor(Constants.Colors.primary)
+                .autocapitalization(.none)
+                .textInputAutocapitalization(.never)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 52)
+        .background(Constants.Colors.welcomeSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Constants.Colors.primary.opacity(0.22), lineWidth: 1)
+        )
     }
 }
 
 struct CustomSecureField: View {
     var placeholder: String
     @Binding var text: String
+    var systemImage: String? = nil
 
     var body: some View {
-        SecureField(placeholder, text: $text)
-            .padding()
-            .background(Constants.Colors.background)
-            .cornerRadius(10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Constants.Colors.primary, lineWidth: 1)
-            )
-            .font(FontManager.primaryText())
-            .foregroundColor(Constants.Colors.primary)
+        HStack(spacing: 10) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundColor(Constants.Colors.welcomeMutedText)
+            }
+            SecureField(placeholder, text: $text)
+                .font(.callout)
+                .foregroundColor(Constants.Colors.primary)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 52)
+        .background(Constants.Colors.welcomeSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Constants.Colors.primary.opacity(0.22), lineWidth: 1)
+        )
     }
 }
 

--- a/Spot/Views/Auth/ThemedAppleSignInButton.swift
+++ b/Spot/Views/Auth/ThemedAppleSignInButton.swift
@@ -16,13 +16,14 @@ enum ThemedAppleSignInButtonMode {
 struct ThemedAppleSignInButton: View {
     @EnvironmentObject var authVM: AuthViewModel
     @State private var isInFlight = false
+    @State private var currentNonce: String?
 
     var mode: ThemedAppleSignInButtonMode = .signIn
     var onRequest: (() -> Void)? = nil
     var onSuccess: (() -> Void)? = nil
     var onError: ((String) -> Void)? = nil
-    /// When `mode` is `.accountDeletionReauth`, called with the Apple identity token instead of signing in.
-    var onAppleIDToken: ((String) -> Void)? = nil
+    /// When `mode` is `.accountDeletionReauth`, called with the Apple identity token and raw nonce.
+    var onAppleIDToken: ((_ idToken: String, _ nonce: String) -> Void)? = nil
     var height: CGFloat = 56
 
     private var buttonLabel: SignInWithAppleButton.Label {
@@ -38,6 +39,9 @@ struct ThemedAppleSignInButton: View {
             onRequest: { request in
                 guard !isInFlight else { return }
                 isInFlight = true
+                let nonce = AppleSignInNonce.make()
+                currentNonce = nonce
+                request.nonce = AppleSignInNonce.sha256(nonce)
                 onRequest?()
                 request.requestedScopes = [.fullName, .email]
             },
@@ -63,18 +67,22 @@ struct ThemedAppleSignInButton: View {
         switch result {
         case .failure(let error):
             isInFlight = false
+            currentNonce = nil
             onError?(error.localizedDescription)
         case .success(let auth):
             guard let credential = auth.credential as? ASAuthorizationAppleIDCredential else {
                 isInFlight = false
+                currentNonce = nil
                 onError?("Could not read Apple credential.")
                 return
             }
             guard let tokenData = credential.identityToken,
                   let idToken = String(data: tokenData, encoding: .utf8),
-                  !idToken.isEmpty
+                  !idToken.isEmpty,
+                  let nonce = currentNonce
             else {
                 isInFlight = false
+                currentNonce = nil
                 onError?("Apple did not return a valid identity token.")
                 return
             }
@@ -84,18 +92,25 @@ struct ThemedAppleSignInButton: View {
                 case .accountDeletionReauth:
                     await MainActor.run {
                         isInFlight = false
-                        onAppleIDToken?(idToken)
+                        currentNonce = nil
+                        onAppleIDToken?(idToken, nonce)
                     }
                 case .signIn:
                     do {
-                        try await authVM.signInWithApple(idToken: idToken, fullName: credential.fullName)
+                        try await authVM.signInWithApple(
+                            idToken: idToken,
+                            nonce: nonce,
+                            fullName: credential.fullName
+                        )
                         await MainActor.run {
                             isInFlight = false
+                            currentNonce = nil
                             onSuccess?()
                         }
                     } catch {
                         await MainActor.run {
                             isInFlight = false
+                            currentNonce = nil
                             onError?(error.localizedDescription)
                         }
                     }

--- a/Spot/Views/Auth/WelcomeBackView.swift
+++ b/Spot/Views/Auth/WelcomeBackView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct WelcomeBackView: View {
+    let account: AuthAccountHint
+    let onUseAnotherAccount: () -> Void
+
+    @State private var showLogin = false
+    @State private var appleError: String?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                AuthWordmark()
+                    .padding(.top, 34)
+
+                Spacer(minLength: 20)
+
+                AuthScreenHeader(
+                    title: "Welcome back",
+                    subtitle: "Choose your account to keep exploring great places."
+                )
+
+                accountCard
+
+                if account.provider == .apple {
+                    ThemedAppleSignInButton(
+                        onError: { appleError = $0 },
+                        height: 52
+                    )
+                } else {
+                    AuthPrimaryButton(title: "Continue as \(account.displayLabel)") {
+                        showLogin = true
+                    }
+                    .accessibilityIdentifier("auth.welcomeBack.continueButton")
+                }
+
+                AuthSecondaryButton(title: "Use another account", action: onUseAnotherAccount)
+                    .accessibilityIdentifier("auth.welcomeBack.useAnotherAccount")
+
+                if let appleError {
+                    Text(appleError)
+                        .font(.footnote)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                }
+
+                Spacer()
+
+                Label(
+                    account.provider == .apple
+                        ? "Secured with Sign in with Apple"
+                        : "Account suggestion synced by iCloud Keychain",
+                    systemImage: "lock.fill"
+                )
+                .font(.caption)
+                .foregroundColor(Constants.Colors.welcomeMutedText)
+                .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 28)
+            .padding(.bottom, 28)
+            .background(Constants.Colors.background.ignoresSafeArea())
+            .navigationDestination(isPresented: $showLogin) {
+                LoginView(initialIdentifier: account.email ?? "")
+            }
+        }
+        .accessibilityIdentifier("auth.welcomeBack.screen")
+    }
+
+    private var accountCard: some View {
+        HStack(spacing: 16) {
+            Circle()
+                .fill(Constants.Colors.accent)
+                .frame(width: 64, height: 64)
+                .overlay(
+                    Text(String(account.displayLabel.filter(\.isLetter).prefix(1)).uppercased())
+                        .font(.title2.weight(.bold))
+                        .foregroundColor(Constants.Colors.primary)
+                )
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(account.displayLabel)
+                    .font(.title3.weight(.bold))
+                    .foregroundColor(Constants.Colors.primary)
+                if let maskedEmail = account.maskedEmail {
+                    Text(maskedEmail)
+                        .font(.footnote)
+                        .foregroundColor(Constants.Colors.welcomeMutedText)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(18)
+        .background(Constants.Colors.accent.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Constants.Colors.primary.opacity(0.14), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    WelcomeBackView(
+        account: AuthAccountHint(
+            email: "maya@example.com",
+            displayLabel: "@maya",
+            provider: .email,
+            lastSignedInAt: .now
+        ),
+        onUseAnotherAccount: {}
+    )
+    .environmentObject(AuthViewModel())
+}

--- a/Spot/Views/Auth/WelcomeBackView.swift
+++ b/Spot/Views/Auth/WelcomeBackView.swift
@@ -4,6 +4,7 @@ struct WelcomeBackView: View {
     let account: AuthAccountHint
     let onUseAnotherAccount: () -> Void
 
+    @ObservedObject private var termsStore = PreAuthTermsAgreementStore.shared
     @State private var showLogin = false
     @State private var appleError: String?
 
@@ -22,15 +23,30 @@ struct WelcomeBackView: View {
 
                 accountCard
 
+                TermsAgreementCheckboxView(
+                    isAgreed: Binding(
+                        get: { termsStore.hasAgreed },
+                        set: { termsStore.setAgreed($0) }
+                    ),
+                    termsURL: termsStore.termsURL,
+                    privacyURL: termsStore.privacyURL,
+                    onLinkTapped: nil
+                )
+
                 if account.provider == .apple {
                     ThemedAppleSignInButton(
                         onError: { appleError = $0 },
                         height: 52
                     )
+                    .disabled(!termsStore.hasAgreed)
+                    .opacity(termsStore.hasAgreed ? 1 : 0.45)
                 } else {
-                    AuthPrimaryButton(title: "Continue as \(account.displayLabel)") {
-                        showLogin = true
-                    }
+                    AuthPrimaryButton(
+                        title: "Continue as \(account.displayLabel)",
+                        isEnabled: termsStore.hasAgreed
+                    ) {
+                            showLogin = true
+                        }
                     .accessibilityIdentifier("auth.welcomeBack.continueButton")
                 }
 
@@ -49,7 +65,7 @@ struct WelcomeBackView: View {
                 Label(
                     account.provider == .apple
                         ? "Secured with Sign in with Apple"
-                        : "Account suggestion synced by iCloud Keychain",
+                        : "Account suggestion saved securely on this device",
                     systemImage: "lock.fill"
                 )
                 .font(.caption)
@@ -61,6 +77,9 @@ struct WelcomeBackView: View {
             .background(Constants.Colors.background.ignoresSafeArea())
             .navigationDestination(isPresented: $showLogin) {
                 LoginView(initialIdentifier: account.email ?? "")
+            }
+            .task {
+                await termsStore.loadActiveVersion()
             }
         }
         .accessibilityIdentifier("auth.welcomeBack.screen")

--- a/Spot/Views/Onboarding/WelcomeView.swift
+++ b/Spot/Views/Onboarding/WelcomeView.swift
@@ -295,8 +295,8 @@ struct WelcomeView: View {
     }
 
     private func heroHeight(for size: CGSize) -> CGFloat {
-        let proposed = size.height * (size.height < 700 ? 0.34 : 0.38)
-        return min(max(proposed, 220), 340)
+        let proposed = size.height * (size.height < 700 ? 0.29 : 0.33)
+        return min(max(proposed, 210), 290)
     }
 
     private func startOnboardingFlow(destination: AuthDestination) {
@@ -333,25 +333,7 @@ struct WelcomeView: View {
 
 private struct SpotWelcomeBackgroundView: View {
     var body: some View {
-        ZStack {
-            Constants.Colors.background.ignoresSafeArea()
-
-            RadialGradient(
-                colors: [
-                    Constants.Colors.welcomeGlow.opacity(0.24),
-                    Constants.Colors.welcomeGlow.opacity(0.08),
-                    .clear
-                ],
-                center: .center,
-                startRadius: 8,
-                endRadius: 360
-            )
-            .ignoresSafeArea()
-
-            TopographicLinesView()
-                .stroke(Constants.Colors.primary.opacity(0.055), lineWidth: 1)
-                .ignoresSafeArea()
-        }
+        Constants.Colors.background.ignoresSafeArea()
     }
 }
 
@@ -368,14 +350,14 @@ private struct SpotWelcomeHeaderView: View {
                 .accessibilityLabel("Spot")
 
             VStack(spacing: 10) {
-                Text("Find places worth sharing")
-                    .font(.system(.largeTitle, design: .rounded, weight: .bold))
+                Text("Places hit different when they come from your people.")
+                    .font(.system(size: 34, weight: .bold, design: .serif))
                     .foregroundColor(Constants.Colors.primary)
                     .multilineTextAlignment(.center)
-                    .minimumScaleFactor(0.82)
+                    .minimumScaleFactor(0.74)
 
-                Text("Discover favorite spots, vibe tags, and saved recommendations from people you trust.")
-                    .font(.callout.weight(.medium))
+                Text("Save the places you love. Discover the ones your friends can’t stop talking about.")
+                    .font(.callout)
                     .foregroundColor(Constants.Colors.welcomeMutedText)
                     .multilineTextAlignment(.center)
                     .lineLimit(3)
@@ -401,68 +383,32 @@ private struct WelcomeAuthActionsView: View {
     let onLogin: () -> Void
 
     var body: some View {
-        VStack(spacing: 14) {
-            TermsAgreementCheckboxView(
-                isAgreed: termsAgreementBinding,
-                termsURL: termsURL,
-                privacyURL: privacyURL,
-                onLinkTapped: nil
+        VStack(spacing: 10) {
+            AuthPrimaryButton(
+                title: "Get started",
+                isEnabled: isTermsAccepted,
+                action: onGetStarted
             )
+            .accessibilityLabel("Get Started")
+            .accessibilityIdentifier("onboarding.getStartedButton")
+
+            AuthSecondaryButton(title: "Log in", action: onLogin)
+                .accessibilityLabel("Log in")
+                .accessibilityIdentifier("auth.loginButton")
+                .disabled(!isTermsAccepted)
+                .opacity(isTermsAccepted ? 1.0 : 0.45)
 
             ThemedAppleSignInButton(
                 onRequest: onAppleRequest,
                 onSuccess: onAppleSuccess,
                 onError: onAppleError,
-                height: 56
+                height: 48
             )
             .frame(maxWidth: .infinity)
             .accessibilityLabel("Sign in with Apple")
             .accessibilityIdentifier("auth.signInWithAppleButton")
             .disabled(!isTermsAccepted)
             .opacity(isTermsAccepted ? 1.0 : 0.45)
-
-            AuthDividerView()
-
-            Button(action: onGetStarted) {
-                Text("Get Started")
-                    .font(FontManager.buttonText())
-                    .foregroundColor(Constants.Colors.buttonText)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 56)
-                    .background(Constants.Colors.primary)
-                    .clipShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Get Started")
-            .accessibilityIdentifier("onboarding.getStartedButton")
-            .disabled(!isTermsAccepted)
-            .opacity(isTermsAccepted ? 1.0 : 0.45)
-
-            HStack(spacing: 8) {
-                Text("Already have an account?")
-                    .font(.callout)
-                    .foregroundColor(Constants.Colors.welcomeMutedText)
-
-                Button(action: onLogin) {
-                    Text("Log in")
-                        .font(.callout.weight(.semibold))
-                        .foregroundColor(Constants.Colors.primary)
-                        .padding(.horizontal, 14)
-                        .frame(minHeight: 44)
-                        .background(Constants.Colors.welcomeSurface.opacity(0.82))
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(Constants.Colors.primary.opacity(0.2), lineWidth: 1)
-                        )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Log in")
-                .accessibilityIdentifier("auth.loginButton")
-                .disabled(!isTermsAccepted)
-                .opacity(isTermsAccepted ? 1.0 : 0.45)
-            }
-            .padding(.top, 2)
 
             if let appleErrorMessage {
                 Text(appleErrorMessage)
@@ -472,6 +418,14 @@ private struct WelcomeAuthActionsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityLabel("Authentication error: \(appleErrorMessage)")
             }
+
+            TermsAgreementCheckboxView(
+                isAgreed: termsAgreementBinding,
+                termsURL: termsURL,
+                privacyURL: privacyURL,
+                onLinkTapped: nil
+            )
+            .padding(.top, 2)
         }
     }
 }
@@ -499,25 +453,13 @@ private struct SpotWelcomeHeroView: View {
     let configuration: WelcomeHeroMotionConfiguration
 
     @State private var entranceVisible = false
-    @State private var floatAnimation = false
 
     var body: some View {
-        GeometryReader { proxy in
-            ZStack {
-                ModernMapBackgroundView()
-                    .opacity(entranceVisible ? 1 : 0)
-                    .scaleEffect(entranceVisible ? 1 : 0.95)
-
-                FloatingCardsLayerView(
-                    configuration: configuration,
-                    containerSize: proxy.size,
-                    isVisible: entranceVisible,
-                    floatAnimation: floatAnimation
-                )
-            }
-        }
+        EditorialPlaceCollageView()
+            .opacity(entranceVisible ? 1 : 0)
+            .scaleEffect(entranceVisible ? 1 : 0.96)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Spot preview showing shared places, vibe tags, and saved recommendations.")
+        .accessibilityLabel("A collection of cozy cafes, scenic views, and local favorites shared on Spot.")
         .onAppear(perform: startAnimations)
     }
 
@@ -530,13 +472,92 @@ private struct SpotWelcomeHeroView: View {
             entranceVisible = true
         }
 
-        guard configuration.continuousAnimationsEnabled else {
-            return
-        }
+    }
+}
 
-        withAnimation(.easeInOut(duration: 3.5).repeatForever(autoreverses: true)) {
-            floatAnimation = true
+private struct EditorialPlaceCollageView: View {
+    var body: some View {
+        ZStack {
+            EditorialPlaceTile(
+                title: "Sunday coffee",
+                vibe: "Cozy Corner",
+                systemImage: "cup.and.saucer.fill",
+                alignment: .bottomLeading
+            )
+            .frame(width: 190, height: 180)
+            .offset(x: -44, y: 4)
+            .rotationEffect(.degrees(-3))
+
+            EditorialPlaceTile(
+                title: "Golden hour",
+                vibe: "Scenic View",
+                systemImage: "sun.max.fill",
+                alignment: .topTrailing
+            )
+            .frame(width: 142, height: 154)
+            .offset(x: 86, y: -24)
+            .rotationEffect(.degrees(4))
+
+            EditorialVibeChip(text: "Local favorite", systemImage: "person.2.fill")
+                .offset(x: 76, y: 80)
+            EditorialVibeChip(text: "Great coffee", systemImage: "cup.and.saucer.fill")
+                .offset(x: -80, y: -78)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct EditorialPlaceTile: View {
+    let title: String
+    let vibe: String
+    let systemImage: String
+    let alignment: Alignment
+
+    var body: some View {
+        ZStack(alignment: alignment) {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Constants.Colors.accent)
+
+            VStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 42, weight: .light))
+                Text(title)
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundColor(Constants.Colors.primary.opacity(0.82))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Text(vibe)
+                .font(.caption2.weight(.semibold))
+                .foregroundColor(Constants.Colors.primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .background(Constants.Colors.welcomeSurface.opacity(0.96))
+                .clipShape(Capsule())
+                .padding(12)
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Constants.Colors.primary.opacity(0.08), lineWidth: 1)
+        )
+        .shadow(color: Constants.Colors.welcomeCardShadow, radius: 18, y: 10)
+    }
+}
+
+private struct EditorialVibeChip: View {
+    let text: String
+    let systemImage: String
+
+    var body: some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2.weight(.semibold))
+            .foregroundColor(Constants.Colors.primary)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(Constants.Colors.welcomeSurface)
+            .clipShape(Capsule())
+            .overlay(Capsule().stroke(Constants.Colors.primary.opacity(0.08), lineWidth: 1))
+            .shadow(color: Constants.Colors.welcomeCardShadow, radius: 8, y: 4)
     }
 }
 

--- a/Spot/Views/Profile/SettingsView.swift
+++ b/Spot/Views/Profile/SettingsView.swift
@@ -599,7 +599,7 @@ struct SettingsView: View {
         }
     }
 
-    private func deleteAccountWithApple(_ appleIDToken: String) {
+    private func deleteAccountWithApple(_ appleIDToken: String, nonce: String) {
         guard !isSaving else { return }
         SpotLogger.log(SettingsViewLogs.deleteAccountTapped, details: [
             "confirmDelete": confirmDelete,
@@ -611,7 +611,7 @@ struct SettingsView: View {
             return
         }
         isSaving = true
-        authVM.deleteAccount(appleIDToken: appleIDToken) { result in
+        authVM.deleteAccount(appleIDToken: appleIDToken, nonce: nonce) { result in
             handleDeleteAccountResult(result)
         }
     }
@@ -753,7 +753,7 @@ private struct AccountSettingsDetailView: View {
     let onUploadPhoto: (UIImage) -> Void
     let onLogout: () -> Void
     let onDeleteWithPassword: () -> Void
-    let onDeleteWithAppleToken: (String) -> Void
+    let onDeleteWithAppleToken: (_ idToken: String, _ nonce: String) -> Void
     let onDeleteAppleError: (String) -> Void
 
     var body: some View {

--- a/Spot/Views/RootView.swift
+++ b/Spot/Views/RootView.swift
@@ -19,6 +19,8 @@ struct RootView: View {
     @State private var needsTermsUpdateAcceptance: Bool = false
     @State private var pendingActiveTermsVersion: ActiveTermsVersion?
     @State private var hasResolvedTermsAcceptance: Bool = false
+    @State private var savedAccountHint: AuthAccountHint? = AuthAccountHintStore.shared.load()
+    @State private var useAnotherAccount = false
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -189,11 +191,20 @@ struct RootView: View {
                     }
                     .environmentObject(authViewModel)
                 }
+            } else if let savedAccountHint, !useAnotherAccount {
+                WelcomeBackView(account: savedAccountHint) {
+                    useAnotherAccount = true
+                }
             } else {
                 WelcomeView()
             }
         }
         .environmentObject(authViewModel)
+        .onChange(of: authViewModel.isAuthenticated) { _, isAuthenticated in
+            guard !isAuthenticated else { return }
+            savedAccountHint = AuthAccountHintStore.shared.load()
+            useAnotherAccount = false
+        }
         .onOpenURL { url in
             // Handle custom scheme URLs
             SpotLogger.log(RootViewLogs.receivedCustomSchemeUrl, details: ["url": url.absoluteString])

--- a/Spot/Views/RootView.swift
+++ b/Spot/Views/RootView.swift
@@ -191,8 +191,10 @@ struct RootView: View {
                     }
                     .environmentObject(authViewModel)
                 }
-            } else if let savedAccountHint, !useAnotherAccount {
+            } else if let savedAccountHint, shouldShowSavedAccountHint {
                 WelcomeBackView(account: savedAccountHint) {
+                    AuthAccountHintStore.shared.clear()
+                    self.savedAccountHint = nil
                     useAnotherAccount = true
                 }
             } else {
@@ -244,6 +246,15 @@ struct RootView: View {
         .onChange(of: permissionManager.lifecycleRefreshTick) { _, _ in
             Task { await refreshPostAuthSetupRequirement() }
         }
+    }
+
+    private var shouldShowSavedAccountHint: Bool {
+        #if DEBUG
+        if SpotLaunchConfiguration.isUITestMode {
+            return false
+        }
+        #endif
+        return !useAnotherAccount
     }
 
     /// Loads the active Terms version + checks whether the signed-in user has

--- a/SpotTests/AuthCredentialStoresTests.swift
+++ b/SpotTests/AuthCredentialStoresTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import Spot
+
+struct AuthCredentialStoresTests {
+    @Test func accountHintMasksEmailAndContainsNoCredentialFields() throws {
+        let hint = AuthAccountHint(
+            email: "maya@example.com",
+            displayLabel: "@maya",
+            provider: .email,
+            lastSignedInAt: Date(timeIntervalSince1970: 100)
+        )
+
+        #expect(hint.maskedEmail == "ma••••@example.com")
+
+        let json = try #require(String(data: JSONEncoder().encode(hint), encoding: .utf8))
+        #expect(!json.localizedCaseInsensitiveContains("password"))
+        #expect(!json.localizedCaseInsensitiveContains("token"))
+        #expect(!json.localizedCaseInsensitiveContains("otp"))
+    }
+
+    @Test func accountHintStoreRoundTripsAndClears() {
+        let storage = InMemoryAuthDataStore()
+        let store = AuthAccountHintStore(keychain: storage)
+        let hint = AuthAccountHint(
+            email: "hello@example.com",
+            displayLabel: "@hello",
+            provider: .apple,
+            lastSignedInAt: Date(timeIntervalSince1970: 200)
+        )
+
+        store.save(hint)
+        #expect(store.load() == hint)
+
+        store.clear()
+        #expect(store.load() == nil)
+    }
+
+    @Test func verificationRecoveryNormalizesEmailAndExpires() {
+        let storage = InMemoryAuthDataStore()
+        var now = Date(timeIntervalSince1970: 1_000)
+        let store = AuthVerificationRecoveryStore(
+            keychain: storage,
+            lifetime: 60,
+            now: { now }
+        )
+
+        store.save(email: "  Maya@Example.COM ")
+        #expect(store.load()?.email == "maya@example.com")
+
+        now = now.addingTimeInterval(61)
+        #expect(store.load() == nil)
+        #expect(storage.data == nil)
+    }
+}
+
+private final class InMemoryAuthDataStore: AuthDataStoring {
+    var data: Data?
+
+    func save(_ data: Data) {
+        self.data = data
+    }
+
+    func load() -> Data? {
+        data
+    }
+
+    func delete() {
+        data = nil
+    }
+}

--- a/SpotTests/AuthCredentialStoresTests.swift
+++ b/SpotTests/AuthCredentialStoresTests.swift
@@ -3,6 +3,14 @@ import Testing
 @testable import Spot
 
 struct AuthCredentialStoresTests {
+    @Test func appleNonceHashMatchesSHA256Reference() {
+        #expect(
+            AppleSignInNonce.sha256("test")
+                == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        )
+        #expect(AppleSignInNonce.make().count == 64)
+    }
+
     @Test func accountHintMasksEmailAndContainsNoCredentialFields() throws {
         let hint = AuthAccountHint(
             email: "maya@example.com",

--- a/SpotUITests/Authentication/AuthGateUITests.swift
+++ b/SpotUITests/Authentication/AuthGateUITests.swift
@@ -39,13 +39,17 @@ final class AuthGateUITests: XCTestCase {
         guard login.waitForExistence(timeout: 20) else {
             throw XCTSkip("Welcome not reachable — likely already signed in on this simulator.")
         }
+        let terms = app.buttons["auth.termsCheckbox"]
+        if terms.waitForExistence(timeout: 3) {
+            terms.tap()
+        }
         login.tap()
 
-        let loginTitle = app.staticTexts["Log In"]
-        let emailOrUsername = app.textFields["Email or Username"]
+        let loginScreen = app.descendants(matching: .any)["auth.login.screen"]
+        let email = app.textFields["auth.login.emailField"]
         XCTAssertTrue(
-            loginTitle.waitForExistence(timeout: 12) || emailOrUsername.waitForExistence(timeout: 12),
-            "Login flow should show the Log In screen"
+            loginScreen.waitForExistence(timeout: 12) || email.waitForExistence(timeout: 12),
+            "Login flow should show the redesigned Log in screen"
         )
     }
 }

--- a/SpotUITests/Onboarding/OnboardingUITests.swift
+++ b/SpotUITests/Onboarding/OnboardingUITests.swift
@@ -21,14 +21,18 @@ final class OnboardingUITests: XCTestCase {
         guard getStarted.waitForExistence(timeout: 20) else {
             throw XCTSkip("Welcome not reachable — likely already signed in on this simulator.")
         }
+        let terms = app.buttons["auth.termsCheckbox"]
+        if terms.waitForExistence(timeout: 3) {
+            terms.tap()
+        }
         getStarted.tap()
 
         let signup = app.descendants(matching: .any)["onboarding.signupScreen"]
         let locationGate = app.staticTexts["Location Access"]
         let settled = signup.waitForExistence(timeout: 12)
             || locationGate.waitForExistence(timeout: 12)
-            || app.staticTexts["Sign Up"].waitForExistence(timeout: 12)
+            || app.staticTexts["Create your\nSpot account"].waitForExistence(timeout: 12)
 
-        XCTAssertTrue(settled, "Get Started should reach signup, permission gate, or Sign Up title")
+        XCTAssertTrue(settled, "Get Started should reach signup, permission gate, or create-account title")
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | [product/overview.md](product/overview.md) | What Spot is, surfaces, principles |
 | [product/terminology.md](product/terminology.md) | Shared vocabulary |
 | [product/user-flows.md](product/user-flows.md) | Primary journeys + Mermaid |
+| [product/auth-reliability-prd.md](product/auth-reliability-prd.md) | **P0 release requirements for signup, verification, login, and session continuity** |
 | [product/onboarding.md](product/onboarding.md) | First-run and home tour |
 | [product/posting-flow.md](product/posting-flow.md) | Create and publish Spots |
 | [product/map-experience.md](product/map-experience.md) | Map, pins, spot drawer |

--- a/docs/diagrams/app-launch-auth-flow.md
+++ b/docs/diagrams/app-launch-auth-flow.md
@@ -16,17 +16,40 @@ Conceptual; align with `SpotApp`, `RootView`, and Supabase session APIs.
 
 ```mermaid
 flowchart TD
-  A[App launch] --> B[Load local session]
-  B --> C{Session exists?}
-  C -->|No| D[Show auth / welcome screen]
-  C -->|Yes| E[Refresh or validate session]
-  E --> F{Session valid?}
-  F -->|No| D
-  F -->|Yes| G[Load profile]
-  G --> H{Profile exists?}
-  H -->|No| I[Create or complete profile]
-  H -->|Yes| J[Enter main app]
-  I --> J
+  A[App launch] --> B[Detect installation state]
+  B --> C[Retain device-local Keychain session]
+  C --> D[Load local Supabase session]
+  D --> E{Session exists?}
+  E -->|No| F{Pending OTP recovery?}
+  F -->|Yes| G[Resume email verification]
+  F -->|No| H{Saved account hint?}
+  H -->|Yes| I[Show Welcome back]
+  H -->|No| J[Show editorial auth entry]
+  E -->|Yes| K{Session expired?}
+  K -->|Yes| L[Refresh session]
+  L --> M{Refresh succeeds?}
+  M -->|No| F
+  M -->|Yes| N[Load profile]
+  K -->|No| N
+  N --> O{Profile complete?}
+  O -->|No| P[Complete required account setup]
+  O -->|Yes| Q[Enter main app]
+  P --> Q
+```
+
+Authentication entry and new-device paths:
+
+```mermaid
+flowchart LR
+  A[Option A editorial welcome] --> B[Create account]
+  B --> C[Email + username + password]
+  C --> D[Six-digit signup OTP]
+  D --> E[Authenticated session]
+  A --> F[Email login]
+  A --> G[Sign in with Apple + nonce]
+  H[New device] --> G
+  H --> I[iCloud Password AutoFill]
+  H -. future Supabase work .-> J[Passkey]
 ```
 
 ## Related docs

--- a/docs/engineering/networking-and-auth.md
+++ b/docs/engineering/networking-and-auth.md
@@ -24,7 +24,39 @@ The Supabase Swift client attaches the current session JWT to Postgres and Stora
 
 ### Session refresh
 
-Handled by Supabase client session management; **TODO: verify** any custom refresh hooks in `AuthService`.
+The Supabase client persists its session in device-local Keychain storage and emits the initial session through `authStateChanges`. `AuthViewModel` explicitly refreshes an expired initial session and returns to a recoverable signed-out state when refresh fails.
+
+An in-place update and a reinstall on the same phone retain a still-valid local session. `FreshInstallDetector` resets install-scoped caches and permission markers but must not sign the user out.
+
+Supabase access and refresh tokens are never configured as synchronizable Keychain items. Copying one rotating refresh token across devices can invalidate sessions and is not the new-device SSO strategy.
+
+### Logout scope
+
+User-initiated logout uses Supabase’s **local** sign-out scope. It removes the current device session without revoking sessions on the user’s other devices. Account deletion still removes the account and clears the saved account hint.
+
+### Credential and recovery storage
+
+- Passwords, OTP values, Apple identity tokens, and Supabase tokens are never stored by Spot application code.
+- `AuthVerificationRecoveryStore` keeps only the pending email and start time in device-only Keychain storage so signup OTP can resume after relaunch.
+- `AuthAccountHintStore` keeps a removable device-local account suggestion for the returning-account screen.
+- Login fields use `.emailAddress`, `.username`, `.password`, and `.newPassword` content types as appropriate so Apple Password AutoFill can offer credentials managed by the operating system.
+- Sign in with Apple requests use a cryptographically random nonce. The request receives the SHA-256 nonce while Supabase receives the raw nonce with the Apple ID token.
+
+### New-device SSO and passkeys
+
+Current supported new-device paths are Sign in with Apple and iCloud Password AutoFill. Spot does not synchronize its own Supabase refresh tokens or raw credentials.
+
+Supabase passkeys are a planned backend/configuration workstream:
+
+1. Upgrade to a reviewed `supabase-swift` release with passkey support.
+2. Enable passkeys in Supabase Auth.
+3. Configure `spotapp.online` as the relying-party domain.
+4. Add `webcredentials:spotapp.online` to the app entitlement.
+5. Publish the matching `webcredentials` Apple App Site Association entry.
+6. Register passkeys only for authenticated, verified accounts.
+7. Verify registration, second-device sign-in, recovery, revocation, and account deletion on physical devices.
+
+The current Supabase Swift passkey surface is experimental and must not be presented as functional before this work is complete.
 
 ### Unauthenticated users
 
@@ -37,6 +69,7 @@ Handled by Supabase client session management; **TODO: verify** any custom refre
 2. **RLS** must enforce row and storage access for every sensitive table/bucket.
 3. **Posting** requires an authenticated user aligned with `auth.uid()` in policies.
 4. **Sensitive data** must not appear in logs in production.
+5. **Never return a private email address from an anonymous username-resolution RPC.** Release login is email-only until username authentication has a server-side design that does not disclose email.
 
 ### Sequence (conceptual)
 
@@ -66,4 +99,6 @@ sequenceDiagram
 
 ## Open questions / TODOs
 
-- Document token lifetime and refresh UX (errors surfaced to user): TODO: verify in `AuthService`.
+- Verify production access-token lifetime, refresh-token rotation, and reuse interval in Supabase.
+- Decide whether to offer an explicit “Log out all devices” security action in addition to local logout.
+- Complete the passkey workstream in the authentication reliability PRD before enabling its UI.

--- a/docs/product/auth-reliability-prd.md
+++ b/docs/product/auth-reliability-prd.md
@@ -11,6 +11,8 @@ Make account creation, email verification, login, and session restoration reliab
 - **Target:** Before release candidate approval
 - **Last reviewed:** 2026-07-27
 - **Evidence basis:** Repository audit. Live staging and production Supabase configuration still requires verification.
+- **Client implementation:** In progress on the authentication reliability branch
+- **Approved UX:** Option A editorial welcome plus create-account, OTP, returning-account, and email-login flow
 
 ## Problem statement
 
@@ -40,10 +42,11 @@ These findings establish credible code-level causes but do not prove which one o
 - Present actionable, privacy-safe errors for invalid credentials, unverified email, connectivity failures, and unavailable backend services.
 - Ensure all client-required database functions are versioned, deployed, permissioned, and tested in staging and production.
 - Add automated coverage and release checks for the critical authentication journeys.
+- Replace the generic authentication entry screens with the approved premium editorial flow.
 
 ## Non-goals
 
-- Redesigning the full onboarding experience.
+- Redesigning post-auth tours, permissions, or the main tab experience.
 - Changing Sign in with Apple behavior except where shared session handling is affected.
 - Adding social login providers.
 - Broad profile or feed architecture changes.
@@ -99,10 +102,11 @@ The client invokes `is_username_available`, but no definition is committed under
    - environment mismatch
    - unknown SDK sign-out
 4. Release builds must fail CI if the embedded Supabase project does not match the approved production project.
-5. The delete/reinstall policy must be explicitly approved. Recommended launch behavior is:
+5. The approved delete/reinstall policy is:
    - preserve valid sessions for in-place updates;
-   - treat a confirmed delete/reinstall separately;
-   - if security requires logout after reinstall, document and test it rather than classifying it as an update.
+   - preserve and validate the device-local Supabase session after reinstall on the same phone;
+   - never copy or synchronize Supabase access or refresh tokens to another device;
+   - use Sign in with Apple, iCloud Password AutoFill, and eventually passkeys for a new-device sign-in.
 
 ### R2 — Username availability
 
@@ -136,6 +140,26 @@ The client invokes `is_username_available`, but no definition is committed under
 4. Username login must not ship unless its backend dependency is versioned, deployed, security-reviewed, and covered end to end.
 5. Recommended release baseline: label the field as **Email** and support email login only until a secure username-login design is approved. Returning an account email from a public username-resolution RPC creates enumeration and privacy risk.
 
+### R6 — Approved authentication UX
+
+1. The welcome screen uses the approved **Option A — Editorial** direction:
+   - “Places hit different when they come from your people.”
+   - a minimal editorial place collage using Spot’s brand palette;
+   - Get started as the primary action;
+   - Log in as the secondary action;
+   - native Sign in with Apple;
+   - visible Terms of Use and Privacy Policy agreement before authentication.
+2. Create account collects email, username, and one password entry with inline requirements.
+3. Username availability distinguishes available, taken, invalid, and backend unavailable.
+4. OTP verification clearly states that the code is required for account creation, supports resend, and supports changing the email.
+5. Returning-account UI may display a device-local account hint after logout. It must:
+   - contain no password, OTP, Apple identity token, Supabase token, or authorization claim;
+   - be removable through “Use another account”;
+   - be cleared on account deletion;
+   - still require the Terms agreement and real authentication.
+6. Email and password fields use iOS credential content types so the system Password AutoFill experience can supply credentials from iCloud Keychain.
+7. New-device passwordless continuation must not be represented as functional until Supabase passkeys are enabled and verified.
+
 ### R5 — Backend contract and environment parity
 
 1. Every RPC invoked by the auth client must exist in migrations, including:
@@ -159,6 +183,9 @@ The client invokes `is_username_available`, but no definition is committed under
 - Use RLS and least-privilege grants for all auth-adjacent tables and functions.
 - Keep username enumeration risk bounded through public-profile policy, validation, and rate limiting.
 - Persist only the minimum verification recovery state; never persist the password.
+- Bind every native Apple authorization to a cryptographically random nonce and pass the raw nonce to Supabase for verification.
+- Keep Supabase session storage device-local. Do not set `kSecAttrSynchronizable` on session or token data.
+- A custom account hint is device-local by default; cross-device credentials are owned by Apple Password AutoFill, Sign in with Apple, or passkeys.
 - Document database and auth security changes in `docs/engineering/database-and-rls.md` and `docs/engineering/networking-and-auth.md`.
 
 ## UX requirements
@@ -229,6 +256,39 @@ Release candidate approval requires all P0 journeys to pass on a physical device
 5. **Quality gates:** add unit, database, and UI tests plus the manual release matrix.
 6. **Operations:** add dashboards, sign-out reason monitoring, and an auth incident runbook.
 
+## Supabase implementation package
+
+The client UI and safe local persistence do not complete the backend work. The following package is required before authentication release approval.
+
+### Database and RPC
+
+1. Create `is_username_available` in a committed migration using the canonical normalized username.
+2. Enforce username uniqueness atomically with a database constraint; the availability RPC is advisory only.
+3. Return only a boolean availability result and expose the minimum execution grant needed for pre-auth signup.
+4. Apply and verify the migration in staging and production through the Supabase migration workflow.
+5. Confirm `sync_current_user_v1` exists, has the expected grants, and succeeds after OTP verification in both projects.
+6. Do not deploy `resolve_login_email` to anonymous clients. Launch login is email-only until a server design can authenticate by username without returning private email addresses.
+
+### Auth configuration
+
+1. Enable email confirmation in both projects.
+2. Configure the email template to include the six-digit OTP token expected by the client.
+3. Align OTP expiry, resend limits, SMTP configuration, and abuse controls across environments.
+4. Confirm Sign in with Apple provider configuration for the production bundle and Services ID.
+5. Verify refresh-token rotation and reuse interval against multi-device sessions.
+
+### Passkeys and new-device SSO
+
+1. Upgrade `supabase-swift` to a version supporting the reviewed passkey API.
+2. Treat the current Swift passkey API as experimental until security and release review approves it.
+3. Enable passkeys in the Supabase project.
+4. Configure `spotapp.online` as the relying-party domain.
+5. Add `webcredentials:spotapp.online` to Associated Domains.
+6. Publish the required `webcredentials` section in the Apple App Site Association file.
+7. Register a passkey only after a user has authenticated and completed account verification.
+8. Test discoverable passkey sign-in on a second physical device using the same iCloud Keychain.
+9. Keep Sign in with Apple and email/password recovery available when passkeys are unavailable.
+
 ## Release gates
 
 The app is not authentication-ready for release until:
@@ -245,11 +305,12 @@ The app is not authentication-ready for release until:
 
 | Decision | Recommended default | Owner |
 | --- | --- | --- |
-| Delete/reinstall session policy | Explicit logout is acceptable only if documented; never apply it to an in-place update | TODO |
-| Launch login identifier | Email only | TODO |
-| Email confirmation mode | Six-digit OTP, matching the current UI | TODO |
-| Verification recovery storage | Keychain-backed minimal state | TODO |
-| Username normalization | One client/database contract, case-insensitive | TODO |
+| Delete/reinstall session policy | **Approved:** retain and validate device-local session | Product |
+| Launch login identifier | **Approved implementation:** email only | Product/Engineering |
+| Cross-device login | Sign in with Apple and Password AutoFill now; passkeys after Supabase setup | Product/Engineering |
+| Email confirmation mode | Six-digit OTP, matching the approved UI | TODO: verify Supabase |
+| Verification recovery storage | Device-local Keychain email + timestamp only | Engineering |
+| Username normalization | One client/database contract, case-insensitive | TODO: approve with database migration |
 
 ## Live verification checklist
 

--- a/docs/product/auth-reliability-prd.md
+++ b/docs/product/auth-reliability-prd.md
@@ -1,0 +1,278 @@
+# Authentication reliability release PRD
+
+## Purpose
+
+Make account creation, email verification, login, and session restoration reliable enough for release. Authentication is a release-blocking user journey: a user must be able to create an account, verify it, return later, and install an in-place update without being incorrectly rejected or unexpectedly signed out.
+
+## Status
+
+- **Priority:** P0 release blocker
+- **Owner:** TODO
+- **Target:** Before release candidate approval
+- **Last reviewed:** 2026-07-27
+- **Evidence basis:** Repository audit. Live staging and production Supabase configuration still requires verification.
+
+## Problem statement
+
+Current tester reports:
+
+1. Installing a new app version appears to sign the user out.
+2. Credentials for a newly created account do not work.
+3. Every attempted username is reported as taken.
+
+The repository audit found code paths that can produce all three symptoms:
+
+- `FreshInstallDetector` deliberately signs out a valid Keychain session when its UserDefaults install marker is absent.
+- Debug builds use staging while distributed Release builds are intended to use production. Sessions and accounts are scoped to the Supabase project, so switching environments looks like a logout and credentials created in one environment do not exist in the other.
+- Username availability treats every RPC error as `false`, which the UI presents as “Username is already taken.”
+- The required `is_username_available` and `resolve_login_email` RPC definitions are not present in committed migrations.
+- Pending email verification exists only in memory. Relaunching before OTP completion loses the verification screen.
+- Login collapses unconfirmed-email and most other authentication failures into “Incorrect email/username or password.”
+
+These findings establish credible code-level causes but do not prove which one occurred in a specific production incident. Runtime telemetry and live Supabase checks are required.
+
+## Goals
+
+- Preserve a valid session across an in-place update using the same bundle identifier and Supabase environment.
+- Make environment mismatches visible in diagnostics and impossible in release artifacts.
+- Make username availability accurate and distinguish “taken” from service failure.
+- Make signup, six-digit OTP verification, relaunch, and subsequent login a recoverable end-to-end flow.
+- Present actionable, privacy-safe errors for invalid credentials, unverified email, connectivity failures, and unavailable backend services.
+- Ensure all client-required database functions are versioned, deployed, permissioned, and tested in staging and production.
+- Add automated coverage and release checks for the critical authentication journeys.
+
+## Non-goals
+
+- Redesigning the full onboarding experience.
+- Changing Sign in with Apple behavior except where shared session handling is affected.
+- Adding social login providers.
+- Broad profile or feed architecture changes.
+- Exposing whether a private email address has an account.
+
+## Current behavior and evidence
+
+### Session restoration and updates
+
+- The Supabase SDK stores its session in Keychain and emits the local session at startup: `Spot/Supabase/Supabase.swift`.
+- `AuthViewModel` restores authentication from `supabase.auth.authStateChanges`: `Spot/Services/Auth/AuthViewModel.swift`.
+- `FreshInstallDetector.handleFreshInstall()` checks a UserDefaults marker. If the marker is missing but Keychain still contains a session, it calls `supabase.auth.signOut()`: `Spot/Utils/FreshInstallDetector.swift`.
+- Debug builds select staging. Release builds select production or an injected plist configuration. Different Supabase projects have different account stores and Keychain session keys: `Spot/Supabase/Supabase.swift`.
+- Firebase App Distribution and TestFlight workflows intend to inject production configuration: `.github/workflows/deploy.yml` and `.github/workflows/testflight.yml`.
+
+A genuine in-place update should preserve both UserDefaults and Keychain. Therefore, repeated logout on every update suggests at least one of:
+
+1. The distribution process behaves like delete/reinstall.
+2. The build changes bundle identity, app container, signing context, or Supabase project.
+3. Session refresh fails and Supabase emits a signed-out event.
+4. The install marker is being lost independently of Keychain.
+
+### Username availability
+
+`SignupView.validateAndSignUp()` asks `AuthViewModel.isUsernameAvailable()`. That method catches every error and returns `false`; the view always translates `false` to “Username is already taken”:
+
+- `Spot/Views/Auth/SignupView.swift`
+- `Spot/Services/Auth/AuthViewModel.swift`
+
+The client invokes `is_username_available`, but no definition is committed under `supabase/migrations/`. This can make every username appear taken when the function is missing, not deployed, not granted to `anon`, or temporarily unavailable.
+
+### Newly created account login
+
+- Email/password signup requires a six-digit signup OTP in the current UI.
+- Pending verification email and state are memory-only in `AuthViewModel`.
+- If the app terminates before verification, relaunch returns to the signed-out welcome flow.
+- Attempting login before confirmation can return Supabase’s email-not-confirmed error, but `LoginView` presents the generic incorrect-credentials message.
+- Username login invokes `resolve_login_email`, whose definition is also absent from committed migrations.
+- The profile synchronization RPC is versioned in `20260702120000_sync_current_user_security_definer_v1.sql`, but deployment to both live projects must be confirmed.
+
+## Product requirements
+
+### R1 — Session continuity
+
+1. A user with a valid session remains authenticated after upgrading from the previous supported build to the release candidate when bundle identifier and Supabase environment are unchanged.
+2. Authentication startup must resolve to signed in, signed out, or a recoverable error state; it must not remain indefinitely on the launch screen for an expired session.
+3. The app must record a privacy-safe reason for each transition to signed out:
+   - explicit user logout
+   - account deletion
+   - reinstall policy
+   - missing local session
+   - refresh token rejected
+   - environment mismatch
+   - unknown SDK sign-out
+4. Release builds must fail CI if the embedded Supabase project does not match the approved production project.
+5. The delete/reinstall policy must be explicitly approved. Recommended launch behavior is:
+   - preserve valid sessions for in-place updates;
+   - treat a confirmed delete/reinstall separately;
+   - if security requires logout after reinstall, document and test it rather than classifying it as an update.
+
+### R2 — Username availability
+
+1. Add `is_username_available` through a committed Supabase migration and deploy the same migration to staging and production.
+2. Define one canonical normalization and validation contract shared by the client and database, including case handling and allowed punctuation.
+3. Grant only the minimum permission required for unauthenticated signup checks and retain RLS/security boundaries.
+4. Return distinct application outcomes:
+   - available
+   - taken
+   - invalid
+   - temporarily unavailable
+5. Network, RPC, permission, or decoding failures must never be shown as “Username is already taken.”
+6. The signup action must prevent duplicate submissions while the availability request is in progress.
+7. Availability is advisory; final username uniqueness must be enforced atomically by the database.
+
+### R3 — Signup and email verification
+
+1. Production and staging Supabase Auth must use the same approved email-confirmation mode.
+2. If the app uses a six-digit OTP, the configured email template must include the OTP token and the app must not depend on a magic-link-only callback.
+3. Pending verification state must survive app termination and relaunch without storing the password.
+4. An unverified user who attempts login must be routed to a verification recovery screen with a resend option.
+5. Resend must enforce cooldown, explain rate limits, and preserve the entered email.
+6. If email confirmation is disabled, signup must not force the user into the OTP flow.
+7. Duplicate-account handling must remain privacy-safe and must not strand the user waiting for an email that will never arrive.
+
+### R4 — Login
+
+1. Email login must work for a confirmed account created in the same environment.
+2. Invalid password, unverified email, network failure, rate limiting, and service failure must have distinct actionable UI states without leaking sensitive account details.
+3. Whitespace and email casing must be normalized consistently.
+4. Username login must not ship unless its backend dependency is versioned, deployed, security-reviewed, and covered end to end.
+5. Recommended release baseline: label the field as **Email** and support email login only until a secure username-login design is approved. Returning an account email from a public username-resolution RPC creates enumeration and privacy risk.
+
+### R5 — Backend contract and environment parity
+
+1. Every RPC invoked by the auth client must exist in migrations, including:
+   - `is_username_available`
+   - the approved replacement or implementation for username login
+   - `sync_current_user_v1`
+2. Required migrations and grants must be verified in both staging and production.
+3. Auth settings that affect client behavior must be recorded and checked:
+   - email confirmation enabled or disabled
+   - OTP email template
+   - OTP expiry
+   - resend/rate limits
+   - allowed redirect URLs, if links are supported
+4. Database errors during post-verification profile sync must produce a recoverable user state and telemetry rather than silently entering a partially initialized account.
+
+## Security and privacy requirements
+
+- Do not expose service-role credentials in the app or CI artifacts.
+- Do not return email addresses from an RPC callable by `anon`.
+- Do not log passwords, OTPs, access tokens, refresh tokens, full email addresses, or Supabase keys.
+- Use RLS and least-privilege grants for all auth-adjacent tables and functions.
+- Keep username enumeration risk bounded through public-profile policy, validation, and rate limiting.
+- Persist only the minimum verification recovery state; never persist the password.
+- Document database and auth security changes in `docs/engineering/database-and-rls.md` and `docs/engineering/networking-and-auth.md`.
+
+## UX requirements
+
+| Condition | Required user experience |
+| --- | --- |
+| Username is available | Allow signup to continue |
+| Username is taken | “That username is taken. Try another.” |
+| Availability service fails | “We couldn’t check that username. Try again.” with retry |
+| Account awaits verification | Open verification recovery and allow resend |
+| Password is incorrect | Generic incorrect-credentials message |
+| Network unavailable | Explain connectivity issue and retain form values |
+| Session cannot refresh | Show signed-out recovery once; record diagnostic reason |
+| Backend profile sync fails | Show retryable account-setup state |
+
+## Instrumentation
+
+Add privacy-safe events or structured logs for:
+
+- app version/build and an environment label or non-secret project identifier
+- auth initial-session outcome
+- token refresh success/failure category
+- sign-out reason
+- install marker state and update versus reinstall classification
+- username availability outcome and failure category
+- signup accepted/rejected category
+- OTP sent, resent, verified, expired, or rate-limited
+- login outcome and provider
+- profile sync outcome
+
+Dashboards must make it possible to compare authentication success rates by app version and distribution channel without collecting credentials or OTP content.
+
+## Acceptance criteria
+
+### Automated
+
+- Unit tests cover username availability: available, taken, invalid response, network error, missing RPC, and permission error.
+- Unit tests cover login error classification, including unverified email and network failure.
+- Unit tests cover verification-state restoration without storing a password.
+- Unit tests cover initial session events: valid, absent, expired then refreshed, and refresh rejected.
+- Database tests cover normalization, case-insensitive uniqueness, concurrent claims, grants, and RLS behavior.
+- UI tests cover signup → OTP → authenticated app, relaunch during OTP, resend, email login, and incorrect password.
+- CI verifies the production Supabase project identifier in every distributed Release artifact.
+
+### Manual release matrix
+
+Run each journey in staging and production-like distribution builds:
+
+1. Fresh install → signup → OTP → app entry.
+2. Signup → terminate before OTP → relaunch → resume verification.
+3. Confirmed account → logout → email login.
+4. Unconfirmed account → login → recover verification.
+5. Authenticated previous build → in-place update → session retained.
+6. Authenticated app → delete/reinstall → verify the approved reinstall policy.
+7. Offline launch with cached session → reconnect → refresh.
+8. Expired/revoked refresh token → clear recovery message.
+9. Username availability with available, taken, malformed, and backend-failure cases.
+10. Cross-environment credentials → explicit internal diagnostic showing environment mismatch.
+
+Release candidate approval requires all P0 journeys to pass on a physical device and the supported iOS simulator/runtime used by CI.
+
+## Delivery workstreams
+
+1. **Incident confirmation:** capture distribution channel, prior/new build numbers, install method, auth event sequence, install marker, and Supabase project identifier.
+2. **Database contract:** design, migrate, secure, deploy, and verify username availability; decide whether username login is removed or implemented through a security-reviewed server boundary.
+3. **Client state:** model typed auth errors, persist verification recovery state, and make startup/session refresh deterministic.
+4. **Environment controls:** enforce production project selection in distributed builds and add artifact verification.
+5. **Quality gates:** add unit, database, and UI tests plus the manual release matrix.
+6. **Operations:** add dashboards, sign-out reason monitoring, and an auth incident runbook.
+
+## Release gates
+
+The app is not authentication-ready for release until:
+
+- “Every username is taken” cannot be reproduced and backend failures are differentiated.
+- A confirmed new account can log in by email in the distributed production build.
+- Verification can be resumed after relaunch.
+- In-place update session continuity passes.
+- Required RPCs and Auth settings are verified in both Supabase projects.
+- P0 automated and manual acceptance tests pass.
+- No auth flow exposes email-resolution, token, OTP, or service-role data.
+
+## Decisions required
+
+| Decision | Recommended default | Owner |
+| --- | --- | --- |
+| Delete/reinstall session policy | Explicit logout is acceptable only if documented; never apply it to an in-place update | TODO |
+| Launch login identifier | Email only | TODO |
+| Email confirmation mode | Six-digit OTP, matching the current UI | TODO |
+| Verification recovery storage | Keychain-backed minimal state | TODO |
+| Username normalization | One client/database contract, case-insensitive | TODO |
+
+## Live verification checklist
+
+These items cannot be established from repository code alone:
+
+- Confirm the distributed failing build’s embedded Supabase project.
+- Confirm `is_username_available` exists and is callable by the intended role in staging and production.
+- Confirm whether any `resolve_login_email` implementation exists outside migrations; remove or security-review it.
+- Confirm `sync_current_user_v1` is applied in both projects.
+- Confirm email confirmation and OTP template settings in both projects.
+- Reproduce the update logout while capturing structured auth and install logs.
+
+## Related code and documentation
+
+- `Spot/Supabase/Supabase.swift`
+- `Spot/Services/Auth/AuthViewModel.swift`
+- `Spot/Services/AuthService.swift`
+- `Spot/Views/Auth/SignupView.swift`
+- `Spot/Views/Auth/LoginView.swift`
+- `Spot/Views/Auth/ConfirmEmailView.swift`
+- `Spot/Utils/FreshInstallDetector.swift`
+- `supabase/migrations/20260702120000_sync_current_user_security_definer_v1.sql`
+- [Networking and auth](../engineering/networking-and-auth.md)
+- [Supabase environment strategy](../engineering/supabase-environment-strategy.md)
+- [Database and RLS](../engineering/database-and-rls.md)
+- [App launch auth flow](../diagrams/app-launch-auth-flow.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- Rebuilds the welcome experience using the approved Option A editorial direction and adds cohesive create-account, OTP, returning-account, and email-login screens.
- Preserves valid device-local Supabase sessions after reinstall instead of intentionally signing users out.
- Uses local-scope logout so signing out one device does not revoke other device sessions.
- Stores only a removable device-local account hint; passwords, OTPs, Apple identity tokens, and Supabase tokens are never persisted by application code.
- Persists minimal device-only email-verification recovery state so OTP setup can resume after relaunch.
- Adds nonce binding to native Sign in with Apple and Apple account-deletion reauthentication.
- Makes launch session refresh deterministic and tears down prior-user caches when refresh fails.
- Ships email-only login, removing the unsafe anonymous username-to-email resolution path.
- Distinguishes username availability backend failures from genuinely taken usernames.
- Adds focused credential-store/nonce tests and updates stable auth UI test identifiers.
- Expands the P0 PRD, networking/auth documentation, and launch diagram with the remaining Supabase username, OTP configuration, and passkey work.

## Testing
- `git diff --check` passes.
- Initial CI identified a Swift type-name collision: unqualified `User` resolved to the app’s profile model instead of Supabase Auth’s user. The helper now accepts the already-typed `Session`, eliminating the collision.
- CI rerun is pending for the fix.
- Xcode is unavailable in the Linux cloud workspace; macOS CI is the authoritative build/test environment.
- Supabase live verification remains intentionally deferred and is listed as a release gate in the PRD.

## Checklist

### Code Quality & Testing (Required)
- [x] Added focused tests for credential stores and Apple nonce hashing
- [ ] macOS CI rerun passes
- [x] No intentional breaking public API changes
- [ ] Confirm warnings with successful CI build
- [x] Code follows existing SwiftUI, ViewModel, service, and structured logging patterns

### Documentation (Required)
- [x] Added and expanded authentication reliability PRD
- [x] Updated documentation index
- [x] Updated networking/auth engineering documentation
- [x] Updated app launch/auth diagram

### Data plane
- [x] Supabase remains the only authentication/data backend
- [x] No Firebase Auth, Firestore, Storage, or SpotUploader path added
- [x] No schema/RLS change is included; required Supabase migrations/configuration are explicit release gates
- [ ] DataPlaneGuardTests pass in macOS CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa447-f066-7533-b3c5-255607c92961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa447-f066-7533-b3c5-255607c92961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

