### PR TITLE
Temporarily bypass the post-auth terms update gate

### DIFF
--- a/Spot/Views/RootView.swift
+++ b/Spot/Views/RootView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct RootView: View {
+    // Temporarily disabled while the production Supabase terms-acceptance RPC
+    // is investigated. Keep the pre-auth legal agreement visible, but do not
+    // make an unavailable backend verification path block signed-in users.
+    private static let isTermsUpdateGateEnabled = false
+
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var deepLinkState: DeepLinkState
     @EnvironmentObject var permissionManager: PermissionManager
@@ -262,6 +267,13 @@ struct RootView: View {
     /// signup flow doesn't block on a network round-trip we can't satisfy yet.
     @MainActor
     private func refreshTermsAcceptanceRequirement() async {
+        guard Self.isTermsUpdateGateEnabled else {
+            hasResolvedTermsAcceptance = true
+            needsTermsUpdateAcceptance = false
+            pendingActiveTermsVersion = nil
+            return
+        }
+
         guard authViewModel.isAuthenticated, authViewModel.isEmailVerified else {
             hasResolvedTermsAcceptance = true
             needsTermsUpdateAcceptance = false

--- a/docs/engineering/ugc-moderation.md
+++ b/docs/engineering/ugc-moderation.md
@@ -64,6 +64,12 @@ All applied via Supabase migrations under `supabase/migrations/`.
 | `Spot/Models/Logs/ModerationServiceLogs.swift` | Structured logs |
 | `Spot/Models/Logs/TermsAcceptanceLogs.swift` | Structured logs |
 
+The post-auth updated-terms gate is temporarily disabled in `RootView` while
+the production deployment of the terms-acceptance RPCs is investigated. The
+pre-auth Terms of Use and Privacy Policy agreement remains visible. Re-enable
+the gate only after `record_terms_acceptance_v1` and
+`has_accepted_active_terms` are verified with an authenticated production user.
+
 `ReportSheet` retains its legacy reasons and bridges to `ModerationReportReason`
 through `ReportReason.moderationReason` so the existing entry point on
 `SpotCard` keeps working while routing through the new RPC.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- Bypass the post-auth updated-terms gate before it makes either Supabase terms RPC call.
- Keep the pre-auth Terms of Use and Privacy Policy agreement visible.
- Document the temporary production behavior and the verification required before re-enabling it.

This prevents signed-in users from being blocked by the terms-acceptance popup while the production deployment of `record_terms_acceptance_v1` and `has_accepted_active_terms` is investigated.

## Testing
- `git diff --check origin/main...HEAD`
- iOS build/tests unavailable on this Linux cloud runner (`xcodebuild` is not installed).

## Checklist

### Code Quality & Testing (Required)
- [ ] Added Unit Tests For New Code (not applicable: temporary constant bypass)
- [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`) — unavailable on Linux runner
- [x] No breaking API changes
- [x] Confirmed no new warnings introduced by inspection
- [x] Code follows existing patterns and style

### Documentation (Required)
- [x] Updated docs
- [x] Updated relevant product behavior documentation
- [x] Updated architecture/engineering docs
- [x] Updated diagrams if flows changed significantly (not applicable)

### Data plane
- [x] No Firebase data plane changes
- [x] Posting path unchanged
- [x] No schema/RLS changes
- [ ] `DataPlaneGuardTests` unavailable on Linux runner

See [docs/engineering/data-plane.md](docs/engineering/data-plane.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa939-690d-78ba-ae51-6c40276c57f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa939-690d-78ba-ae51-6c40276c57f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

