### PR TITLE
Refresh documentation for current app architecture and flows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -53,8 +53,10 @@ The workflow uses three validation scripts in `scripts/`:
 ### `deploy.yml` - Firebase App Distribution Deployment (Test ENV)
 
 **Triggers:**
-- Merges/pushes to `main` (after CI passes)
+- Pushes to `main`
 - Manual workflow dispatch
+
+This trigger does not depend on the separate CI workflow. Repository branch protection and merge policy are responsible for preventing unvalidated changes from reaching `main`.
 
 **What it does:**
 - Automatically increments build number in `CURRENT_PROJECT_VERSION` (build number `+1` only)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,7 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
   - **Documentation Validation**: Checks if documentation needs updates
   - **Unit Tests**: Runs full test suite using the `SpotTests` scheme
   - **Code Coverage Enforcement**: Validates 80% minimum coverage on changed files
-- Uses macOS 15 runners with Xcode 16.3 (includes Swift 6.1 required by swift-crypto@4.5.0)
+- Uses macOS 15 runners and reports the selected Xcode version at runtime
 - Boots an iPhone simulator and executes tests
 - Enables code coverage collection
 - Posts validation results as PR comment
@@ -102,16 +102,14 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 
 **What it does:**
 - Derives the marketing version from the branch name (e.g. `release/1.1.0` → `MARKETING_VERSION=1.1.0`)
-- Uses `github.run_number` as the unique build number (the version itself is **not** auto-bumped)
+- Increments `CURRENT_PROJECT_VERSION` with `scripts/increment-build-number.sh` (the marketing version itself is not auto-bumped)
 - Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
 - Installs Apple signing assets into a temporary CI keychain
 - Archives unsigned, then exports a **signed App Store IPA**
 - Uploads the IPA artifact, then uploads to App Store Connect / TestFlight via `xcrun altool`
 - Does **not** submit to App Store Review
 
-**Versioning examples:**
-- `release/1.1.0` run 101 → version `1.1.0`, build `101`
-- `release/1.1.0` run 102 → version `1.1.0`, build `102`
+**Versioning example:** if the committed project build is 35, a `release/1.1.0` run sets marketing version `1.1.0` and increments the project build to 36.
 
 **Signing assets (TestFlight / App Store lane):**
 - Certificate: `TESTFLIGHT_APPLE_CERT` (base64-encoded **.p12**, Apple Distribution)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-**Spot** is a SwiftUI iOS app for social **place discovery**: users share and browse **Spots** (saved place recommendations with photos, location, and **vibe tags**). The stack centers on **Supabase** (Auth, Postgres, Storage) with **Firebase** used for analytics, crash reporting, and App Check. See **[docs/README.md](docs/README.md)** for the full documentation index.
+**Spot** is a SwiftUI iOS app for social **place discovery**: users share and browse **Spots** (saved place recommendations with photos, location, and **vibe tags**). The stack centers on **Supabase** (Auth, Postgres, Storage) with **Firebase** used for analytics and crash reporting. Firebase App Check is linked but is not currently initialized in app code. See **[docs/README.md](docs/README.md)** for the full documentation index.
 
 ## Quick start
 
 1. Clone the repository and open **`Spot.xcodeproj`** in Xcode.
-2. Configure **`Spot/Info.plist`** → `Supabase` with your project **`url`** and **`anonKey`** from the [Supabase dashboard](https://supabase.com/dashboard) (never commit real keys to a public fork).
+2. Local DEBUG builds use the staging configuration in **`Spot/Supabase/Supabase.swift`**. Release workflows inject the intended Supabase project into **`Spot/Info.plist`**. See [environment variables](docs/engineering/environment-variables.md) before changing either path.
 3. Select the **Spot** scheme and an **iPhone Simulator** (or device), then Run (**⌘R**).
 
 ## Repository structure
@@ -24,7 +24,7 @@
 
 ## Requirements
 
-- **macOS** with **Xcode** (recent release recommended; minimum version: TODO: verify team standard).
+- **macOS** with an Xcode release that supports the project's iOS 17 deployment target and installed simulator runtimes. CI uses the default Xcode on `macos-15`; distribution workflows select or require Xcode 26 when available.
 - **Apple Developer** account for device testing, Sign in with Apple, push, and Associated Domains as used by the app.
 - **Supabase** project access for backend configuration.
 
@@ -32,7 +32,7 @@ iOS deployment targets vary by target in the project (e.g. **17.0** / **18.5** i
 
 ## Configuration
 
-- **Supabase** — `Spot/Info.plist` under the `Supabase` dictionary (`url`, `anonKey`). Loaded in `Spot/Supabase/Supabase.swift`.
+- **Supabase** — DEBUG selects staging in `Spot/Supabase/Supabase.swift`; Release prefers CI-injected `Spot/Info.plist` values and falls back to the environment enum.
 - **Share / Universal Links** — `Spot/Info.plist` → `SpotURLs` (`shareURLBase`, `universalLinkDomains`, `customScheme`); see [docs/engineering/configuration.md](docs/engineering/configuration.md).
 - **Entitlements** — `Spot/Spot.entitlements` (Associated Domains, Sign in with Apple).
 
@@ -71,7 +71,7 @@ See [docs/engineering/testing.md](docs/engineering/testing.md) for philosophy an
 
 ## Security and safety
 
-Authentication and **Row Level Security (RLS)** on Supabase are authoritative for data access. **Image moderation** is required for Spot and profile media. The app **does not** use Firebase Firestore or Firebase Storage for user or spot data ([docs/engineering/data-plane.md](docs/engineering/data-plane.md)). See [docs/engineering/image-moderation.md](docs/engineering/image-moderation.md). Operational response: [docs/operations/incident-response.md](docs/operations/incident-response.md).
+Authentication and **Row Level Security (RLS)** on Supabase are authoritative for data access. **Image moderation** is required for Spot and profile media. Spot images use the moderation path; profile avatars currently bypass it, which is a documented safety gap. The app **does not** use Firebase Firestore or Firebase Storage for user or Spot data ([docs/engineering/data-plane.md](docs/engineering/data-plane.md)). See [docs/engineering/image-moderation.md](docs/engineering/image-moderation.md). Operational response: [docs/operations/incident-response.md](docs/operations/incident-response.md).
 
 ## Universal Links
 
@@ -83,4 +83,4 @@ High-level checklists: [docs/engineering/release-process.md](docs/engineering/re
 
 ## Support
 
-User-facing support and policy links: see [docs/product/support-and-policies.md](docs/product/support-and-policies.md) and in-app Settings (TODO: verify exact URLs in code).
+User-facing support and policy links are verified in [docs/product/support-and-policies.md](docs/product/support-and-policies.md) and exposed in Settings.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ New developers, reviewers, release owners, support, and Cursor agents.
 
 ## Current status
 
-Reflects the repository as of the documentation refresh. Implementation details that were not verified in code are marked `TODO: verify` in the relevant pages.
+Code and workflow behavior were re-audited on **2026-07-28**. Remaining unknowns are explicitly marked; verified implementation gaps are documented as limitations rather than target behavior.
 
 ## Details
 
@@ -32,6 +32,7 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | [product/posting-flow.md](product/posting-flow.md) | Create and publish Spots |
 | [product/map-experience.md](product/map-experience.md) | Map, pins, spot drawer |
 | [product/home-feed.md](product/home-feed.md) | Feed purpose and ranking |
+| [product/search-experience.md](product/search-experience.md) | Search segments, grids, privacy, Pro filters |
 | [product/profiles-and-social.md](product/profiles-and-social.md) | Profiles, follows, privacy |
 | [product/pro-subscription.md](product/pro-subscription.md) | Pro / StoreKit |
 | [product/support-and-policies.md](product/support-and-policies.md) | Support and policy surfaces |
@@ -41,10 +42,12 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | Doc | Topics |
 | --- | --- |
 | [engineering/architecture.md](engineering/architecture.md) | Modules, data flow, integrations |
+| [engineering/runtime-flows.md](engineering/runtime-flows.md) | **Code-verified runtime flows, source map, and known limitations** |
 | [engineering/local-setup.md](engineering/local-setup.md) | Xcode, schemes, simulator |
 | [engineering/environment-variables.md](engineering/environment-variables.md) | Config keys (no secrets) |
 | [engineering/configuration.md](engineering/configuration.md) | Info.plist, entitlements |
 | [engineering/logging.md](engineering/logging.md) | SpotLogger, debug categories |
+| [engineering/notifications.md](engineering/notifications.md) | Local notifications and remote-push gaps |
 | [engineering/networking-and-auth.md](engineering/networking-and-auth.md) | Sessions, RLS expectations |
 | [engineering/supabase.md](engineering/supabase.md) | Supabase role in the app |
 | [engineering/supabase-environment-strategy.md](engineering/supabase-environment-strategy.md) | **Production and non-production environment split strategy** |
@@ -60,6 +63,8 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | [testing/private-account-tests.md](testing/private-account-tests.md) | Private account test suite |
 | [engineering/ci-cd.md](engineering/ci-cd.md) | GitHub Actions CI/CD, Xcode Cloud disabled |
 | [engineering/release-process.md](engineering/release-process.md) | Pre-release and App Store |
+| [engineering/firebase-distribution-setup.md](engineering/firebase-distribution-setup.md) | Firebase App Distribution setup |
+| [engineering/location-selection-improvements.md](engineering/location-selection-improvements.md) | Location selection implementation notes |
 | [engineering/troubleshooting.md](engineering/troubleshooting.md) | Common failures |
 
 ### Diagrams
@@ -84,13 +89,15 @@ Reflects the repository as of the documentation refresh. Implementation details 
 | [operations/runbooks.md](operations/runbooks.md) | Routine checks |
 | [operations/incident-response.md](operations/incident-response.md) | Severity and response |
 | [operations/app-store-review-notes.md](operations/app-store-review-notes.md) | Review-facing notes |
+| [operations/app-store-rejection-july-2026-fix-guide.md](operations/app-store-rejection-july-2026-fix-guide.md) | Historical July 2026 rejection remediation |
+| [operations/documentation-audit-2026-07.md](operations/documentation-audit-2026-07.md) | **Code/docs audit, external verification, known implementation gaps** |
 | [operations/documentation-maintenance.md](operations/documentation-maintenance.md) | When to update docs |
 
 ### Suggested reading paths
 
-**New developer:** [local-setup](engineering/local-setup.md) → [architecture](engineering/architecture.md) → [testing](engineering/testing.md) → [product overview](product/overview.md).
+**New developer:** [local-setup](engineering/local-setup.md) → [architecture](engineering/architecture.md) → [runtime flows](engineering/runtime-flows.md) → [testing](engineering/testing.md) → [product overview](product/overview.md).
 
-**Cursor agent:** [.cursor/rules/project.mdc](../.cursor/rules/project.mdc) → [data-plane](engineering/data-plane.md) → [architecture](engineering/architecture.md) → [networking-and-auth](engineering/networking-and-auth.md) → [database-and-rls](engineering/database-and-rls.md) → [universal-links](engineering/universal-links.md).
+**Cursor agent:** [.cursor/rules/project.mdc](../.cursor/rules/project.mdc) → [data-plane](engineering/data-plane.md) → [runtime flows](engineering/runtime-flows.md) → [networking-and-auth](engineering/networking-and-auth.md) → [database-and-rls](engineering/database-and-rls.md) → [universal-links](engineering/universal-links.md).
 
 **Release owner:** [release-process](engineering/release-process.md) → [runbooks](operations/runbooks.md) → [app-store-review-notes](operations/app-store-review-notes.md) → [troubleshooting](engineering/troubleshooting.md).
 

--- a/docs/diagrams/app-launch-auth-flow.md
+++ b/docs/diagrams/app-launch-auth-flow.md
@@ -10,31 +10,34 @@ Engineers, reviewers.
 
 ## Current status
 
-Conceptual; align with `SpotApp`, `RootView`, and Supabase session APIs.
+Verified against `AppDelegate`, `SpotApp`, `AuthViewModel`, and `RootView` on 2026-07-28.
 
 ## Details
 
 ```mermaid
 flowchart TD
-  A[App launch] --> B[Detect installation state]
-  B --> C[Retain device-local Keychain session]
-  C --> D[Load local Supabase session]
-  D --> E{Session exists?}
-  E -->|No| F{Pending OTP recovery?}
-  F -->|Yes| G[Resume email verification]
-  F -->|No| H{Saved account hint?}
-  H -->|Yes| I[Show Welcome back]
-  H -->|No| J[Show editorial auth entry]
-  E -->|Yes| K{Session expired?}
+  A[AppDelegate launch setup] --> B[SpotApp branded splash]
+  B --> C[RootView]
+  C --> D{AuthViewModel loading?}
+  D -->|Yes| B
+  D -->|No| E{Pending verification recovery?}
+  E -->|Yes| F[ConfirmEmailView]
+  E -->|No| G{Session exists?}
+  G -->|No| H{Saved account hint?}
+  H -->|Yes| I[WelcomeBackView]
+  H -->|No| J[WelcomeView]
+  G -->|Yes| K{Session expired?}
   K -->|Yes| L[Refresh session]
   L --> M{Refresh succeeds?}
-  M -->|No| F
-  M -->|Yes| N[Load profile]
+  M -->|No| H
+  M -->|Yes| N{Email verified?}
   K -->|No| N
-  N --> O{Profile complete?}
-  O -->|No| P[Complete required account setup]
-  O -->|Yes| Q[Enter main app]
+  N -->|No| F
+  N -->|Yes| O{Apple username setup needed?}
+  O -->|Yes| P[PostAuthSetupFlowView]
+  O -->|No| Q[MainTabView]
   P --> Q
+  Q --> R[Contextual first-run coach and permissions]
 ```
 
 Authentication entry and new-device paths:
@@ -43,13 +46,13 @@ Authentication entry and new-device paths:
 flowchart LR
   A[Option A editorial welcome] --> B[Create account]
   B --> C[Email + username + password]
-  C --> D[Six-digit signup OTP]
+  C --> D[Six-digit signup OTP when required]
   D --> E[Authenticated session]
   A --> F[Email login]
   A --> G[Sign in with Apple + nonce]
   H[New device] --> G
   H --> I[iCloud Password AutoFill]
-  H -. future Supabase work .-> J[Passkey]
+  H -. not implemented .-> J[Passkey]
 ```
 
 ## Related docs

--- a/docs/diagrams/image-moderation-flow.md
+++ b/docs/diagrams/image-moderation-flow.md
@@ -10,7 +10,7 @@ Engineering, safety.
 
 ## Current status
 
-Architectural; matches [../engineering/image-moderation.md](../engineering/image-moderation.md).
+Verified for the Spot-image path. Profile avatars currently bypass this sequence.
 
 ## Details
 
@@ -24,15 +24,26 @@ sequenceDiagram
   participant DB as Supabase DB
 
   User->>App: Selects image
-  App->>Function: Submit image for moderation
+  App->>DB: Insert pending media_assets row
+  App->>Storage: Upload to pending_images
+  App->>Function: Send mediaAssetId with user JWT
+  Function->>DB: Verify caller owns asset
+  Function->>Storage: Read pending object
   Function->>Azure: Analyze image
   Azure-->>Function: Category severities
-  Function-->>App: Approved or blocked
   alt Blocked
+    Function->>DB: Mark rejected and record event
+    Function->>Storage: Remove pending object
+    Function-->>App: 422 approved=false
     App->>User: Show safe rejection message
+  else Moderation unavailable
+    Function->>DB: Mark failed where possible
+    Function-->>App: 503 retryable
   else Approved
-    App->>Storage: Upload / promote media
-    App->>DB: Save via RPC
+    Function->>Storage: Promote to approved bucket
+    Function->>DB: Mark approved and record event
+    Function-->>App: 200 approved=true
+    App->>DB: Publish via approved-assets RPC
   end
 ```
 
@@ -42,4 +53,5 @@ sequenceDiagram
 
 ## Open questions / TODOs
 
-- None.
+- Route profile avatars through this sequence.
+- Add cleanup for unlinked approved and failed assets.

--- a/docs/diagrams/map-spot-drawer-flow.md
+++ b/docs/diagrams/map-spot-drawer-flow.md
@@ -10,7 +10,7 @@ Engineering, QA.
 
 ## Current status
 
-Target behavior for map UX; keep aligned with map tests.
+Verified against map selection and drawer-policy tests.
 
 ## Details
 
@@ -19,17 +19,17 @@ stateDiagram-v2
   [*] --> MapIdle
   MapIdle --> SpotSelected: user taps pin
   SpotSelected --> DrawerOpen: open drawer
-  DrawerOpen --> SpotSelected: user taps different pin / replace selected Spot
+  DrawerOpen --> DrawerOpen: different pin replaces selected Spot
   DrawerOpen --> MapIdle: user dismisses drawer
   DrawerOpen --> MapIdle: user pans or zooms away
-  DrawerOpen --> SpotDetail: user opens full Spot detail
-  SpotDetail --> DrawerOpen: user returns to map
 ```
 
 ## Related docs
 
 - [../product/map-experience.md](../product/map-experience.md)
 
+The drawer hosts `MapSpotPreviewCard` and the shared `SpotCard`; there is no separate `SpotDetailView` transition.
+
 ## Open questions / TODOs
 
-- Confirm “SpotDetail” transition naming vs actual navigation stack: TODO: verify in Map views.
+- None.

--- a/docs/diagrams/onboarding-flow.md
+++ b/docs/diagrams/onboarding-flow.md
@@ -10,21 +10,24 @@ Product and engineering.
 
 ## Current status
 
-High-level; see `HomeTourManager` and `SpotFirstRunOnboardingManager` for exact steps.
+Verified against `SpotFirstRunOnboardingManager` wiring in `BottomTabNavigationView`. `HomeTourManager` is legacy and unmounted.
 
 ## Details
 
 ```mermaid
 flowchart TD
-  A[Authenticated user enters app] --> B{First-run onboarding done?}
-  B -->|No| C[SpotFirstRunOnboardingManager steps]
-  C --> D[Complete or skip]
-  B -->|Yes| E[Main tabs]
-  D --> E
-  E --> F{Home tour needed?}
-  F -->|Yes| G[HomeTourManager coach]
-  F -->|No| H[Normal home]
-  G --> H
+  A[Verified user enters tab shell] --> B{First-session candidate and not completed?}
+  B -->|No| C[Normal tabs]
+  B -->|Yes| D[SpotFirstRunOnboarding overlay]
+  D --> E[Spot card, social, and map coach steps]
+  E --> F{Complete or skip}
+  F --> G{Notification permission undetermined?}
+  G -->|Yes| H[Notification pre-prompt after 600 ms]
+  G -->|No| C
+  H --> C
+  E --> I[User-location step]
+  I --> J[Optional location permission sheet]
+  J --> E
 ```
 
 ## Related docs
@@ -33,4 +36,4 @@ flowchart TD
 
 ## Open questions / TODOs
 
-- Wire exact conditions to UI entry files: TODO: verify in `RootView`.
+- None.

--- a/docs/diagrams/posting-flow.md
+++ b/docs/diagrams/posting-flow.md
@@ -16,16 +16,19 @@ Matches `SpotPublishCoordinator`, `SpotSupabaseRepository`, and moderation migra
 
 ```mermaid
 flowchart TD
-  A[PostFlowViewModel submitPost] --> B[Build SpotPublishDraft]
-  B --> C[SpotPublishCoordinator.enqueue]
-  C --> D[Upload JPEGs to pending_images]
-  D --> E[moderate-image Edge Function]
-  E --> F{All assets approved?}
-  F -->|No| G[Toast error / draft retained]
-  F -->|Yes| H[publish_spot_with_approved_media_assets_v1 RPC]
-  H --> I{RPC success?}
-  I -->|No| J[Toast error]
-  I -->|Yes| K[spotDidPostSuccess notification]
+  A[PostFlowViewModel submitPost] --> B[Validate auth, input, entitlement]
+  B --> C[Persist local draft snapshot]
+  C --> D[SpotPublishCoordinator.enqueue]
+  D --> E[Reset composer and show global progress]
+  E --> F[Insert pending media_assets row]
+  F --> G[Upload JPEG to pending_images]
+  G --> H[moderate-image Edge Function]
+  H --> I{All assets approved?}
+  I -->|No| J[Safe failure toast; recovery not guaranteed]
+  I -->|Yes| K[publish_spot_with_approved_media_assets_v1 RPC]
+  K --> L{RPC success?}
+  L -->|No| M[Failure toast; approved assets may be unlinked]
+  L -->|Yes| N[spotDidPostSuccess and optimistic feed insert]
 ```
 
 ## Related docs

--- a/docs/diagrams/testing-release-flow.md
+++ b/docs/diagrams/testing-release-flow.md
@@ -24,12 +24,12 @@ flowchart TD
   F --> C
   E -->|Yes| G[Code review]
   G --> H[Merge to main]
-  H --> I[CI runs on main]
+  H --> I[CI plus Firebase staging distribution]
   I --> J[Run SpotUITests if major UI changes]
-  J --> K[Run manual smoke tests]
-  K --> L[Verify docs updated]
-  L --> M[Verify security/RLS/moderation if touched]
-  M --> N[TestFlight build]
+  J --> K[Run staging smoke tests]
+  K --> L[Cut release/X.Y.Z branch]
+  L --> M[TestFlight workflow with production Supabase]
+  M --> N[Run production-safe release smoke]
   N --> O[App Store review checklist]
 ```
 

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -10,7 +10,7 @@ Engineers and Cursor agents onboarding to the repo.
 
 ## Current status
 
-Matches SwiftUI + services layout under `Spot/` and **Supabase as the sole application data plane**; Firebase limited to analytics/crash/app-check (see `docs/engineering/data-plane.md` and `AppDelegate`).
+Matches SwiftUI + services layout under `Spot/` and **Supabase as the sole application data plane**. Firebase Analytics and Crashlytics initialize in `AppDelegate`; App Check is linked but not initialized.
 
 ## Details
 
@@ -18,15 +18,16 @@ Matches SwiftUI + services layout under `Spot/` and **Supabase as the sole appli
 
 ```mermaid
 flowchart LR
-  A[iOS App] --> B[Auth Layer]
-  A --> C[ViewModels / Services]
-  C --> D[Supabase Database]
+  A[SwiftUI Views] --> B[ViewModels]
+  B --> C[Typed services and repositories]
+  C --> D[Supabase Auth / Postgres]
   C --> E[Supabase Storage]
   C --> F[Edge Functions / RPC]
-  A --> G[StoreKit / Pro Subscription]
+  A --> G[StoreKit / Pro]
   A --> H[DeepLinkRouter / DeepLinkState]
-  D --> I[RLS Policies]
+  D --> I[RLS and visibility functions]
   E --> I
+  A --> J[Firebase Analytics / Crashlytics]
 ```
 
 ### App directories (concise)
@@ -37,7 +38,7 @@ flowchart LR
 | `Spot/ViewModels` | `ObservableObject` state for screens |
 | `Spot/Services` | Auth, feed, map, search, spots, subscriptions, analytics |
 | `Spot/Services/Supabase` | `SpotSupabaseRepository` and related Postgres/Storage access |
-| `Spot/Supabase` | `SupabaseClient` bootstrap from Info.plist |
+| `Spot/Supabase` | `SupabaseClient` bootstrap and environment selection |
 | `Spot/Models` | Codable models and log enums |
 | `Spot/Utils` | Constants, logging, URL config, validators |
 | `Spot/Managers` | Cross-feature managers (e.g. onboarding tours) |
@@ -50,6 +51,17 @@ View → ViewModel → Service/Repository → Supabase client → Postgres/Stora
 ### Auth flow
 
 `AuthService` + Supabase Auth session; `SpotAuthBridge` exposes current user id for gates (e.g. deep links). See [networking-and-auth.md](networking-and-auth.md).
+
+### Feature read paths
+
+| Surface | Path |
+| --- | --- |
+| Feed | `FeedViewModel` → `FeedRepository` → `FeedAPI` → feed RPCs |
+| Map | `MapViewModel` → `MapViewportLoader` → `FeedAPI` → viewport RPC |
+| Search | `SearchViewModel` → `SearchService` → `SpotSearchDataSource` / repository |
+| Profile/social | `ProfileViewModel` → `ProfileService`, `UserSpotService`, `FollowRequestsService` |
+
+`AuthorPrivacyCache` adds client-side filtering for Search and social changes; Supabase RLS remains authoritative. `FeedEventService` records visibility events, and `FeedDiversity` lightly reorders only the first hydrated home page.
 
 ### Posting (canonical modules)
 
@@ -64,6 +76,8 @@ View → ViewModel → Service/Repository → Supabase client → Postgres/Stora
 ### Media / storage flow
 
 Pending buckets → moderation → approved buckets; see [storage-and-media.md](storage-and-media.md) and [image-moderation.md](image-moderation.md).
+
+The implemented Spot-image path follows this architecture. Profile avatar uploads currently use the public legacy `avatars` bucket and are a documented exception that must be removed.
 
 ### Universal Links routing
 
@@ -84,6 +98,7 @@ Pending buckets → moderation → approved buckets; see [storage-and-media.md](
 - [local-setup.md](local-setup.md)
 - [supabase.md](supabase.md)
 - [testing.md](testing.md)
+- [runtime-flows.md](runtime-flows.md)
 
 ## Open questions / TODOs
 

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -30,7 +30,7 @@ The Spot project uses GitHub Actions for continuous integration and deployment. 
 | --- | --- | --- | --- | --- | --- |
 | PR validation | `pull_request` → `main` | none | none | n/a (simulator tests) | n/a |
 | Firebase Test ENV | `push` → `main` | `FIREBASE_DEV_CERT` | `FIREBASE_PROVISIONING_PROFILE` | `ad-hoc` | build number `+1` |
-| TestFlight | `push` → `release/**` | `TESTFLIGHT_APPLE_CERT` | `TESTFLIGHT_APPLE_PROFILE` | `app-store` | version from branch, build = `run_number` |
+| TestFlight | `push` → `release/**` | `TESTFLIGHT_APPLE_CERT` | `TESTFLIGHT_APPLE_PROFILE` | `app-store` | version from branch, build number `+1` |
 
 The Firebase and TestFlight signing assets are never swapped: the Ad Hoc profile is only used for Firebase, and the App Store Connect profile is only used for TestFlight. `APPLE_CERTIFICATE_PASSWORD` is the single password used to import both `.p12` files, and `KEYCHAIN_PASSWORD` is the temporary CI keychain password.
 
@@ -131,7 +131,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
-2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and set `CURRENT_PROJECT_VERSION` to `github.run_number`
+2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and increment `CURRENT_PROJECT_VERSION` with `scripts/increment-build-number.sh`
 3. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
 4. **Code Signing:** Install `TESTFLIGHT_APPLE_CERT` + `TESTFLIGHT_APPLE_PROFILE` into a temporary keychain
 5. **Build:** Archive unsigned, then export an App Store `.ipa`
@@ -141,7 +141,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 
 **Versioning rule:**
 - The release branch name controls the user-facing version. `release/1.1.0` → `MARKETING_VERSION = 1.1.0`.
-- Only the build number auto-increments, using the unique `github.run_number`:
+- The build number increments from the project value using the same script as the Firebase lane:
   - `release/1.1.0` run 101 → version `1.1.0`, build `101`
   - `release/1.1.0` run 102 → version `1.1.0`, build `102`
 - The pipeline never bumps `1.1.0` → `1.2.0` automatically. To ship a new version, create a new `release/<version>` branch.

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -73,25 +73,27 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 #### Deployment workflow: `deploy.yml`
 
 **Triggers:**
-- Merge to `main` (after PR validation passes)
+- Push to `main`
 - Manual workflow dispatch
+
+The workflow trigger is not technically gated on the separate CI workflow succeeding. Branch protection and merge policy must enforce validation before code reaches `main`.
 
 **Environment:**
 - Runner: macOS 15
-- Xcode: Default Xcode on the runner
+- Xcode: Selects Xcode 26.x when installed; otherwise retains the runner default and reports the selected version
 - Requires: Apple signing certificates and Firebase credentials
 
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
 2. **Version Management:** Auto-increment build number
-3. **Release Notes:** Extract PR information for release notes
-4. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
-5. **Supabase Configuration:** Inject and verify staging project credentials
-6. **Code Signing:** Install certificates and provisioning profiles
-7. **Build:** Archive and export signed IPA
-8. **Deploy:** Upload to Firebase App Distribution
-9. **Version Commit:** Push build number update back to main
+3. **Version Commit:** Push build number update back to `main`
+4. **Release Notes:** Extract PR information for release notes
+5. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
+6. **Supabase Configuration:** Inject and verify staging project credentials
+7. **Code Signing:** Install certificates and provisioning profiles
+8. **Build:** Archive and export signed IPA
+9. **Deploy:** Upload to Firebase App Distribution
 
 **What it does:**
 - Automatically increments `CURRENT_PROJECT_VERSION` in Xcode project via `scripts/increment-build-number.sh`
@@ -142,8 +144,8 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 **Versioning rule:**
 - The release branch name controls the user-facing version. `release/1.1.0` → `MARKETING_VERSION = 1.1.0`.
 - The build number increments from the project value using the same script as the Firebase lane:
-  - `release/1.1.0` run 101 → version `1.1.0`, build `101`
-  - `release/1.1.0` run 102 → version `1.1.0`, build `102`
+  - if the branch contains build 35, the workflow builds version `1.1.0` (36)
+  - a later run only advances again if the branch's committed project value has advanced
 - The pipeline never bumps `1.1.0` → `1.2.0` automatically. To ship a new version, create a new `release/<version>` branch.
 - TestFlight upload does **not** submit the build to App Store Review.
 
@@ -372,8 +374,8 @@ If Xcode Cloud starts building again:
 
 **Build versioning:**
 - Marketing version: `1.000` (manual updates for releases)
-- Build number: Auto-incremented on every deployment (current: `7`)
-- Format: `Version 1.000 (Build 7)`
+- Build number: Auto-incremented from `CURRENT_PROJECT_VERSION` on every deployment
+- The Xcode project is authoritative; do not duplicate a static “current build” number in this runbook.
 
 **Deploy safeguards:**
 - **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)

--- a/docs/engineering/configuration.md
+++ b/docs/engineering/configuration.md
@@ -20,8 +20,10 @@ Verified file paths: `Spot/Info.plist`, `Spot/Spot.entitlements`.
 | --- | --- |
 | `CFBundleURLTypes` | Custom URL scheme **`spotapp`** for deep links. |
 | `SpotURLs` | `shareURLBase`, `universalLinkDomains`, `customScheme` read by `URLConfiguration`. |
-| `Supabase` | `url` and `anonKey` for `SupabaseClient` initialization. |
-| Usage descriptions | Notifications, photos, camera, location as required by Apple. |
+| `Supabase` | Release-workflow-injected `url` and `anonKey`; DEBUG uses `SupabaseEnvironment` in `Supabase.swift`. |
+| Generated usage descriptions | Camera, photo-library, and location strings are set through Xcode `INFOPLIST_KEY_*` build settings in `project.pbxproj`. |
+
+Notification authorization uses UserNotifications and does not have a plist usage-description key. Notification categories and the delegate are registered by `AppDelegate`.
 
 ### Entitlements (`Spot/Spot.entitlements`)
 

--- a/docs/engineering/data-plane.md
+++ b/docs/engineering/data-plane.md
@@ -10,7 +10,7 @@ All engineers, reviewers, Cursor agents, and anyone merging PRs that touch posti
 
 ## Current status
 
-**Authoritative as of April 2026.** `main` uses **Supabase only** for the application data plane. Firebase is limited to observability SDKs.
+Verified on 2026-07-28. `main` uses **Supabase only** for the application data plane. Firebase is limited to observability SDKs; App Check is linked but not initialized.
 
 ## Supabase (required data plane)
 
@@ -21,7 +21,7 @@ All engineers, reviewers, Cursor agents, and anyone merging PRs that touch posti
 | Spots | `public.spots`, `public.spot_images`, vibe tags |
 | Home feed | RPC `get_home_feed_v1` |
 | Publish | `SpotPublishCoordinator` → `SpotSupabaseRepository.publishSpotFromDraft` → moderation + RPC `publish_spot_with_approved_media_assets_v1` |
-| Images | Supabase Storage buckets (`pending_images`, `approved_spot_images`, `approved_profile_images`) |
+| Images | Supabase Storage, including moderated Spot buckets and legacy `spots` / `avatars` paths |
 | Social graph | `follows`, `follow_requests`, likes/bookmarks tables + RLS |
 | Schema changes | `supabase/migrations/` (apply via reviewed SQL + Supabase MCP in agent workflows) |
 
@@ -46,6 +46,8 @@ flowchart LR
 | Firebase Crashlytics | Crash reporting |
 | Firebase App Check | Abuse reduction (if enabled for build) |
 
+App Check is currently a linked dependency only; no app-code initialization was found. Do not claim enforcement until initialization and backend verification are implemented.
+
 Firebase must **not** be used for:
 
 - Firestore reads/writes (`FirebaseFirestore`, `Firestore.firestore()`)
@@ -62,6 +64,15 @@ Firebase must **not** be used for:
 - `Firestore.firestore()`, `Storage.storage()` (Firebase Storage API)
 
 **Allowed exceptions:** `FirebaseCore`, `FirebaseAnalytics`, `FirebaseCrashlytics`, `FirebaseAppCheck` in `AppDelegate` / analytics files only.
+
+## Known Supabase media exceptions
+
+These do not change the data-plane decision, but they are important safety gaps:
+
+- Profile avatars upload directly to the public Supabase `avatars` bucket and currently bypass `media_assets` moderation.
+- Home-feed batch signing assumes the legacy Supabase `spots` bucket even when `spot_images.storage_bucket` points to `approved_spot_images`.
+
+Fix these within Supabase Storage and the existing moderation pipeline. They are not reasons to add Firebase Storage.
 
 ## Obsolete PRs and branches
 

--- a/docs/engineering/database-and-rls.md
+++ b/docs/engineering/database-and-rls.md
@@ -36,9 +36,12 @@ flowchart TD
 
 ### Table / policy inventory
 
-**TODO: verify** — generate from live schema or maintain a curated list. Starting references from migrations:
+Curated security-sensitive inventory from committed migrations:
 
-- `media_assets`, `media_moderation_events`
+- `media_assets`: authenticated owners can insert pending rows and select their own rows; clients cannot approve assets. `media_moderation_events`: service-role-only moderation audit.
+- `terms_versions`, `user_terms_acceptances`: active legal versions and per-user acceptance records.
+- `moderation_events`, `content_moderation_results`, and `moderation_queue`: service-role moderation audit and work queue.
+- `spot_vibe_tags`: multi-vibe junction used by Pro publishing and discovery.
 - `users`, `spots` (including `media_display_aspect_ratio`, `media_count`, `media_layout_version` for feed layout), `spot_images` (per-image width/height and clamped display ratio), follow-related tables (see dated migrations)
 - `public.follows`: RLS policies `follows_select_related`, `follows_insert_self`, `follows_delete_related` (`20260502120000_security_sweep_rls_part_1.sql`); **unique** `(follower_id, followee_id)` via `follows_follower_followee_uidx` (`20260503120000_follows_unique_follower_followee.sql`)
 - `public.reports`: client **insert only** (`reports_insert_own`); columns include `spot_id`, `reporter_id`, `owner_id` (must match `spots.user_id` for `spot_id`), `reason`, `details`, `block_requested`, `platform`, `app_version`, `created_at` (`20260502120000_security_sweep_rls_part_1.sql`, `20260507120000_reports_block_requested_insert_validation.sql`); **after insert** trigger `reports_apply_volume_suspension` sets `users.suspended_for_reports_at` when an author hits report thresholds (see `20260510120000_report_volume_suspension.sql`)
@@ -48,6 +51,7 @@ flowchart TD
 - `public.users`: **select/insert/delete** + column-scoped **update** for `authenticated` (`20260503120000_users_grant_authenticated_table_dml.sql`, `20260509120000_users_grants_user_blocks_insert_fix.sql`). The column-scoped update deliberately **excludes `id`** so users cannot rewrite their own primary key.
 - **Username availability** uses `public.is_username_available(text)` (`SECURITY DEFINER`) so `anon` can receive one boolean without gaining table access (`20260727210000_username_availability_v1.sql`). The shared syntax is 3–20 ASCII letters, numbers, dots, underscores, or hyphens; separators cannot lead, trail, or appear consecutively. Normalization is `lower(btrim(username))`. The RPC is advisory; `users_username_normalized_uidx` atomically enforces final case-insensitive uniqueness.
 - **User profile sync** goes through `public.sync_current_user_v1(...)` (**SECURITY DEFINER**, `search_path = public`), not a direct client upsert (`20260702120000_sync_current_user_security_definer_v1.sql`). A PostgREST `upsert(onConflict: "id")` compiles to `INSERT ... ON CONFLICT (id) DO UPDATE SET id = excluded.id, ...`; because `authenticated` lacks **update** on `id`, that failed for existing rows with **42501 permission denied for table users** (new users worked via the INSERT branch, returning users' sync silently failed). The RPC derives the row id from `auth.uid()`, only writes the caller's own row, and on conflict refreshes only login/heartbeat fields (`email`, `email_verified`, `last_active_at`, `locale`) while preserving user-managed fields (`username`, `username_lower`, `is_private`, `profile_image_url`, `is_pro`, `pro_until`).
+- **Account deletion** uses the latest `delete_my_account` definition applied in migration order and removes `media_assets` rows after clearing references. Storage blobs are outside Postgres; current client cleanup does not cover all moderated buckets.
 
 ### Privacy classification (high level)
 
@@ -64,7 +68,7 @@ Add dated SQL under `supabase/migrations/`. Never edit applied migration files i
 ### Testing RLS
 
 - Use Supabase SQL editor with different `auth.uid()` contexts, or
-- Integration tests with test users (**TODO: verify** if repo has automated RLS tests beyond app-level).
+- Integration tests with environment-specific test users. Unit tests cover client privacy and guard logic, but they do not prove live RLS policy behavior.
 
 ## Related docs
 

--- a/docs/engineering/environment-variables.md
+++ b/docs/engineering/environment-variables.md
@@ -10,22 +10,25 @@ Engineers and infra owners.
 
 ## Current status
 
-iOS client reads Supabase URL and anon key from **`Spot/Info.plist`** (see `Spot/Supabase/Supabase.swift`). Edge functions and Azure keys belong in **Supabase dashboard / function secrets**, not the app bundle.
+DEBUG builds select staging defaults in **`Spot/Supabase/Supabase.swift`**. Release builds prefer values injected into **`Spot/Info.plist`** by CI. Edge Function and Azure credentials belong in Supabase function secrets, never the app bundle.
 
 ## Details
 
 | Name | Used by | Required | Secret? | Location | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Supabase **project URL** (staging) | iOS app (DEBUG) | Yes | No (public URL) | `SupabaseEnvironment.swift` → `.staging.url` | Staging/development environment. |
-| Supabase **anon / publishable key** (staging) | iOS app (DEBUG) | Yes | **Treat as sensitive** — must rely on **RLS** | `SupabaseEnvironment.swift` → `.staging.anonKey` | Never ship service-role in the app. |
+| Supabase **project URL** (staging) | iOS app (DEBUG) | Yes | No (public URL) | `Spot/Supabase/Supabase.swift` → `.staging.url` | Staging/development environment. |
+| Supabase **anon / publishable key** (staging) | iOS app (DEBUG) | Yes | Public client credential; protect data with **RLS** | `Spot/Supabase/Supabase.swift` → `.staging.anonKey` | Never ship service-role in the app. |
 | Supabase **project URL** (production) | iOS app (RELEASE) | Yes | No (public URL) | Injected by CI/CD from `SUPABASE_PRODUCTION_URL` secret | Production environment. |
-| Supabase **anon / publishable key** (production) | iOS app (RELEASE) | Yes | **Treat as sensitive** — must rely on **RLS** | Injected by CI/CD from `SUPABASE_PRODUCTION_ANON_KEY` secret | Never ship service-role in the app. |
+| Supabase **anon / publishable key** (production) | iOS app (RELEASE) | Yes | Public client credential; protect data with **RLS** | Injected by CI/CD from `SUPABASE_PRODUCTION_ANON_KEY` secret | Never ship service-role in the app. |
 | `SUPABASE_STAGING_URL` | GitHub Actions (deploy.yml) | Optional | No | GitHub repository secrets | Staging project URL; falls back to hardcoded if not set. |
 | `SUPABASE_STAGING_ANON_KEY` | GitHub Actions (deploy.yml) | Optional | Yes | GitHub repository secrets | Staging anon key; falls back to hardcoded if not set. |
 | `SUPABASE_PRODUCTION_URL` | GitHub Actions (testflight.yml) | **Required** | No | GitHub repository secrets | Production project URL; TestFlight builds fail without this. |
 | `SUPABASE_PRODUCTION_ANON_KEY` | GitHub Actions (testflight.yml) | **Required** | Yes | GitHub repository secrets | Production anon key; TestFlight builds fail without this. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server / Edge only | If admin operations | **Yes** | Supabase secrets | **Never** in client. |
-| `AZURE_CONTENT_SAFETY_*` | Moderation function | If Azure enabled | Endpoint: often non-secret; key: **Yes** | Function env in Supabase | Do not put in client. |
+| `AZURE_CONTENT_SAFETY_ENDPOINT` | `moderate-image` | Yes | Usually no | Function secret/config in Supabase | Server-side only. |
+| `AZURE_CONTENT_SAFETY_KEY` | `moderate-image` | Yes | **Yes** | Function secret in Supabase | Server-side only. |
+| `AZURE_CONTENT_SAFETY_API_VERSION` | `moderate-image` | Optional | No | Function config in Supabase | Provider API override. |
+| `MODERATION_THRESHOLDS_JSON` | `moderate-image` | Optional | Policy-sensitive | Function config in Supabase | Overrides default category thresholds. |
 | Share / Universal Link config | iOS app | Yes | No | `Info.plist` → `SpotURLs` | Domains must match entitlements. |
 
 ### Example placeholders only
@@ -49,4 +52,4 @@ iOS client reads Supabase URL and anon key from **`Spot/Info.plist`** (see `Spot
 
 ## Open questions / TODOs
 
-- Enumerate every Edge Function secret name from deployed functions: TODO: verify in Supabase dashboard.
+- Dashboard deployment state and secret presence cannot be proven from source control; verify them during environment smoke tests without copying values into docs.

--- a/docs/engineering/firebase-distribution-setup.md
+++ b/docs/engineering/firebase-distribution-setup.md
@@ -72,15 +72,15 @@ This is the Firebase iOS App ID from your Firebase project.
 6. Click **Download GoogleService-Info.plist**
 7. Save the file to your computer
 
-#### Step 2: Convert to Base64
+#### Step 2: Encode the Firebase plist
 
 ```bash
 cd ~/Downloads  # or wherever you saved the plist
 base64 -i GoogleService-Info.plist | pbcopy
-# The base64 string is now in your clipboard
+# The encoded Firebase plist is now in your clipboard
 ```
 
-#### Step 3: Add to GitHub Secrets
+#### Step 3: Add the Firebase plist secret
 
 - Secret name: `GOOGLE_SERVICE_INFO_PLIST_BASE64`
 - Secret value: Paste from clipboard (should be a long string of letters and numbers)
@@ -107,16 +107,16 @@ base64 -i GoogleService-Info.plist | pbcopy
 # 7. Set a password (remember this for next step!)
 ```
 
-#### Step 2: Convert to Base64
+#### Step 2: Encode the distribution certificate
 
 ```bash
 # In Terminal:
 cd ~/Downloads  # or wherever you saved the .p12
 base64 -i Certificates.p12 | pbcopy
-# The base64 string is now in your clipboard
+# The encoded certificate is now in your clipboard
 ```
 
-#### Step 3: Add to GitHub Secrets
+#### Step 3: Add the certificate secret
 
 - Secret name: `FIREBASE_DEV_CERT`
 - Secret value: Paste from clipboard (should be a long string of letters and numbers)
@@ -146,15 +146,15 @@ base64 -i Certificates.p12 | pbcopy
 2. Find your **Ad Hoc** profile for `com.edwardwynman.Spot`
 3. Download it (will be named something like `Spot_AdHoc.mobileprovision`)
 
-#### Step 2: Convert to Base64
+#### Step 2: Encode the provisioning profile
 
 ```bash
 cd ~/Downloads  # or wherever you downloaded the profile
 base64 -i Spot_Distribution.mobileprovision | pbcopy
-# The base64 string is now in your clipboard
+# The encoded provisioning profile is now in your clipboard
 ```
 
-#### Step 3: Add to GitHub Secrets
+#### Step 3: Add the provisioning-profile secret
 
 - Secret name: `FIREBASE_PROVISIONING_PROFILE`
 - Secret value: Paste from clipboard

--- a/docs/engineering/image-moderation.md
+++ b/docs/engineering/image-moderation.md
@@ -10,7 +10,7 @@ Engineers, safety, review.
 
 ## Current status
 
-Postgres migration `20260504100000_image_moderation_azure_v1.sql` defines **`media_assets`**, Azure provider fields, and related policies. Client coordinates with Edge moderation and RPC publish.
+The Spot-image path is implemented through `supabase/functions/moderate-image/index.ts`. The profile-image schema exists, but the current iOS avatar uploader bypasses moderation; see the explicit gap below.
 
 ## Details
 
@@ -21,29 +21,46 @@ Postgres migration `20260504100000_image_moderation_azure_v1.sql` defines **`med
 ### Client responsibilities
 
 - Upload to pending storage only for new moderated assets.
-- Poll or await moderation completion per post-flow implementation.
+- Invoke the function with the owned `mediaAssetId` and await its response.
 - Show **safe** rejection messages when blocked.
 
 ### Server / function responsibilities
 
-- Call **Azure Content Safety** (or configured provider) with server-held credentials.
+- Validate the caller JWT and `media_assets.owner_id`.
+- Call **Azure Content Safety** with server-held credentials.
 - Persist scores and outcomes on `media_assets` / `media_moderation_events`.
+- Promote approved objects from pending to the appropriate approved bucket.
 - Gate final publish on approved status.
 
 ### Threshold policy
 
-Category thresholds may live in Edge Function code or SQL—**TODO: verify** in function source (repo path if mirrored, else dashboard).
+Default Azure severity thresholds use a 0–6 scale and block at or above:
+
+| Asset kind | Sexual | Violence | Hate | Self-harm |
+| --- | ---: | ---: | ---: | ---: |
+| `spot_image` | 4 | 4 | 4 | 4 |
+| `profile_image` | 2 | 4 | 4 | 4 |
+
+`MODERATION_THRESHOLDS_JSON` can override defaults in the deployed function environment. Policy changes require safety review and tests.
 
 ### Block / allow
 
 - **Blocked** — user sees non-graphic explanation; no public approved path.
 - **Allowed** — promote to approved bucket paths and allow RPC completion.
 
+The function returns JSON containing `approved: boolean`. Policy rejection returns HTTP 422. Provider, configuration, or Storage failures return retryable HTTP 503. The client intentionally maps these to non-graphic user messages.
+
+### Current profile-image gap
+
+`SupabaseUserService.uploadProfileAvatarJPEG` writes directly to the public `avatars` bucket. It does not create `media_assets`, invoke `moderate-image`, or use `approved_profile_images`.
+
+The product requirement remains that every profile image must be moderated, but that requirement is **not currently met**. Do not use the profile upload implementation as a pattern for new image flows.
+
 ### Logging
 
 Use `SpotLogger` moderation category and repository logs; avoid logging raw image bytes or PII.
 
-### Sequence (target architecture)
+### Sequence (implemented Spot-image path)
 
 ```mermaid
 sequenceDiagram
@@ -55,15 +72,26 @@ sequenceDiagram
   participant DB as Supabase DB
 
   User->>App: Selects image
-  App->>Function: Submit image for moderation
+  App->>DB: Insert owned pending media_assets row
+  App->>Storage: Upload to pending_images
+  App->>Function: Submit mediaAssetId with user JWT
+  Function->>DB: Verify owner and pending asset
+  Function->>Storage: Read pending object
   Function->>Azure: Analyze image
   Azure-->>Function: Category severities
-  Function-->>App: Approved or blocked
   alt Blocked
+    Function->>DB: Mark rejected and record event
+    Function->>Storage: Delete pending object
+    Function-->>App: 422 approved=false
     App->>User: Show safe rejection message
+  else Provider or storage failure
+    Function->>DB: Mark failed where possible
+    Function-->>App: 503 retryable failure
   else Approved
-    App->>Storage: Complete upload / promotion
-    App->>DB: Save profile or Spot via RPC
+    Function->>Storage: Promote to approved bucket
+    Function->>DB: Mark approved and record event
+    Function-->>App: 200 approved=true
+    App->>DB: Publish Spot via approved-assets RPC
   end
 ```
 
@@ -75,4 +103,6 @@ sequenceDiagram
 
 ## Open questions / TODOs
 
-- Exact category thresholds and copy strings: TODO: verify in Edge Function implementation.
+- Migrate profile avatars to the implemented moderation architecture.
+- Add cleanup for approved-but-unlinked and failed media.
+- Verify deployed threshold overrides separately in each Supabase environment.

--- a/docs/engineering/local-setup.md
+++ b/docs/engineering/local-setup.md
@@ -18,17 +18,18 @@ Verified against `Spot.xcodeproj` build settings (deployment target and Swift ve
 
 | Requirement | Notes |
 | --- | --- |
-| **macOS + Xcode** | Recent Xcode recommended; exact minimum: **TODO: verify** team standard. |
-| **iOS deployment target** | Project uses **17.0** for some targets and **18.5** for others in `project.pbxproj`—open Xcode to see the active app target deployment. |
+| **macOS + Xcode** | Use an Xcode version that supports the installed iOS simulator runtime and iOS 17 deployment target. CI uses `macos-15`; distribution workflows select or require Xcode 26. |
+| **iOS deployment target** | App and test targets use iOS 17.0; project-level settings also contain 18.5 values, so inspect the active target when changing deployment support. |
 | **Swift** | **5.0** in project settings. |
-| **Supabase** | Project URL and anon key live in **`Spot/Info.plist`** under the `Supabase` dictionary (copy from your Supabase dashboard for local dev—do not commit real keys to public forks). |
+| **Supabase** | Local DEBUG selects staging in `Spot/Supabase/Supabase.swift`. Release workflows inject `Info.plist` values. |
+| **Firebase** | A valid gitignored `GoogleService-Info.plist` is needed for normal Firebase initialization; CI injects it from secrets. |
 | **Apple Developer** | For device runs, push, Associated Domains, and Sign in with Apple as enabled for the bundle ID. |
 
 ### Clone and open
 
 ```sh
 git clone <repository-url>
-cd spot
+cd <cloned-repository-directory>
 open Spot.xcodeproj
 ```
 
@@ -66,4 +67,4 @@ See [troubleshooting.md](troubleshooting.md).
 
 ## Open questions / TODOs
 
-- Pin one canonical “minimum Xcode” version for the team: TODO: confirm with owner.
+- Pin one canonical local Xcode version when the team standardizes it; workflow requirements remain authoritative for distribution.

--- a/docs/engineering/notifications.md
+++ b/docs/engineering/notifications.md
@@ -1,244 +1,111 @@
 # Notifications
 
-**Owner**: Engineering  
-**Last Updated**: 2026-07-02
+## Purpose
 
-## Overview
+Document notification permission, delivery, action handling, and current production limitations.
 
-Spot implements a local notification system for social events, specifically follow requests and follow acceptances. Users are prompted to grant notification permissions after completing the first-run onboarding tour.
+## Audience
 
-## Architecture
+Engineering, product, QA, and operations.
 
-### Permission Request Flow
+## Current status
 
-1. User completes the first-run onboarding tour (all steps through `.finale`) **OR** skips the tour
-2. After 600ms delay, `BottomTabNavigationView` checks notification permission status
-3. If status is `.notDetermined`, presents `NotificationPermissionView` sheet
-4. User grants or denies permissions through the system dialog
-5. Permission status is tracked in `PermissionManager.notificationStatus`
+Spot registers UserNotifications categories and can schedule local notifications. It does **not** register for remote notifications, store APNs tokens, or have a push backend. Notification action events are posted but are not consumed by production navigation.
 
-**Important**: Notification permissions are requested regardless of whether the user completes or skips onboarding, ensuring all users have the opportunity to enable notifications.
+## Permission flow
 
-### Notification Service
+1. The user completes or skips `SpotFirstRunOnboardingManager`.
+2. After 600 ms, `BottomTabNavigationView` checks authorization.
+3. If status is `.notDetermined`, it presents `NotificationPermissionView`.
+4. `PermissionManager` requests system authorization and tracks the result.
 
-**Location**: `Spot/Services/NotificationService.swift`
+Permission is contextual and does not block authentication or the tab shell.
 
-The `NotificationService` singleton manages local notification delivery and action handling:
+## Registration and delivery
 
-- **Categories**:
-  - `FOLLOW_REQUEST` — New incoming follow request
-  - `FOLLOW_ACCEPTED` — Your follow request was accepted
+`AppDelegate.application(_:didFinishLaunchingWithOptions:)`:
 
-- **Actions**:
-  - Accept Follow Request (foreground)
-  - View Follow Request (foreground)
-  - View Profile (foreground)
+- calls `NotificationService.shared.registerNotificationCategories()`;
+- sets `UNUserNotificationCenter.current().delegate`;
+- shows banner, sound, and badge for foreground local notifications.
 
-### Notification Types
+Registered categories:
 
-#### Follow Request Accepted ✅
+| Category | Actions |
+| --- | --- |
+| `FOLLOW_REQUEST` | Accept, View |
+| `FOLLOW_ACCEPTED` | View profile |
 
-**Trigger**: When a user accepts another user's follow request  
-**Implementation**: Client-side local notification  
-**Status**: ✅ Implemented
+`NotificationService` contains helpers for follow-request-received and follow-accepted local notifications.
 
-When User B accepts User A's follow request:
-- `FollowRequestsService.accept()` is called
-- Service fetches User B's username from database
-- `NotificationService.notifyFollowRequestAccepted()` sends a local notification
-- User A receives: "Follow Request Accepted — [username] accepted your follow request"
+## Current behavior
 
-**Code Path**:
+### Follow request received
+
+The scheduling helper exists but has no call site when another user creates a request. The profile flow polls the pending-request count; it does not schedule a notification. Cross-device delivery requires a push backend.
+
+### Follow request accepted
+
+`FollowRequestsService.accept()` schedules a local “accepted” notification on the device performing the acceptance. That is the acceptor's device, not reliably the original requester's device. This is not a substitute for server-triggered push and should not be described as notifying the requester.
+
+## Action handling
+
+The `UNUserNotificationCenterDelegate` extension in `Spot/AppDelegate.swift` maps taps/actions to:
+
+- `.navigateToFollowRequests`;
+- `.navigateToFollowRequestsAndAccept`;
+- `.navigateToProfile`.
+
+No production view currently observes these events. Tapping an action foregrounds the app, but the intended navigation is not wired.
+
+## Security requirements for future push
+
+A production implementation needs:
+
+1. APNs registration and token rotation handling in the app.
+2. An RLS-protected device-token table keyed to the authenticated user and installation.
+3. Server-triggered delivery after authoritative database changes.
+4. Server-held APNs credentials; never a service-role or APNs private key in the client.
+5. Generic notification copy that does not expose private content on a lock screen.
+6. Token removal on sign-out/account deletion and invalid-token feedback handling.
+7. Navigation that revalidates auth, relationship, and content visibility rather than trusting payload IDs.
+
+## Flow
+
+```mermaid
+flowchart TD
+  A[Complete or skip first-run coach] --> B{Authorization undetermined?}
+  B -->|Yes| C[Show notification pre-prompt]
+  C --> D[Request system authorization]
+  B -->|No| E[Continue]
+  D --> E
+  F[Local notification action] --> G[AppDelegate maps action]
+  G --> H[Post navigation event]
+  H --> I[Known gap: no production consumer]
 ```
-FollowRequestsView (Accept button) 
-  → FollowRequestsService.accept()
-  → notifyFollowRequestAcceptedByCurrentUser()
-  → NotificationService.notifyFollowRequestAccepted()
-```
-
-#### Follow Request Received ⚠️
-
-**Trigger**: When a user receives a new follow request  
-**Implementation**: ⚠️ **Requires backend implementation**  
-**Status**: ⚠️ Infrastructure ready, but needs backend trigger
-
-**Current Limitation**: The client cannot detect when another user sends a follow request without:
-1. Polling the `follow_requests` table (inefficient, battery-draining)
-2. Real-time subscriptions (Supabase Realtime, but still client-initiated)
-3. Backend push notifications (proper solution)
-
-**Recommended Production Implementation**:
-
-Use Supabase Edge Functions or database triggers to send push notifications when a follow request is created:
-
-1. **Database Trigger** (PostgreSQL):
-```sql
-CREATE OR REPLACE FUNCTION notify_follow_request_received()
-RETURNS TRIGGER AS $$
-BEGIN
-  -- Call Edge Function to send push notification
-  PERFORM net.http_post(
-    url := 'https://[project].supabase.co/functions/v1/send-notification',
-    headers := jsonb_build_object('Authorization', 'Bearer [service_role_key]'),
-    body := jsonb_build_object(
-      'type', 'follow_request_received',
-      'target_user_id', NEW.target_user_id,
-      'requester_id', NEW.requester_id
-    )
-  );
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER on_follow_request_created
-  AFTER INSERT ON follow_requests
-  FOR EACH ROW
-  WHEN (NEW.status = 'pending')
-  EXECUTE FUNCTION notify_follow_request_received();
-```
-
-2. **Edge Function** (`supabase/functions/send-notification/index.ts`):
-```typescript
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
-
-serve(async (req) => {
-  const { type, target_user_id, requester_id } = await req.json()
-  
-  // Fetch requester username
-  const supabase = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  )
-  
-  const { data: requester } = await supabase
-    .from('users')
-    .select('username')
-    .eq('id', requester_id)
-    .single()
-  
-  // Fetch target user's push token (would need to be stored in database)
-  const { data: targetUser } = await supabase
-    .from('user_push_tokens')
-    .select('token')
-    .eq('user_id', target_user_id)
-    .single()
-  
-  if (!targetUser?.token) {
-    return new Response(JSON.stringify({ error: 'No push token' }), { status: 400 })
-  }
-  
-  // Send push notification via APNs (Apple Push Notification service)
-  // Implementation depends on push notification provider (e.g., Firebase, OneSignal, direct APNs)
-  
-  return new Response(JSON.stringify({ success: true }))
-})
-```
-
-3. **Client Setup**:
-   - Store device push token in `user_push_tokens` table after permission grant
-   - Register for remote notifications in `AppDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
-   - Handle remote notifications in `UNUserNotificationCenterDelegate` methods
-
-### Notification Actions
-
-#### App-Side Handling
-
-**Location**: `AppDelegate+UNUserNotificationCenterDelegate`
-
-When a user taps a notification or action button:
-
-1. `userNotificationCenter(_:didReceive:withCompletionHandler:)` is called
-2. Action identifier is matched to `NotificationService.NotificationAction` cases
-3. Navigation is triggered via `NotificationCenter` posts:
-   - `.navigateToFollowRequests` — Opens Follow Requests screen
-   - `.navigateToFollowRequestsAndAccept` — Opens Follow Requests and auto-accepts
-   - `.navigateToProfile` — Opens a specific user's profile
-
-#### Navigation Handling
-
-Navigation events are posted via `NotificationCenter.default.post()`. Consumers (e.g., `ProfileView`, `BottomTabNavigationView`) can observe these notifications and respond accordingly.
-
-**Example**:
-```swift
-.onReceive(NotificationCenter.default.publisher(for: .navigateToFollowRequests)) { _ in
-    // Switch to Profile tab and navigate to Follow Requests
-    selectedTab = 4
-    showFollowRequests = true
-}
-```
-
-## Security Considerations
-
-- Notification content never includes sensitive data (user IDs are in `userInfo`, not body)
-- All notification actions require foreground activation (user must unlock device)
-- Database RLS policies ensure users can only accept follow requests directed to them
-- Service-role keys must never be included in client-side code
-
-## Future Enhancements
-
-### Required for Production
-
-- [ ] Implement push notification backend (Edge Functions + APNs)
-- [ ] Store device push tokens in database
-- [ ] Handle remote notification registration in AppDelegate
-- [ ] Add database trigger for follow request creation
-- [ ] Add notification preferences UI (allow users to mute specific notification types)
-
-### Optional
-
-- [ ] Comment notifications (when commenting is implemented)
-- [ ] Batch notifications (e.g., "3 new follow requests")
-- [ ] Rich notifications with profile pictures
-- [ ] Notification history in-app
-- [ ] Notification sounds customization
 
 ## Testing
 
-### Manual Testing
+Current useful checks:
 
-1. **Permission Grant After Completing Onboarding**:
-   - Sign up for a new account
-   - Complete onboarding tour through all steps
-   - After finale, notification permission sheet should appear
-   - Grant permissions → verify `PermissionManager.notificationStatus == .authorized`
+- complete and skip onboarding paths both offer permission when undetermined;
+- category identifiers and action mappings remain stable;
+- foreground local delivery uses banner, sound, and badge;
+- denied authorization does not block app use.
 
-2. **Permission Grant After Skipping Onboarding**:
-   - Sign up for a new account
-   - Start onboarding tour
-   - Tap "Skip" button on any step
-   - After 600ms, notification permission sheet should appear
-   - Grant permissions → verify `PermissionManager.notificationStatus == .authorized`
+Do not write a test that claims the requester receives a follow-accepted notification until remote delivery exists. End-to-end action navigation should remain marked unavailable until consumers are wired.
 
-2. **Follow Request Accepted Notification**:
-   - User A sends follow request to User B (private account)
-   - User B accepts the request
-   - User A should receive local notification: "Follow Request Accepted — [User B username] accepted your follow request"
-   - Tap notification → should navigate to User B's profile
+## Known limitations
 
-3. **Notification Actions**:
-   - Long-press on a follow request notification
-   - Verify action buttons appear: "Accept", "View"
-   - Tap "Accept" → should navigate to Follow Requests screen
-   - Tap "View Profile" on follow accepted notification → should navigate to profile
+- Local notifications only; no APNs device-token registration or backend.
+- Follow-request-received helper has no trigger.
+- Follow-accepted local notification is scheduled on the wrong user's device for the intended social event.
+- Action navigation events have no production consumers.
+- No notification preference UI or notification history.
 
-### Automated Testing
+## Related docs
 
-Current test coverage:
-- ✅ `PermissionManager.requestNotificationPermission()` unit tests
-- ✅ Onboarding flow includes notification permission prompt
-- ❌ **Missing**: End-to-end UI tests for notification flow (requires simulator notification delivery)
-
-## Known Limitations
-
-1. **Follow Request Received Notifications**: Requires backend implementation (see above)
-2. **No Comment Notifications**: Commenting feature not yet implemented
-3. **No Like Notifications**: Intentionally excluded per product requirements
-4. **Local Notifications Only**: Production app should use remote push notifications for reliability and backend triggering
-
-## References
-
-- [Apple Human Interface Guidelines — Notifications](https://developer.apple.com/design/human-interface-guidelines/notifications)
-- [UserNotifications Framework](https://developer.apple.com/documentation/usernotifications)
-- [Supabase Edge Functions](https://supabase.com/docs/guides/functions)
-- [Apple Push Notification Service](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server)
+- [runtime-flows.md](runtime-flows.md)
+- [networking-and-auth.md](networking-and-auth.md)
+- [../product/onboarding.md](../product/onboarding.md)
+- [../product/profiles-and-social.md](../product/profiles-and-social.md)

--- a/docs/engineering/runtime-flows.md
+++ b/docs/engineering/runtime-flows.md
@@ -125,7 +125,7 @@ See the linked safety and feature docs before changing these paths.
 | Feed | `Spot/ViewModels/FeedViewModel.swift`, `Spot/Services/Feed/` |
 | Map | `Spot/ViewModels/MapViewModel.swift`, `Spot/Services/Map/`, `Spot/Views/Home/MapView.swift` |
 | Search | `Spot/ViewModels/SearchViewModel.swift`, `Spot/Services/Search/` |
-| Profile/social | `Spot/ViewModels/ProfileViewModel.swift`, `Spot/Services/ProfileService.swift`, `Spot/Services/FollowRequestsService.swift` |
+| Profile/social | `Spot/ViewModels/ProfileViewModel.swift`, `Spot/Views/Profile/ProfileService.swift`, `Spot/Services/FollowRequestsService.swift` |
 | Publish | `Spot/ViewModels/PostFlowViewModel.swift`, `Spot/Services/Spots/`, `Spot/Services/Supabase/SpotSupabaseRepository.swift` |
 | Deep links | `Spot/Services/DeepLinkRouter.swift`, `Spot/ViewModels/DeepLinkState.swift` |
 

--- a/docs/engineering/runtime-flows.md
+++ b/docs/engineering/runtime-flows.md
@@ -1,0 +1,139 @@
+# Runtime flows and source map
+
+## Purpose
+
+Provide a code-verified map of Spot's major runtime flows and the boundaries between SwiftUI, view models, services, Supabase, and platform integrations.
+
+## Audience
+
+Engineers, reviewers, QA, support, and Cursor agents.
+
+## Current status
+
+Verified against the repository on 2026-07-28. This is the concise system map; feature pages contain product detail and diagrams contain focused visual flows.
+
+## Application shell
+
+```mermaid
+flowchart TD
+  A[AppDelegate] --> B[Firebase observability, logging, notification categories]
+  B --> C[SpotApp branded launch screen]
+  C --> D[RootView]
+  D --> E{Auth state}
+  E -->|Loading| C
+  E -->|Pending verification| F[ConfirmEmailView]
+  E -->|Signed out| G[Welcome or WelcomeBack]
+  E -->|Signed in, unverified| F
+  E -->|Signed in, verified| H{Apple profile setup required?}
+  H -->|Yes| I[PostAuthSetupFlowView]
+  H -->|No| J[MainTabView]
+  I --> J
+  J --> K[Home]
+  J --> L[Map]
+  J --> M[Post]
+  J --> N[Search]
+  J --> O[Profile]
+```
+
+`SpotApp` owns `AuthViewModel`, wraps `DeepLinkState.shared`, and injects `PermissionManager.shared`. `RootView` owns the auth gate, tab shell, paywall sheets, subscription success, and deep-link Spot overlays. The updated-terms gate exists but is disabled by `RootView.isTermsUpdateGateEnabled`.
+
+## Shared state and cross-feature events
+
+| Boundary | Responsibility |
+| --- | --- |
+| `AuthViewModel` | Session-derived identity, verification, likes, bookmarks, blocks, and effective Pro state |
+| `SpotAuthBridge` | Minimal session identity bridge for non-SwiftUI gates such as deep links |
+| `DeepLinkState` | Pending route, Spot fetch, unavailable state, subscription return |
+| `PermissionManager` | Location, notification, photo, and camera authorization state |
+| `SpotPublishCoordinator` | Background publish state and global success/failure banner |
+| `NotificationCenter` events | Tab selection, paywall, publish completion, and immediate feed removal |
+
+Most services are shared singletons. Screen-owned view models use `@StateObject` and call typed service or repository boundaries.
+
+## Read flows
+
+| Surface | Runtime path | Pagination / cache |
+| --- | --- | --- |
+| Home | `HomepageView` → `FeedViewModel` → `FeedRepository` → `FeedAPI` → `get_home_feed_v1` | 24 rows; server impression dedupe, client dedupe; first-page `FeedDiversity` |
+| Map | `MapView` → `MapViewModel` → `MapViewportLoader` → `FeedAPI.get_map_spots_v1` | Viewport request; 250-pin cap; 60-second actor cache |
+| Search | `SearchView` → `SearchViewModel` → `SearchService` → `SpotSearchDataSource` / repository | 24-row offset pages for Spot grids |
+| Profile | `ProfileView` → `ProfileViewModel` → `ProfileService` / `UserSpotService` | Visibility check before loading private-author Spots |
+| Deep-link Spot | `AppDelegate` or `RootView` → `DeepLinkRouter` → `DeepLinkState` → `SpotService` | Pending while signed out; duplicate-route debounce |
+
+All application data reads use Supabase. RLS and server visibility functions are authoritative; `AuthorPrivacyCache` is an additive client-side filter.
+
+## Spot presentation
+
+There is no dedicated `SpotDetailView`. `SpotCard` is the shared detail presentation:
+
+- inline in the home feed;
+- inside the map spot drawer through `MapSpotPreviewCard`;
+- selected from Search or profile grids;
+- full-screen over the tab shell for deep links.
+
+`SpotImageGallery` lazily fetches and signs the full image set after the primary image is shown.
+
+## Write and safety flows
+
+```mermaid
+flowchart LR
+  A[Authenticated, verified composer] --> B[PostFlowViewModel]
+  B --> C[Persist local draft]
+  C --> D[SpotPublishCoordinator]
+  D --> E[media_assets pending row]
+  E --> F[pending_images upload]
+  F --> G[moderate-image Edge Function]
+  G --> H{Approved?}
+  H -->|No| I[Safe failure message]
+  H -->|Yes| J[publish_spot_with_approved_media_assets_v1]
+  J --> K[Optimistic home insertion]
+```
+
+Reporting uses `submit_content_report`. Blocking from current UI paths inserts into `user_blocks`; database triggers create the audit event and visibility functions remove blocked authors. Account deletion reauthenticates, performs best-effort client storage cleanup, then calls `delete_my_account`.
+
+## Platform integrations
+
+| System | Current role |
+| --- | --- |
+| Supabase | Auth, Postgres, RLS, Storage, Edge Functions, application data |
+| Firebase | Analytics and Crashlytics initialization; App Check is linked but not initialized in app code |
+| StoreKit 2 | `spotPro` purchase, restore, and transaction updates |
+| MapKit / Core Location | Map rendering, viewport discovery, location permission |
+| UserNotifications | Permission and local notification categories; remote push is not implemented |
+| Azure Content Safety | Server-side Spot-image analysis through `moderate-image` |
+
+## Verified known limitations
+
+These are implementation gaps, not target behavior:
+
+- Profile avatars currently upload directly to the public `avatars` bucket and do not use the moderation pipeline.
+- Home-feed batch signing assumes the legacy `spots` bucket while newer media records can use `approved_spot_images`.
+- Failed or timed-out multi-image publishes can leave unlinked approved assets; draft recovery copy can overstate recoverability.
+- Notification actions post navigation events, but no production view consumes those events.
+- The Pro map "Following" filter currently receives an empty followed-user ID set.
+- Base SQL definitions for some production feed/map RPCs are not fully represented in repository migrations.
+
+See the linked safety and feature docs before changing these paths.
+
+## Source index
+
+| Concern | Primary paths |
+| --- | --- |
+| Launch and root gate | `Spot/SpotApp.swift`, `Spot/AppDelegate.swift`, `Spot/Views/RootView.swift` |
+| Tab shell | `Spot/Views/MainTabView.swift`, `Spot/Views/Components/BottomTabNavigationView.swift` |
+| Auth | `Spot/Services/Auth/AuthViewModel.swift`, `Spot/Services/AuthService.swift` |
+| Feed | `Spot/ViewModels/FeedViewModel.swift`, `Spot/Services/Feed/` |
+| Map | `Spot/ViewModels/MapViewModel.swift`, `Spot/Services/Map/`, `Spot/Views/Home/MapView.swift` |
+| Search | `Spot/ViewModels/SearchViewModel.swift`, `Spot/Services/Search/` |
+| Profile/social | `Spot/ViewModels/ProfileViewModel.swift`, `Spot/Services/ProfileService.swift`, `Spot/Services/FollowRequestsService.swift` |
+| Publish | `Spot/ViewModels/PostFlowViewModel.swift`, `Spot/Services/Spots/`, `Spot/Services/Supabase/SpotSupabaseRepository.swift` |
+| Deep links | `Spot/Services/DeepLinkRouter.swift`, `Spot/ViewModels/DeepLinkState.swift` |
+
+## Related docs
+
+- [architecture.md](architecture.md)
+- [data-plane.md](data-plane.md)
+- [networking-and-auth.md](networking-and-auth.md)
+- [storage-and-media.md](storage-and-media.md)
+- [../product/user-flows.md](../product/user-flows.md)
+- [../diagrams/README.md](../diagrams/README.md)

--- a/docs/engineering/storage-and-media.md
+++ b/docs/engineering/storage-and-media.md
@@ -10,7 +10,7 @@ Engineers working on posts, profiles, or moderation.
 
 ## Current status
 
-Bucket names and `media_assets` schema are defined in **`supabase/migrations/20260504100000_image_moderation_azure_v1.sql`**. Client constants in `SpotSupabaseRepository` include **`pending_images`**.
+Verified against the moderation migration, `SpotSupabaseRepository`, `FeedAPI`, `SpotImageGallery`, and `SupabaseUserService` on 2026-07-28.
 
 ## Details
 
@@ -20,25 +20,34 @@ Bucket names and `media_assets` schema are defined in **`supabase/migrations/202
 | --- | --- | --- |
 | `pending_images` | Private | New uploads awaiting moderation |
 | `approved_spot_images` | Private | Approved Spot imagery |
-| `approved_profile_images` | Private | Approved profile photos |
+| `approved_profile_images` | Private | Intended approved profile photos; not used by current iOS upload path |
+| `spots` | Private | Legacy Spot imagery and the bucket assumed by home-feed batch signing |
+| `avatars` | Public | Current legacy profile avatar upload path |
 
 ### Spot media flow (summary)
 
-1. Client uploads to **pending** path and creates/updates **`media_assets`** rows.
-2. **Edge Function** `moderate-image` (per code comments) runs moderation.
-3. On approval, assets move to **approved** buckets; Spot publish may use RPC **`publish_spot_with_approved_media_assets_v1`**.
+1. Client inserts an owned **pending** `media_assets` row.
+2. Client uploads bytes to the user's folder in `pending_images`.
+3. Client invokes **`moderate-image`** with the media asset ID.
+4. The Edge Function analyzes the image and, on approval, promotes it to `approved_spot_images`.
+5. The client passes approved asset IDs to **`publish_spot_with_approved_media_assets_v1`**.
 
 ### Profile photos
 
-Same `media_assets` model with `kind = 'profile_image'` (see migration check constraint).
+The schema supports `kind = 'profile_image'` and `approved_profile_images`, but current iOS code does not use that path. `SupabaseUserService.uploadProfileAvatarJPEG` uploads directly to the public `avatars/{userId}/profile.jpg` path and returns a public URL.
+
+This is a security and App Review gap. New profile-image work must migrate the client to pending upload, server moderation, and approved private storage; do not describe the current direct upload as compliant.
 
 ### Signed URLs
 
-Feed and image views use signing paths from repository helpers—**TODO: verify** exact signing RPC or storage API used in `SpotSupabaseRepository` / `FeedRepository`.
+- Repository, profile, map, Search, optimistic-publish, and lazy gallery paths read `spot_images.storage_bucket` and create seven-day signed URLs.
+- Home-feed batch signing currently calls `createSignedURLs` on `spots` for all rows. Moderated rows can live in `approved_spot_images`, so the feed requires a bucket-aware RPC/result contract or grouped signing.
 
 ### Failed publishes
 
-Orphan pending objects and `media_assets` statuses (`failed`, `rejected`) should be handled per policy—**TODO: verify** cleanup jobs or client retry semantics.
+There is no repository-defined scheduled cleanup for pending, failed, rejected, or approved-but-unlinked assets. A partial multi-image failure can leave approved unlinked assets.
+
+Account deletion performs best-effort client cleanup for `avatars` and `spots`; it does not enumerate `pending_images`, `approved_spot_images`, or `approved_profile_images`. The database RPC deletes `media_assets` rows, but Storage objects are not database rows and may remain.
 
 ## Related docs
 
@@ -47,4 +56,7 @@ Orphan pending objects and `media_assets` statuses (`failed`, `rejected`) should
 
 ## Open questions / TODOs
 
-- Document retention policy for rejected pending files: TODO: verify in migrations or ops runbooks.
+- Define and implement retention/garbage collection for unlinked media and all moderation statuses.
+- Make feed signing bucket-aware.
+- Route profile avatars through the moderation pipeline.
+- Extend account-deletion Storage cleanup to all owned buckets.

--- a/docs/engineering/supabase-environment-setup-guide.md
+++ b/docs/engineering/supabase-environment-setup-guide.md
@@ -1,454 +1,185 @@
-# Supabase Environment Setup Guide
+# Supabase environment setup guide
 
 ## Purpose
 
-Step-by-step instructions for setting up the two-environment Supabase strategy (staging + production) as implemented in the codebase.
+Runbook for validating or recreating Spot's staging and production Supabase environments without exposing credentials.
 
 ## Audience
 
-Repository administrators, infrastructure owners, and engineers completing the environment strategy implementation.
+Repository administrators, infrastructure owners, and release engineers.
 
-## Current Status
+## Current status
 
-**Code is implemented** — Swift environment selection and CI/CD credential injection are ready. This guide covers the remaining manual setup steps:
-1. Create the production Supabase project
-2. Replicate schema and data
-3. Configure GitHub secrets
+Both project routes exist in code:
 
----
+| Environment | Project ref | Build lane |
+| --- | --- | --- |
+| Staging | `aeurigbbohyxvtsfiyul` | Local DEBUG and Firebase App Distribution |
+| Production | `gomdoguewaawdlvijahg` | TestFlight and App Store |
 
-## Overview
+This repository does not prove deployed schema parity, Edge Function deployment, Auth provider settings, backups, or secret presence. Validate those items in the Supabase and GitHub dashboards.
 
-The codebase now supports two Supabase environments:
+## Prerequisites
 
-| Environment | Build Type | Branch | Supabase Project | Status |
-|-------------|-----------|--------|------------------|--------|
-| **Staging** | Firebase App Distribution | `main` | Current project (`aeurigbbohyxvtsfiyul`) | ✅ Ready (current project) |
-| **Production** | TestFlight / App Store | `release/**` | New project (to be created) | ⚠️ Needs setup |
+- Supabase access to both projects.
+- GitHub repository access to manage Actions secrets.
+- Supabase MCP authentication for applying reviewed migrations.
+- Apple/Firebase signing configuration appropriate to the distribution lane.
 
-### How It Works
+Never copy service-role, Azure, database-password, or private signing values into the repository, terminal transcript, issue, or PR.
 
-**DEBUG builds (local development, simulators)**:
-- Use `#if DEBUG` to select staging environment
-- Connect to current Supabase project (`aeurigbbohyxvtsfiyul`)
-- Configuration hardcoded in `SupabaseEnvironment.swift`
+## 1. Validate client routing
 
-**RELEASE builds (CI/CD for Firebase and TestFlight)**:
-- GitHub Actions inject credentials into `Info.plist` before building
-- Firebase builds (`deploy.yml`) inject staging credentials
-- TestFlight builds (`testflight.yml`) inject production credentials
-- Production builds **require** GitHub secrets to be configured
+The environment enum and configuration loader are in [`Spot/Supabase/Supabase.swift`](../../Spot/Supabase/Supabase.swift).
 
----
+- DEBUG must select `.staging`.
+- Release must prefer a complete `Supabase` dictionary from `Info.plist`.
+- Firebase workflow injection must target staging.
+- TestFlight workflow injection must target production and fail if required values are missing.
 
-## Step 1: Create Production Supabase Project
+Review:
 
-### 1.1 Create New Project
+- [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
+- [`.github/workflows/testflight.yml`](../../.github/workflows/testflight.yml)
+- [`Spot/Info.plist`](../../Spot/Info.plist)
 
-1. Go to [Supabase Dashboard](https://supabase.com/dashboard)
-2. Click **New Project**
-3. Configure:
-   - **Name**: `Spot Production` (or similar)
-   - **Database Password**: Generate a strong password (save in secure location)
-   - **Region**: Same region as staging for consistency (check current project settings)
-   - **Organization**: Same organization as current project (`mdnqvdzrrhjtaxbwnleq`)
-4. Wait for project provisioning (2-3 minutes)
+Do not add a second environment selector or a separate `SupabaseEnvironment.swift`.
 
-### 1.2 Record Project Details
+## 2. Configure GitHub Actions
 
-After creation, save these values:
+### Firebase / staging lane
 
-```
-Project ID: ____________________  (e.g., abcdefghijklmnopqrst)
-Project URL: https://______________________.supabase.co
-Anon/Publishable Key: sb_publishable_____________________
-Service Role Key: sb_service_role_______________________  (DO NOT add to repo or client)
-```
+| Secret | Requirement |
+| --- | --- |
+| `SUPABASE_STAGING_URL` | Optional workflow override |
+| `SUPABASE_STAGING_ANON_KEY` | Optional workflow override |
 
-**⚠️ Security**: Only the **Anon/Publishable Key** goes in GitHub secrets. Never commit or ship the service role key.
+The workflow validates the staging project URL before archive.
 
----
+### TestFlight / production lane
 
-## Step 2: Replicate Schema to Production
+| Secret | Requirement |
+| --- | --- |
+| `SUPABASE_PRODUCTION_URL` | Required |
+| `SUPABASE_PRODUCTION_ANON_KEY` | Required |
 
-### 2.1 Export Current Schema
+These are publishable client values. Data protection still depends on Auth, RLS, grants, and safe RPC definitions. Never configure a service-role key in an iOS build secret.
 
-From the workspace root:
+## 3. Apply schema changes
 
-```bash
-cd /workspace
+Migrations live under [`supabase/migrations/`](../../supabase/migrations/).
 
-# Export schema from staging project
-# Option A: Using Supabase CLI (if linked)
-supabase db dump --linked > /tmp/staging-schema.sql
+1. Review SQL for idempotency, RLS, grants, and rollback impact.
+2. Resolve the staging project with the Supabase MCP.
+3. Apply the migration to staging using `apply_migration`.
+4. Run focused staging tests.
+5. Resolve the production project and apply the same reviewed migration.
+6. Compare migration history and affected objects.
 
-# Option B: Using pg_dump directly (requires connection string)
-# Get connection string from Supabase dashboard → Database → Connection String
-pg_dump "postgresql://..." > /tmp/staging-schema.sql
-```
+Agents must follow the repository rule requiring MCP application. Do not treat a committed SQL file as deployed.
 
-### 2.2 Apply Migrations to Production
+### Minimum parity query set
 
-**Recommended approach**: Apply migrations in order to maintain history.
-
-```bash
-# Link CLI to production project
-supabase link --project-ref YOUR_PRODUCTION_PROJECT_ID
-
-# Apply each migration file in order
-for migration in supabase/migrations/*.sql; do
-  echo "Applying $migration..."
-  supabase db push --db-url "YOUR_PRODUCTION_DB_CONNECTION_STRING" < "$migration"
-done
-```
-
-**Alternative**: Import full schema dump (loses migration history):
-
-```bash
-psql "YOUR_PRODUCTION_DB_CONNECTION_STRING" < /tmp/staging-schema.sql
-```
-
-### 2.3 Verify Schema Parity
-
-Run these checks on both staging and production:
+Run in each project through an authenticated administrative channel:
 
 ```sql
--- Check table count
-SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';
+select version, name
+from supabase_migrations.schema_migrations
+order by version;
 
--- Check RLS enabled
-SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname = 'public';
+select tablename, rowsecurity
+from pg_tables
+where schemaname = 'public'
+order by tablename;
 
--- Check policies
-SELECT schemaname, tablename, policyname FROM pg_policies WHERE schemaname = 'public';
+select schemaname, tablename, policyname
+from pg_policies
+where schemaname in ('public', 'storage')
+order by schemaname, tablename, policyname;
 
--- Check functions
-SELECT routine_name FROM information_schema.routines WHERE routine_schema = 'public';
+select routine_name
+from information_schema.routines
+where routine_schema = 'public'
+order by routine_name;
 ```
 
-Compare results between environments. They should be identical.
+Use counts and object definitions for parity; never export production user rows to staging.
 
----
+## 4. Validate Storage
 
-## Step 3: Configure Storage Buckets
+Expected buckets include:
 
-### 3.1 Create Buckets in Production
+| Bucket | Visibility | Current use |
+| --- | --- | --- |
+| `pending_images` | Private | Pre-moderation uploads |
+| `approved_spot_images` | Private | Approved modern Spot images |
+| `approved_profile_images` | Private | Intended approved profile images; client not wired |
+| `spots` | Private | Legacy Spot image paths |
+| `avatars` | Public | Legacy/current profile avatar path |
 
-In the Supabase dashboard for your **production project**:
+Apply Storage policies through migrations. Verify an authenticated user can only upload a pending object under their own folder and cannot write an approved bucket.
 
-1. Go to **Storage**
-2. Create these buckets:
+## 5. Deploy and validate `moderate-image`
 
-| Bucket ID | Public | File Size Limit | Allowed MIME Types |
-|-----------|--------|-----------------|-------------------|
-| `pending_images` | Private | 5 MB | `image/jpeg`, `image/png`, `image/webp` |
-| `approved_spot_images` | Private | 5 MB | `image/jpeg`, `image/png`, `image/webp` |
-| `approved_profile_images` | Private | 5 MB | `image/jpeg`, `image/png`, `image/webp` |
-| `spots` | Private | 5 MB | `image/jpeg`, `image/png`, `image/webp` |
+The function source is [`supabase/functions/moderate-image/`](../../supabase/functions/moderate-image/).
 
-### 3.2 Apply Storage Policies
+Configure server-side secrets independently in each project:
 
-Storage RLS policies are defined in migration `20260504100000_image_moderation_azure_v1.sql`. Verify they were applied when you replicated the schema.
+- `AZURE_CONTENT_SAFETY_ENDPOINT`
+- `AZURE_CONTENT_SAFETY_KEY`
+- optional `AZURE_CONTENT_SAFETY_API_VERSION`
+- optional `MODERATION_THRESHOLDS_JSON`
 
-Check via dashboard or SQL:
+The Supabase runtime provides its own URL and service-role context. Do not expose those values to the app.
 
-```sql
-SELECT bucket_id, name FROM storage.policies;
-```
+Validate with an authenticated test user:
 
----
+1. Create an owned pending `media_assets` row.
+2. Upload a safe image to the user's `pending_images` folder.
+3. Invoke `moderate-image`.
+4. Confirm an approved response promotes the object and records the moderation result.
+5. Confirm a policy rejection returns 422 and a provider/config failure returns retryable 503.
 
-## Step 4: Deploy Edge Functions to Production
+Repeat deliberately for each environment; function deployments are project-specific.
 
-### 4.1 Deploy moderate-image Function
+## 6. Validate Auth and URLs
 
-```bash
-cd /workspace
+For each project, review:
 
-# Link to production project
-supabase link --project-ref YOUR_PRODUCTION_PROJECT_ID
+- email/password and Sign in with Apple provider settings;
+- confirmation and redirect URLs;
+- SMTP/email templates and rate limits;
+- Universal Link and custom-scheme return URLs;
+- account deletion and session refresh behavior.
 
-# Deploy the function
-supabase functions deploy moderate-image
-```
+Use environment-specific accounts. A staging account should not authenticate against production and vice versa.
 
-### 4.2 Configure Function Secrets
+## 7. Smoke-test matrix
 
-The `moderate-image` function requires Azure Content Safety credentials.
+| Flow | Staging | Production |
+| --- | --- | --- |
+| Email signup, OTP, login, logout | Required | Focused release smoke |
+| Sign in with Apple | Required before release | Focused release smoke |
+| Feed, map, Search, profile | Required | Read-only smoke |
+| Private profile and block visibility | Required | As needed with controlled accounts |
+| Moderated Spot publish | Required | One controlled release smoke |
+| Profile avatar | Verify current legacy path and known moderation gap | Avoid changing during smoke |
+| Pro entitlement / StoreKit return | Sandbox | TestFlight sandbox |
+| Deep-linked Spot | Required | Required |
 
-In Supabase dashboard → **Edge Functions** → **moderate-image** → **Settings**:
+## 8. Failure and rollback
 
-Add these secrets (get values from Azure portal):
+- If a build embeds the wrong project, stop distribution immediately and follow incident response.
+- If a migration fails in staging, fix it with a new reviewed migration before production.
+- If production migration partially applies, capture the exact applied state and prefer a forward fix.
+- If moderation fails, do not bypass the approval gate; restore function/secrets or pause publishing.
+- If schema parity is uncertain, do not promote the release.
 
-```
-AZURE_CONTENT_SAFETY_ENDPOINT=https://your-endpoint.cognitiveservices.azure.com/
-AZURE_CONTENT_SAFETY_KEY=your-azure-key-here
-```
+## Related docs
 
-**Note**: You can use the same Azure endpoint for both staging and production, or create separate endpoints for isolation.
-
-### 4.3 Test Edge Function
-
-```bash
-# Test invocation (requires auth)
-curl -X POST \
-  "https://YOUR_PRODUCTION_PROJECT_ID.supabase.co/functions/v1/moderate-image" \
-  -H "Authorization: Bearer YOUR_ANON_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"test": true}'
-```
-
----
-
-## Step 5: Configure GitHub Secrets
-
-### 5.1 Navigate to Repository Secrets
-
-1. Go to GitHub repository: `https://github.com/Ewynman/spot-ios-app`
-2. Click **Settings** → **Secrets and variables** → **Actions**
-3. Click **New repository secret**
-
-### 5.2 Add Staging Secrets (Optional)
-
-These are optional since staging uses hardcoded values as a fallback:
-
-| Secret Name | Value | Description |
-|-------------|-------|-------------|
-| `SUPABASE_STAGING_URL` | `https://aeurigbbohyxvtsfiyul.supabase.co` | Current project URL |
-| `SUPABASE_STAGING_ANON_KEY` | `sb_publishable_5IKZU3dDw6C0-V9lRPc7vw_z_v8a08G` | Current project anon key |
-
-### 5.3 Add Production Secrets (Required)
-
-These are **required** for TestFlight builds to work:
-
-| Secret Name | Value | Description |
-|-------------|-------|-------------|
-| `SUPABASE_PRODUCTION_URL` | `https://YOUR_PROD_PROJECT_ID.supabase.co` | New production project URL |
-| `SUPABASE_PRODUCTION_ANON_KEY` | `sb_publishable_YOUR_PROD_ANON_KEY` | New production project anon key |
-
-**⚠️ Critical**: TestFlight builds will **fail** if these secrets are not set. The workflow intentionally blocks production builds without valid credentials.
-
-### 5.4 Verify Secret Configuration
-
-Secrets should look like this in GitHub:
-
-```
-✅ GOOGLE_SERVICE_INFO_PLIST_BASE64
-✅ FIREBASE_DEV_CERT
-✅ FIREBASE_PROVISIONING_PROFILE
-✅ TESTFLIGHT_APPLE_CERT
-✅ TESTFLIGHT_APPLE_PROFILE
-✅ APP_STORE_CONNECT_API_KEY_ID
-✅ APP_STORE_CONNECT_API_ISSUER_ID
-✅ APP_STORE_CONNECT_API_KEY_P8_BASE64
-✅ SUPABASE_STAGING_URL (optional)
-✅ SUPABASE_STAGING_ANON_KEY (optional)
-✅ SUPABASE_PRODUCTION_URL (required)
-✅ SUPABASE_PRODUCTION_ANON_KEY (required)
-```
-
----
-
-## Step 6: Update Code Configuration (Optional)
-
-### 6.1 Update SupabaseEnvironment.swift
-
-If you want to hardcode the production URL (not recommended for security), update:
-
-```swift
-// File: Spot/Utils/SupabaseEnvironment.swift
-
-case .production:
-    return "https://YOUR_ACTUAL_PRODUCTION_PROJECT_ID.supabase.co"
-```
-
-**However**, it's better to leave placeholders and rely on CI/CD injection for production builds.
-
----
-
-## Step 7: Test the Configuration
-
-### 7.1 Test Staging Build (Firebase)
-
-1. Make a test commit to `main` branch
-2. Wait for GitHub Actions workflow to complete
-3. Check workflow logs for:
-   ```
-   ✅ Using Supabase staging credentials from GitHub secrets
-   ✅ Supabase staging configuration injected into Info.plist
-   ```
-4. Download the Firebase App Distribution build
-5. Install and verify app connects to staging Supabase
-
-### 7.2 Test Production Build (TestFlight)
-
-1. Create a test `release/1.0.0` branch (or use existing)
-2. Push a commit to trigger the workflow
-3. Check workflow logs for:
-   ```
-   ✅ Using Supabase production credentials from GitHub secrets
-   ✅ Supabase production configuration injected into Info.plist
-   ```
-4. Wait for TestFlight processing
-5. Install TestFlight build and verify it connects to production Supabase
-
-### 7.3 Test Local DEBUG Build
-
-1. Open project in Xcode
-2. Build and run in simulator (DEBUG configuration)
-3. Check console logs:
-   ```
-   🔧 Supabase Environment: Staging
-   🔧 Supabase URL: https://aeurigbbohyxvtsfiyul.supabase.co
-   ```
-4. Verify app functionality with staging database
-
----
-
-## Step 8: Seed Production Data (Optional)
-
-If you want to migrate existing user data from staging to production:
-
-⚠️ **Warning**: Only do this if staging contains real user data you want to preserve. For most cases, start with an empty production database.
-
-### 8.1 Export Data from Staging
-
-```sql
--- Export users (passwords are hashed, safe to copy)
-COPY (SELECT * FROM auth.users) TO '/tmp/users.csv' WITH CSV HEADER;
-COPY (SELECT * FROM public.users) TO '/tmp/public_users.csv' WITH CSV HEADER;
-
--- Export spots and related data
-COPY (SELECT * FROM public.spots) TO '/tmp/spots.csv' WITH CSV HEADER;
-COPY (SELECT * FROM public.spot_images) TO '/tmp/spot_images.csv' WITH CSV HEADER;
--- ... repeat for other tables
-```
-
-### 8.2 Import to Production
-
-```sql
-COPY auth.users FROM '/tmp/users.csv' WITH CSV HEADER;
-COPY public.users FROM '/tmp/public_users.csv' WITH CSV HEADER;
--- ... repeat for other tables
-```
-
-### 8.3 Verify Data Integrity
-
-```sql
--- Check record counts match
-SELECT 'users', count(*) FROM public.users
-UNION ALL
-SELECT 'spots', count(*) FROM public.spots
-UNION ALL
-SELECT 'follows', count(*) FROM public.follows;
-```
-
----
-
-## Step 9: Monitor Production
-
-### 9.1 Enable Monitoring
-
-In production Supabase project:
-- Enable **Realtime** → Monitor subscriptions
-- Check **Logs** → Enable log retention
-- Configure **Usage** → Set up billing alerts
-
-### 9.2 Monitor After First Production Release
-
-After the first TestFlight build using production:
-- Check **Auth** → Users (should see new signups in production only)
-- Check **Database** → Tables (production should remain separate from staging)
-- Check **Storage** → Buckets (uploads should go to production buckets)
-- Check **API** → Logs (verify no errors)
-
----
-
-## Rollback Plan
-
-If production environment has issues:
-
-### Quick Rollback (Emergency)
-
-1. Update GitHub secrets to point production to staging temporarily:
-   ```
-   SUPABASE_PRODUCTION_URL → https://aeurigbbohyxvtsfiyul.supabase.co
-   SUPABASE_PRODUCTION_ANON_KEY → sb_publishable_5IKZU3dDw6C0-V9lRPc7vw_z_v8a08G
-   ```
-2. Rebuild and redeploy TestFlight
-
-### Full Rollback (Revert Implementation)
-
-1. Revert these files to previous versions:
-   - `Spot/Utils/SupabaseEnvironment.swift` (delete)
-   - `Spot/Supabase/Supabase.swift` (restore old version)
-   - `.github/workflows/deploy.yml` (remove Supabase injection step)
-   - `.github/workflows/testflight.yml` (remove Supabase injection step)
-2. Commit and push
-3. Both environments will use the same Supabase project again
-
----
-
-## Troubleshooting
-
-### Problem: TestFlight build fails with "Production Supabase credentials are not configured"
-
-**Solution**: Add `SUPABASE_PRODUCTION_URL` and `SUPABASE_PRODUCTION_ANON_KEY` to GitHub secrets.
-
-### Problem: Local DEBUG build crashes with "Supabase configuration error"
-
-**Solution**: Ensure `SupabaseEnvironment.swift` has valid staging credentials (not PLACEHOLDER values).
-
-### Problem: App connects to wrong environment
-
-**Check**:
-- DEBUG builds → Should use staging (hardcoded in `SupabaseEnvironment.swift`)
-- Firebase builds → Should use staging (check `deploy.yml` logs)
-- TestFlight builds → Should use production (check `testflight.yml` logs)
-
-**Debug**:
-```swift
-// Add temporary logging to see which URL is being used
-print("Supabase URL: \(supabase.supabaseURL)")
-```
-
-### Problem: Schema drift between environments
-
-**Fix**:
-```bash
-# Compare schemas
-supabase db diff --linked --schema public
-
-# If differences found, apply missing migrations to the outdated environment
-```
-
----
-
-## Related Documentation
-
-- [docs/engineering/supabase-environment-strategy.md](supabase-environment-strategy.md) — Full PRD and strategy
-- [docs/engineering/supabase.md](supabase.md) — Supabase integration overview
-- [docs/engineering/database-and-rls.md](database-and-rls.md) — Database and RLS policies
-- [docs/engineering/environment-variables.md](environment-variables.md) — Configuration secrets
-
----
-
-## Completion Checklist
-
-- [ ] Production Supabase project created
-- [ ] Schema replicated from staging to production
-- [ ] Storage buckets configured in production
-- [ ] Edge Functions deployed to production
-- [ ] Azure credentials configured for production Edge Function
-- [ ] GitHub secrets added (staging optional, production required)
-- [ ] Firebase build tested (uses staging)
-- [ ] TestFlight build tested (uses production)
-- [ ] Local DEBUG build tested (uses staging)
-- [ ] Production monitoring enabled
-- [ ] Team trained on new environment strategy
-
----
-
-**Status**: Ready for implementation  
-**Last Updated**: 2026-07-06  
-**Implemented By**: Cursor Agent
+- [supabase-environment-strategy.md](supabase-environment-strategy.md)
+- [environment-variables.md](environment-variables.md)
+- [database-and-rls.md](database-and-rls.md)
+- [image-moderation.md](image-moderation.md)
+- [ci-cd.md](ci-cd.md)
+- [../operations/incident-response.md](../operations/incident-response.md)

--- a/docs/engineering/supabase-environment-strategy.md
+++ b/docs/engineering/supabase-environment-strategy.md
@@ -1,835 +1,128 @@
-# Supabase Environment Strategy: Production and Non-Production Split
+# Supabase environment strategy
 
 ## Purpose
 
-Define the strategy for splitting Spot's Supabase backend into separate **production** and **non-production** environments, ensuring data isolation between TestFlight releases and internal testing builds.
+Define Spot's implemented staging/production split, build routing, migration policy, and safety invariants.
 
 ## Audience
 
-Engineering team, infrastructure owners, release managers, and Cursor agents implementing the environment split.
+Engineering, infrastructure owners, release managers, and Cursor agents.
 
-## Quick Reference
+## Current status
 
-| Item | Current State | Target State |
-|------|--------------|--------------|
-| **Supabase Projects** | 2 isolated projects | Keep staging and production isolated |
-| **Firebase Builds (main)** | Use staging Supabase | Keep using staging Supabase |
-| **TestFlight Builds (release/**)** | Use production Supabase | Keep using production Supabase |
-| **Config Method** | Injected by GitHub Actions with guarded fallbacks | Keep project-ID artifact checks |
-| **Schema Migrations** | Applied directly to production | Test in staging first, then production |
-| **Data Isolation** | None (shared database) | Complete (separate databases) |
-| **Implementation Status** | Not started | [See Phase 1](#phase-1-project-setup-week-1) |
+**Environment routing is implemented.** Verified against `Spot/Supabase/Supabase.swift`, `.github/workflows/deploy.yml`, and `.github/workflows/testflight.yml` on 2026-07-28.
 
-## Before You Begin
+| Environment | Project ref | Used by | Configuration |
+| --- | --- | --- | --- |
+| Staging | `aeurigbbohyxvtsfiyul` | Local DEBUG, Firebase App Distribution from `main` | DEBUG enum defaults or staging workflow injection |
+| Production | `gomdoguewaawdlvijahg` | TestFlight / App Store from `release/**` | Required GitHub Actions secrets injected into `Info.plist` |
 
-### Prerequisites
+The projects have isolated Auth, Postgres, Storage, and Edge Function deployments. Test data must never be copied into production.
 
-- [ ] Access to Supabase dashboard with permission to create new projects
-- [ ] GitHub repository admin access to add secrets
-- [ ] Supabase MCP server configured (for migration management)
-- [ ] Understand current CI/CD workflows ([deploy.yml](.github/workflows/deploy.yml), [testflight.yml](.github/workflows/testflight.yml))
-- [ ] Review current Supabase configuration in [Info.plist](Spot/Info.plist) and [Supabase.swift](Spot/Supabase/Supabase.swift)
+## Decision
 
-### Key Files to Review
+Spot uses two Supabase projects selected at build time:
 
-| File | Purpose |
-|------|---------|
-| [Spot/Info.plist](../../Spot/Info.plist) | Current hardcoded Supabase configuration |
-| [Spot/Supabase/Supabase.swift](../../Spot/Supabase/Supabase.swift) | Supabase client initialization |
-| [.github/workflows/deploy.yml](../../.github/workflows/deploy.yml) | Firebase App Distribution build (will use staging) |
-| [.github/workflows/testflight.yml](../../.github/workflows/testflight.yml) | TestFlight build (will use production) |
-| [supabase/migrations/](../../supabase/migrations/) | Schema migrations to replicate |
+- `#if DEBUG` selects staging in `SupabaseEnvironment.current`.
+- Release loads `Spot/Info.plist` values first, allowing CI to select the intended project.
+- Release enum values are fallback configuration, not the preferred distribution mechanism.
+- Firebase distribution validates that the embedded URL belongs to staging before archiving.
+- TestFlight requires production URL and publishable-key secrets and fails when they are absent.
 
-## Current Status
+The environment enum and loader live together in [`Spot/Supabase/Supabase.swift`](../../Spot/Supabase/Supabase.swift); there is no separate `SupabaseEnvironment.swift`.
 
-**Environment routing implemented** — As of 2026-07-28, local DEBUG and Firebase App Distribution builds use staging (`aeurigbbohyxvtsfiyul`), while TestFlight/App Store builds use production (`gomdoguewaawdlvijahg`). The Firebase workflow rejects any non-staging project URL before building.
+## Build routing
 
-## Table of Contents
-
-- [Decision Summary](#decision-summary)
-- [Getting Started](#getting-started)
-- [Executive Summary](#executive-summary)
-- [Current State Analysis](#current-state-analysis)
-- [Proposed Solution](#proposed-solution)
-- [Implementation Strategy](#implementation-strategy)
-  - [Phase 1: Project Setup](#phase-1-project-setup)
-  - [Phase 2: iOS App Changes](#phase-2-ios-app-changes)
-  - [Phase 3: CI/CD Pipeline Changes](#phase-3-cicd-pipeline-changes)
-  - [Phase 4: Schema Migration Strategy](#phase-4-schema-migration-strategy)
-  - [Phase 5: Testing and Validation](#phase-5-testing-and-validation)
-  - [Phase 6: Documentation Updates](#phase-6-documentation-updates)
-- [Alternative Approaches Considered](#alternative-approaches-considered)
-- [Success Criteria](#success-criteria)
-- [Risks and Mitigations](#risks-and-mitigations)
-- [Cost Analysis](#cost-analysis)
-- [Timeline and Phases](#timeline-and-phases)
-- [Open Questions](#open-questions)
-- [Related Documentation](#related-documentation)
-- [Next Steps](#next-steps)
-- [Appendices](#appendix-a-current-supabase-usage-audit)
-  - [Appendix A: Current Supabase Usage Audit](#appendix-a-current-supabase-usage-audit)
-  - [Appendix B: Migration Script Template](#appendix-b-migration-script-template)
-  - [Appendix C: Environment Validation Checklist](#appendix-c-environment-validation-checklist)
-  - [Appendix D: Implementation Notes for Cursor Agents](#appendix-d-implementation-notes-for-cursor-agents)
-
----
-
-## Decision Summary
-
-**Recommendation:** Implement a two-project Supabase environment strategy with build-time configuration injection via GitHub Actions.
-
-**Key Benefits:**
-- Complete data isolation between testing and production
-- Safe schema migration testing in staging before production
-- No risk of test data contaminating production queries
-- Independent rate limits and quotas per environment
-
-**Estimated Effort:** 4 weeks (6 phases)
-
-**Cost Impact:** Additional Supabase project (free tier initially, or ~$25/month for Pro tier)
-
-**Risk Level:** Low — implementation is incremental with rollback capability at each phase
-
----
-
-## Getting Started
-
-If you're ready to implement this strategy, follow this quick guide:
-
-1. **Review this entire document** — especially the [Current State Analysis](#current-state-analysis) and [Implementation Strategy](#implementation-strategy)
-2. **Complete prerequisites** — see [Before You Begin](#before-you-begin)
-3. **Start with Phase 1** — [Project Setup](#phase-1-project-setup-week-1) to create the staging Supabase project
-4. **Use the MCP** — Supabase MCP server (`plugin-supabase-supabase`) can automate schema replication and migration application
-5. **Track progress** — Use the [Success Criteria](#success-criteria) checklist to validate each phase
-6. **Refer to appendices** — [Migration Script Template](#appendix-b-migration-script-template) and [Environment Validation Checklist](#appendix-c-environment-validation-checklist) provide implementation scaffolding
-
-**Implementation scope:** 6 phases covering project setup, iOS changes, CI/CD pipeline updates, migration strategy, testing, and documentation.
-
----
-
-## Executive Summary
-
-Currently, Spot uses a **single Supabase project** for all builds (Firebase App Distribution testing builds from `main` and TestFlight production builds from `release/**` branches). This means:
-
-- Test data and production user data share the same database
-- Internal testing can interfere with production users
-- No safe environment for destructive testing or schema experiments
-- Risk of accidentally affecting production data during development
-
-This PRD proposes splitting into **two Supabase projects** with build-time environment selection:
-
-| Environment | Build Pipeline | Branch | Distribution | Supabase Project |
-|-------------|---------------|--------|--------------|------------------|
-| **Non-Production** | Firebase App Distribution | `main` | Internal testers | New staging project |
-| **Production** | TestFlight / App Store | `release/**` | Public users | Current project (migrated) |
-
----
-
-## Current State Analysis
-
-### Current Supabase Configuration
-
-**Single Project Setup:**
-- **Project Reference:** `aeurigbbohyxvtsfiyul`
-- **Project Name:** "Spot"
-- **Organization:** `mdnqvdzrrhjtaxbwnleq`
-- **Configuration Location:** `Spot/Info.plist` → `Supabase` dictionary
-- **Client Initialization:** `Spot/Supabase/Supabase.swift` (global `supabase` client)
-
-**Hardcoded in Info.plist:**
-```xml
-<key>Supabase</key>
-<dict>
-    <key>anonKey</key>
-    <string>sb_publishable_5IKZU3dDw6C0-V9lRPc7vw_z_v8a08G</string>
-    <key>url</key>
-    <string>https://aeurigbbohyxvtsfiyul.supabase.co</string>
-</dict>
+```mermaid
+flowchart TD
+  A{Build lane} -->|Local DEBUG| B[SupabaseEnvironment.staging]
+  A -->|main / Firebase| C[Inject staging config]
+  A -->|release/** / TestFlight| D[Inject production config]
+  C --> E{Embedded project is staging?}
+  E -->|No| F[Fail workflow]
+  E -->|Yes| G[Archive and distribute]
+  D --> H{Production secrets present?}
+  H -->|No| F
+  H -->|Yes| I[Archive and upload]
 ```
 
-### Current Build Pipeline
+| Lane | Branch / trigger | Supabase | Distribution |
+| --- | --- | --- | --- |
+| Local development | DEBUG | Staging | Simulator or signed device |
+| PR CI | PR to `main` | No live backend required for unit tests | Test artifacts |
+| Internal testing | Push to `main` | Staging | Firebase App Distribution |
+| Release | Push to `release/**` | Production | TestFlight |
 
-**Non-Production (Testing):**
-- **Workflow:** `.github/workflows/deploy.yml`
-- **Trigger:** Merges/pushes to `main` branch
-- **Distribution:** Firebase App Distribution
-- **Build Type:** Ad Hoc signed
-- **Auto-increments:** Build number in `CURRENT_PROJECT_VERSION`
-- **Current Supabase:** Production project (shared with TestFlight)
+## Migration policy
 
-**Production:**
-- **Workflow:** `.github/workflows/testflight.yml`
-- **Trigger:** Pushes to `release/**` branches
-- **Distribution:** App Store Connect / TestFlight
-- **Build Type:** App Store signed
-- **Versioning:** Marketing version from branch name (e.g., `release/1.1.0` → version `1.1.0`)
-- **Current Supabase:** Production project (shared with testing builds)
+1. Add reviewed, idempotent SQL under `supabase/migrations/`.
+2. Apply and validate in staging first.
+3. Exercise affected auth, RLS, RPC, Storage, and Edge Function paths with test accounts.
+4. Apply the identical migration to production through the approved Supabase MCP workflow.
+5. Verify migration history and a focused production smoke test.
 
-### Current Data Usage
+Do not edit production schema ad hoc and then backfill a migration later. A migration is incomplete until the linked project application succeeds or the owner explicitly opts out.
 
-The app uses Supabase for:
+### Parity checks
 
-1. **Authentication:** `Supabase.auth` (email/password, OAuth)
-2. **User Profiles:** `public.users` table with RLS
-3. **Spots:** `public.spots`, `public.spot_images`, `public.vibe_tags`
-4. **Social Graph:** `follows`, `follow_requests`, likes, bookmarks
-5. **Feed:** RPC `get_home_feed_v1` with server-side signing
-6. **Storage:** Private buckets (`pending_images`, `approved_spot_images`, `approved_profile_images`)
-7. **Moderation:** Edge Function `moderate-image` with Azure Content Safety
-8. **Publishing:** RPC `publish_spot_with_approved_media_assets_v1`
+Compare these between environments without copying user data:
 
-### Current Pain Points
+- migration history and public tables;
+- RLS enabled state and policy names;
+- functions and execute grants;
+- Storage bucket names, visibility, and object policies;
+- Edge Function versions and required secret names;
+- Auth provider and redirect configuration.
 
-1. **Data Contamination:** Test spots appear in production queries (or vice versa)
-2. **No Safe Testing:** Cannot test destructive operations (account deletion, mass data operations) without affecting production
-3. **Schema Migration Risk:** Cannot safely test migrations before applying to production
-4. **Analytics Pollution:** Firebase Analytics and user metrics include test data
-5. **Moderation Testing:** Cannot test moderation edge cases without creating real moderation events
-6. **No Rollback Safety:** Schema changes immediately affect all users
-7. **Auth Confusion:** Test accounts mixed with real user accounts
+Schema parity does not mean data parity. Staging can be reset and seeded; production cannot.
 
----
+## Security invariants
 
-## Proposed Solution
+- Never ship or document a service-role key.
+- Publishable client credentials do not replace RLS.
+- Keep production credentials in GitHub/Supabase secret stores.
+- Never use production accounts or exports to seed staging.
+- Deploy `moderate-image` and its Azure secrets separately in each environment.
+- Validate Storage and RLS before enabling an app build against a new project.
 
-### Two-Project Strategy
+## Operational verification
 
-Create **two separate Supabase projects** with identical schemas but isolated data:
+For Firebase builds:
 
-#### Project 1: Non-Production / Staging
-- **Purpose:** Internal testing, QA, schema migration validation
-- **Used By:** Firebase App Distribution builds from `main`
-- **Data Policy:** Can be reset/cleared periodically; no production data
-- **Schema:** Mirror of production (ahead during migration testing)
-- **Users:** Test accounts only
-- **Edge Functions:** Separate deployment (can test experimental features)
+1. Confirm the workflow reports the staging project ref.
+2. Sign in with a staging-only account.
+3. Verify feed, map, Search, profile, and moderated Spot publish.
+4. Confirm created data exists only in staging.
 
-#### Project 2: Production
-- **Purpose:** Real user data for TestFlight and App Store releases
-- **Used By:** TestFlight builds from `release/**` branches
-- **Data Policy:** Never cleared; full backups; strict change control
-- **Schema:** Authoritative; changes applied after staging validation
-- **Users:** Real users only
-- **Edge Functions:** Production-only deployment with uptime monitoring
+For TestFlight builds:
 
-### Build-Time Environment Selection
+1. Confirm production secrets were injected and artifact checks passed.
+2. Use an approved production smoke-test account.
+3. Verify auth, feed, deep links, Pro status, and one safe write path.
+4. Avoid destructive account or bulk-data tests in production.
 
-Use **Xcode build configurations** or **preprocessor macros** to select the correct Supabase project at build time:
+## Rollback
 
-```swift
-// Spot/Utils/SupabaseEnvironment.swift (proposed)
-import Foundation
+App rollback and database rollback are separate:
 
-enum SupabaseEnvironment {
-    case production
-    case staging
-    
-    static var current: SupabaseEnvironment {
-        #if PRODUCTION_BUILD
-        return .production
-        #else
-        return .staging
-        #endif
-    }
-    
-    var url: String {
-        switch self {
-        case .production:
-            return "https://PROD_PROJECT.supabase.co"
-        case .staging:
-            return "https://STAGING_PROJECT.supabase.co"
-        }
-    }
-    
-    var anonKey: String {
-        switch self {
-        case .production:
-            return "PROD_ANON_KEY"
-        case .staging:
-            return "STAGING_ANON_KEY"
-        }
-    }
-}
-```
+- Stop distributing a bad binary or upload a corrected build.
+- Prefer forward-fix migrations. Only run destructive reversal SQL after reviewing data-loss impact.
+- If an environment was misrouted, stop the lane, revoke affected sessions or credentials as appropriate, inspect writes, and follow the incident-response runbook.
 
-**Alternative Approach:** Inject environment-specific `Info.plist` files during CI/CD:
-- Keep base `Info.plist` in source control with placeholders
-- GitHub Actions injects correct values from secrets before build
-- More secure (keys never in source control, even for staging)
+## Known operational gaps
 
----
+- Source control proves routing logic, not deployed schema parity or secret presence.
+- The staging migration workflow is narrow and does not replace a general production migration runbook.
+- The repository's `deploy-moderate-image.sh` is staging-oriented; production deployment must be deliberately targeted and verified.
+- Some base feed/map RPC definitions are not fully represented in migrations, which limits reproducible project creation.
 
-## Implementation Strategy
+## Related docs
 
-### Phase 1: Project Setup
-
-1. **Create Staging Supabase Project**
-   - Use Supabase MCP or dashboard to create new project
-   - Name: "Spot Staging" or "Spot Non-Production"
-   - Same organization as production project
-   - Document project ref, URL, and anon key in **secure location** (not in repo)
-
-2. **Replicate Schema to Staging**
-   - Export current schema from production: `supabase db dump`
-   - Apply all migrations from `supabase/migrations/` to staging project
-   - Verify schema parity: tables, columns, indexes, RLS policies, functions, triggers
-
-3. **Configure Storage Buckets**
-   - Create matching buckets: `pending_images`, `approved_spot_images`, `approved_profile_images`
-   - Apply same RLS policies from production
-   - Test upload/download with signed URLs
-
-4. **Deploy Edge Functions to Staging**
-   - Deploy `moderate-image` function to staging project
-   - Configure separate Azure Content Safety endpoint (or shared dev endpoint)
-   - Test moderation pipeline end-to-end
-
-5. **Seed Staging Data**
-   - Create test user accounts (5-10 accounts with various states)
-   - Create test spots across different vibes, locations, privacy settings
-   - Create test follow relationships and blocked users
-   - Create Pro subscription test accounts (StoreKit sandbox)
-
-### Phase 2: iOS App Changes
-
-1. **Add Build Configuration Support**
-   ```swift
-   // Option A: Swift preprocessor flags
-   #if PRODUCTION_BUILD
-   let supabaseURL = "https://PROD.supabase.co"
-   let supabaseKey = "PROD_KEY"
-   #else
-   let supabaseURL = "https://STAGING.supabase.co"
-   let supabaseKey = "STAGING_KEY"
-   #endif
-   ```
-
-2. **Update Client Initialization**
-   - Modify `Spot/Supabase/Supabase.swift` to use environment-based config
-   - Update all services to use the singleton `supabase` client (no changes needed if they already do)
-   - Add logging to show which environment is active on launch (DEBUG builds only)
-
-3. **Update Info.plist Strategy**
-   - **Option A:** Keep one Info.plist with preprocessor macros
-   - **Option B:** Create separate Info-Staging.plist and Info-Production.plist
-   - **Option C:** Inject via CI/CD (recommended for security)
-
-4. **Add Environment Indicator (DEBUG only)**
-   ```swift
-   #if DEBUG
-   // Show banner or log indicating staging vs production
-   SpotLogger.log(.info, "Supabase Environment: \(SupabaseEnvironment.current)")
-   #endif
-   ```
-
-### Phase 3: CI/CD Pipeline Changes
-
-#### Firebase Deploy Workflow (Non-Production)
-
-Update `.github/workflows/deploy.yml`:
-
-```yaml
-- name: Install Supabase Configuration (Staging)
-  env:
-    SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
-    SUPABASE_STAGING_ANON_KEY: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}
-  run: |
-    # Inject staging Supabase config into Info.plist
-    /usr/libexec/PlistBuddy -c "Set :Supabase:url ${SUPABASE_STAGING_URL}" Spot/Info.plist
-    /usr/libexec/PlistBuddy -c "Set :Supabase:anonKey ${SUPABASE_STAGING_ANON_KEY}" Spot/Info.plist
-
-- name: Build app
-  run: |
-    xcodebuild \
-      -scheme Spot \
-      -destination "generic/platform=iOS" \
-      -archivePath $RUNNER_TEMP/Spot.xcarchive \
-      -configuration Release \
-      CODE_SIGNING_ALLOWED=NO \
-      CODE_SIGNING_REQUIRED=NO \
-      OTHER_SWIFT_FLAGS="-D STAGING_BUILD" \
-      clean archive | xcbeautify
-```
-
-#### TestFlight Workflow (Production)
-
-Update `.github/workflows/testflight.yml`:
-
-```yaml
-- name: Install Supabase Configuration (Production)
-  env:
-    SUPABASE_PRODUCTION_URL: ${{ secrets.SUPABASE_PRODUCTION_URL }}
-    SUPABASE_PRODUCTION_ANON_KEY: ${{ secrets.SUPABASE_PRODUCTION_ANON_KEY }}
-  run: |
-    # Inject production Supabase config into Info.plist
-    /usr/libexec/PlistBuddy -c "Set :Supabase:url ${SUPABASE_PRODUCTION_URL}" Spot/Info.plist
-    /usr/libexec/PlistBuddy -c "Set :Supabase:anonKey ${SUPABASE_PRODUCTION_ANON_KEY}" Spot/Info.plist
-
-- name: Build and export production archive
-  run: |
-    xcodebuild \
-      -scheme Spot \
-      -destination "generic/platform=iOS" \
-      -archivePath $RUNNER_TEMP/Spot.xcarchive \
-      -configuration Release \
-      MARKETING_VERSION="$MARKETING_VERSION" \
-      CURRENT_PROJECT_VERSION="$CURRENT_PROJECT_VERSION" \
-      CODE_SIGNING_ALLOWED=NO \
-      CODE_SIGNING_REQUIRED=NO \
-      OTHER_SWIFT_FLAGS="-D PRODUCTION_BUILD" \
-      clean archive | xcbeautify
-```
-
-#### GitHub Secrets to Add
-
-In GitHub Repository Settings → Secrets and variables → Actions ([GitHub documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)):
-
-| Secret Name | Environment | Description |
-|-------------|-------------|-------------|
-| `SUPABASE_STAGING_URL` | Non-Production | Staging project URL |
-| `SUPABASE_STAGING_ANON_KEY` | Non-Production | Staging anon/publishable key |
-| `SUPABASE_PRODUCTION_URL` | Production | Production project URL |
-| `SUPABASE_PRODUCTION_ANON_KEY` | Production | Production anon/publishable key |
-
-**Note:** These secrets will be injected into `Info.plist` during the build process, replacing the currently hardcoded values.
-
-### Phase 4: Schema Migration Strategy
-
-1. **Test-First Migration Flow**
-   ```
-   1. Write migration SQL in supabase/migrations/
-   2. Apply to STAGING via Supabase MCP or CLI
-   3. Run full test suite against staging
-   4. Validate data integrity, RLS policies, query performance
-   5. If successful, apply SAME migration to PRODUCTION
-   6. Monitor production for errors/performance issues
-   ```
-
-2. **Migration Automation**
-   - Use Supabase MCP `apply_migration` for both environments
-   - Document rollback procedures for each migration
-   - Maintain migration log with staging/production application dates
-
-3. **Schema Drift Prevention**
-   - Weekly schema comparison: `supabase db diff --linked --schema public`
-   - Alert on unexpected drift between staging and production
-   - Document intentional differences (e.g., test-only functions)
-
-### Phase 5: Testing and Validation
-
-1. **Staging Environment Tests**
-   - [ ] Auth flow: signup, login, password reset
-   - [ ] Spot creation with moderation pipeline
-   - [ ] Feed loading with signed image URLs
-   - [ ] Search across users, spots, vibes
-   - [ ] Follow/unfollow, private accounts
-   - [ ] Block/report flows
-   - [ ] Pro subscription mock (StoreKit sandbox)
-   - [ ] Account deletion
-   - [ ] Universal Links and deep links
-
-2. **Production Validation**
-   - [ ] Smoke test on TestFlight build
-   - [ ] Verify production data is isolated from staging
-   - [ ] Monitor Supabase dashboard: query performance, error rates
-   - [ ] Check Firebase Analytics: no staging data in production reports
-
-3. **CI/CD Validation**
-   - [ ] Merge to `main` → Firebase build uses staging
-   - [ ] Push to `release/1.x.x` → TestFlight build uses production
-   - [ ] Verify no accidental cross-contamination
-
-### Phase 6: Documentation Updates
-
-Update the following documentation:
-
-1. **docs/engineering/supabase.md**
-   - Document two-project setup
-   - Explain environment selection logic
-   - Update "Local vs production" section
-
-2. **docs/engineering/environment-variables.md**
-   - Add staging and production Supabase config entries
-   - Document GitHub Secrets requirements
-
-3. **docs/engineering/database-and-rls.md**
-   - Update migration workflow to include staging-first strategy
-   - Document schema parity validation process
-
-4. **.github/workflows/README.md**
-   - Document new Supabase secrets
-   - Explain environment injection steps
-
-5. **README.md (root)**
-   - Update Quick Start to mention environment setup
-   - Link to this environment strategy doc
-
-6. **docs/README.md**
-   - Add link to this document in Engineering section
-
----
-
-## Alternative Approaches Considered
-
-### Single Project with Namespace Prefixes
-
-**Approach:** Use a single Supabase project but prefix all data with environment tags.
-
-**Example:**
-- Tables: Keep shared schema
-- Data: Add `environment` column (`'staging'` or `'production'`)
-- RLS: Filter queries by `environment` value
-
-**Pros:**
-- Single project to manage
-- Easier schema migrations (one update)
-- Lower cost (one project)
-
-**Cons:**
-- High risk of data leakage (RLS mistakes expose all data)
-- Shared rate limits and quotas
-- Cannot test destructive operations safely
-- Analytics still mixed
-- No isolation for Edge Functions
-- Complex RLS policies increase attack surface
-
-**Decision:** **Rejected** — Risk of cross-contamination too high for production user data.
-
----
-
-### Separate Projects with Manual Sync
-
-**Approach:** Two projects but manually replicate schema changes.
-
-**Pros:**
-- Full isolation
-- Independent scaling and quotas
-
-**Cons:**
-- Schema drift inevitable without automation
-- Manual process error-prone
-- No forcing function to test staging first
-
-**Decision:** **Accepted with automation** — Automation via Supabase MCP and CI/CD mitigates drift risk.
-
----
-
-### Three Environments (Dev, Staging, Production)
-
-**Approach:** Add a third local development project.
-
-**Pros:**
-- Local development doesn't affect staging or production
-- Faster iteration for schema experiments
-
-**Cons:**
-- Increased complexity
-- Three projects to maintain schema parity
-- Higher cost
-- Local Supabase CLI already provides local-only development
-
-**Decision:** **Deferred** — Start with two environments; revisit if local Supabase adoption increases.
-
----
-
-## Success Criteria
-
-### Functional Requirements
-
-- [ ] Firebase App Distribution builds connect to staging Supabase project
-- [ ] TestFlight builds connect to production Supabase project
-- [ ] No staging data in production database
-- [ ] No production data in staging database
-- [ ] All migrations tested in staging before production
-- [ ] Schema parity maintained between environments
-- [ ] CI/CD automatically injects correct configuration
-- [ ] No secrets committed to source control
-
-### Non-Functional Requirements
-
-- [ ] Zero downtime during migration
-- [ ] No user impact (production users unaffected by staging tests)
-- [ ] Migration completed within 4 weeks
-- [ ] Rollback plan documented for each phase
-- [ ] Performance unchanged (no additional latency from environment logic)
-
-### Documentation Requirements
-
-- [ ] All engineering docs updated with environment strategy
-- [ ] Runbook created for environment management
-- [ ] Migration workflow documented for future schema changes
-- [ ] Troubleshooting guide for environment-specific issues
-
----
-
-## Risks and Mitigations
-
-| Risk | Impact | Probability | Mitigation |
-|------|--------|-------------|------------|
-| **Schema drift** between environments | High | Medium | Automated schema comparison in CI; weekly drift reports |
-| **Secrets leak** in GitHub Actions logs | High | Low | Use GitHub Actions secret masking; audit logs quarterly |
-| **Wrong environment** config in production build | High | Low | CI validation step: check URLs before upload; manual verification checklist |
-| **Staging data** mixed into production during migration | High | Low | Dry-run migration validation; separate migration windows; schema-only migrations first |
-| **Increased cost** from two projects | Medium | High | Expected; budget for 2x Supabase project costs; evaluate free tier limits |
-| **Edge Function** staging deployment fails | Medium | Medium | Separate Azure credentials for staging; test deployment in Phase 1 |
-| **Migration breaks** production | High | Low | Staging-first testing; canary rollout; documented rollback SQL |
-| **Developer confusion** about which environment is active | Low | Medium | Clear logging in DEBUG builds; environment indicator in app (staging only) |
-
----
-
-## Cost Analysis
-
-### Current State
-
-- **Supabase:** 1 project (current plan: contact team to verify free/pro tier status)
-- **Firebase:** 1 project for both environments (Analytics, Crashlytics)
-- **GitHub Actions:** Current usage can be viewed in repository Insights → Actions
-
-### Proposed State
-
-- **Supabase:** 2 projects (staging + production)
-  - **Staging:** Start with free tier if usage is low; upgrade to Pro tier if needed
-  - **Production:** Current plan (no change)
-  - **Estimated increase:** $0-$25/month depending on staging usage
-- **Firebase:** 1 project (no change)
-- **GitHub Actions:** Same (no additional workflow runs)
-
-### Budget Recommendation
-
-- **Minimum:** Keep staging on free tier, upgrade if needed
-- **Recommended:** Pro tier for both environments for consistent feature set
-
----
-
-## Timeline and Phases
-
-This implementation is structured into 6 phases. Each phase builds on the previous one and has clear deliverables. Phases can be implemented sequentially or with some overlap.
-
-| Phase | Key Deliverables | Dependencies |
-|-------|------------------|--------------|
-| **Phase 1: Project Setup** | Staging project created, schema replicated, Edge Functions deployed, test data seeded | Supabase dashboard access, MCP configured |
-| **Phase 2: iOS App Changes** | Environment selection logic implemented, client initialization updated | Phase 1 complete |
-| **Phase 3: CI/CD Pipeline** | GitHub Actions updated, secrets configured, automated environment injection | Phase 2 complete |
-| **Phase 4: Migration Strategy** | Test-first migration flow documented and automated | Phase 3 complete |
-| **Phase 5: Testing** | End-to-end validation, smoke tests, production verification | Phase 4 complete |
-| **Phase 6: Documentation** | All docs updated, runbooks created, team trained | Phase 5 complete |
-
-**Implementation approach:** Each phase should be fully completed and validated before proceeding to the next. Phases 2 and 3 can partially overlap if needed.
-
----
-
-## Open Questions
-
-1. **Supabase Plan:** What is the current Supabase plan (Free, Pro, Team, Enterprise)? Does staging need Pro tier?
-2. **Azure Credentials:** Should staging use separate Azure Content Safety credentials or shared dev endpoint?
-3. **Data Seeding:** Should staging be seeded with production-like data volume for load testing?
-4. **StoreKit:** Does StoreKit sandbox work correctly with staging Supabase project?
-5. **Universal Links:** Do Universal Links need separate AASA files for staging app?
-6. **Firebase Projects:** Should staging use a separate Firebase project for Analytics/Crashlytics?
-7. **Local Development:** Should developers be encouraged to use local Supabase CLI instead of staging?
-8. **Migration Cutover:** Should production migration be the original project or new project? (Recommend: keep production as-is, create new staging)
-
----
-
-## Related Documentation
-
-- [docs/engineering/supabase.md](supabase.md) — Supabase role in architecture
-- [docs/engineering/data-plane.md](data-plane.md) — Data plane policy (Supabase only)
-- [docs/engineering/environment-variables.md](environment-variables.md) — Configuration secrets
-- [docs/engineering/database-and-rls.md](database-and-rls.md) — Schema and RLS
-- [docs/engineering/ci-cd.md](ci-cd.md) — GitHub Actions workflows
-- [.github/workflows/README.md](../../.github/workflows/README.md) — Workflow documentation
-
----
-
-## Next Steps
-
-1. **Approve PRD:** Review this document with team and stakeholders
-2. **Create Staging Project:** Use Supabase MCP or dashboard
-3. **Assign Ownership:** Designate environment strategy owner
-4. **Schedule Implementation:** Block 4-week window for migration
-5. **Create Tracking Issue:** GitHub issue with checklist for all phases
-6. **Budget Approval:** Confirm budget for second Supabase project
-
----
-
-## Version History
-
-| Date | Author | Changes |
-|------|--------|---------|
-| 2026-07-06 | Cursor Agent | Initial PRD from discovery work |
-
----
-
-## Appendix A: Current Supabase Usage Audit
-
-### Tables in Use
-
-```
-public.users
-public.spots
-public.spot_images
-public.vibe_tags
-public.follows
-public.follow_requests
-public.spot_likes
-public.spot_bookmarks
-public.user_feed_events
-public.reports
-public.user_blocks
-public.user_terms_acceptances
-public.terms_versions
-public.moderation_events
-public.content_moderation_results
-public.media_assets
-public.media_moderation_events
-public.spot_vibe_tags
-public.bookmark_collections (legacy)
-public.bookmark_collection_spots (legacy)
-```
-
-### RPCs in Use
-
-```sql
-get_home_feed_v1
-publish_spot_with_approved_media_assets_v1
-submit_content_report
-record_terms_acceptance
-delete_my_account
-sync_current_user (security definer)
-```
-
-### Edge Functions
-
-```
-moderate-image (in supabase/functions/moderate-image/)
-```
-
-### Storage Buckets
-
-```
-spots (legacy private bucket for older spot images)
-pending_images (moderation queue - pre-approval)
-approved_spot_images (post-moderation approved spot images)
-approved_profile_images (post-moderation approved profile pictures)
-```
-
-All buckets are private with RLS policies enforced (see `20260504100000_image_moderation_azure_v1.sql`).
-
-### Authentication Methods
-
-- Email/Password (primary)
-- Sign in with Apple (verified - implemented in `AuthViewModel.swift` and `ThemedAppleSignInButton.swift`)
-- OAuth providers: None currently enabled (no Google, GitHub, or Facebook providers configured in migrations)
-
----
-
-## Appendix B: Migration Script Template
-
-```sql
--- Template for migrations that need to run in both staging and production
-
--- Migration: [DESCRIPTIVE_NAME]
--- Applied to staging: YYYY-MM-DD
--- Applied to production: YYYY-MM-DD
--- Author: [NAME]
--- Rollback: [LINK TO ROLLBACK SQL OR DESCRIPTION]
-
-BEGIN;
-
--- 1. Schema changes (DDL)
--- Example: ALTER TABLE, CREATE TABLE, etc.
-
--- 2. Data migrations (DML)
--- Example: UPDATE, INSERT, etc.
-
--- 3. RLS policy changes
--- Example: CREATE POLICY, ALTER POLICY, etc.
-
--- 4. Grants and permissions
--- Example: GRANT, REVOKE
-
--- 5. Validation queries (commented out)
--- SELECT count(*) FROM new_table;
--- SELECT * FROM pg_policies WHERE tablename = 'new_table';
-
-COMMIT;
-
--- Rollback script (commented out)
--- BEGIN;
--- DROP TABLE IF EXISTS new_table CASCADE;
--- COMMIT;
-```
-
----
-
-## Appendix C: Environment Validation Checklist
-
-Use this checklist before releasing to production:
-
-### Pre-Flight Checks
-
-- [ ] Confirm Supabase URL in build matches expected environment
-- [ ] Verify anon key is correct for environment
-- [ ] Check Firebase project ID (if separate projects)
-- [ ] Validate Universal Link configuration
-- [ ] Test auth flow (signup, login, password reset)
-- [ ] Verify RLS policies are identical in staging and production
-- [ ] Check Edge Function deployment status
-- [ ] Confirm storage bucket policies match
-
-### Post-Deployment Validation
-
-- [ ] Monitor Supabase dashboard for error spikes
-- [ ] Check Firebase Crashlytics for new crashes
-- [ ] Verify feed loads with correct environment data
-- [ ] Test spot creation and publishing
-- [ ] Validate image uploads and signed URLs
-- [ ] Check moderation pipeline is working
-- [ ] Monitor query performance (no regressions)
-- [ ] Verify no staging data leaking into production
-
----
-
-**End of PRD**
-
----
-
-## Appendix D: Implementation Notes for Cursor Agents
-
-When implementing this environment strategy as a Cursor agent, follow these guidelines:
-
-### Using Supabase MCP
-
-1. **List projects:** Use `list_projects` to discover the current production project
-2. **Create staging project:** Use MCP tools to create a new project in the same organization
-3. **Schema replication:** Use `execute_sql` or `apply_migration` to replicate schema from production to staging
-4. **Verify schema parity:** Compare tables, policies, functions, and triggers between environments
-
-### Key Considerations
-
-- **Never expose service role keys** — only add anon/publishable keys to GitHub secrets
-- **Test migrations in staging first** — always validate with `get_advisors` before applying to production
-- **Use environment-specific secrets** — ensure GitHub Actions use the correct `SUPABASE_*_URL` and `SUPABASE_*_ANON_KEY` per workflow
-- **Update Info.plist via CI** — do not hardcode staging credentials in source control
-- **Validate RLS policies** — ensure all policies are identical between staging and production after replication
-
-### Implementation Order
-
-1. Start with Phase 1 (Project Setup) — this can be done independently
-2. Phase 2 (iOS changes) requires careful review of `Spot/Supabase/Supabase.swift`
-3. Phase 3 (CI/CD) must update both `.github/workflows/deploy.yml` and `.github/workflows/testflight.yml`
-4. Test thoroughly in Phase 5 before considering complete
-
-### Documentation Updates Required
-
-After implementation, update:
-- `docs/engineering/supabase.md` — add environment split details
-- `docs/engineering/environment-variables.md` — document new GitHub secrets
-- `docs/engineering/database-and-rls.md` — update migration workflow
-- `docs/engineering/local-setup.md` — explain how to configure local environment
-- This file — update implementation status to "Complete" and add actual dates
-
----
-
-**End of Document**
+- [supabase-environment-setup-guide.md](supabase-environment-setup-guide.md)
+- [environment-variables.md](environment-variables.md)
+- [ci-cd.md](ci-cd.md)
+- [database-and-rls.md](database-and-rls.md)
+- [release-process.md](release-process.md)
+- [../operations/incident-response.md](../operations/incident-response.md)
+- [Firebase workflow](../../.github/workflows/deploy.yml)
+- [TestFlight workflow](../../.github/workflows/testflight.yml)

--- a/docs/engineering/supabase.md
+++ b/docs/engineering/supabase.md
@@ -30,20 +30,37 @@ Postgres with RLS policies defined in migrations (e.g. `20260502120000_security_
 
 ### Storage
 
-Private buckets for pending and approved images (`pending_images`, `approved_spot_images`, `approved_profile_images`) per `20260504100000_image_moderation_azure_v1.sql`.
+Private buckets for pending and approved images (`pending_images`, `approved_spot_images`, `approved_profile_images`) per `20260504100000_image_moderation_azure_v1.sql`, plus legacy `spots` and public `avatars` paths still used by client code.
 
 ### Edge Functions
 
-Image moderation pipeline references Edge Function **`moderate-image`** in repository comments—**TODO: verify** deployed function names and secrets in Supabase dashboard.
+The versioned Edge Function is **`moderate-image`** under `supabase/functions/moderate-image/`. Deployment and secret presence must be verified independently in each project.
+
+### Key RPCs and functions
+
+| Function | Role |
+| --- | --- |
+| `get_home_feed_v1`, `get_home_feed_status_v1` | Ranked feed and empty/caught-up state |
+| `get_map_spots_v1` | Viewport discovery |
+| `record_feed_event_v1`, `recompute_my_feed_profile_v1` | Feed telemetry and profile recomputation |
+| `publish_spot_with_approved_media_assets_v1` | Atomic publish from approved assets |
+| `submit_content_report` | Authenticated UGC report |
+| `delete_my_account` | Account and relational-data deletion |
+| `sync_current_user_v1` | Authenticated profile synchronization |
+| `is_username_available` | Privacy-limited signup availability result |
+| `record_terms_acceptance_v1`, `has_accepted_active_terms` | Terms version state |
+
+Some base feed/map RPC definitions are not fully represented in committed migrations. Treat that as a reproducibility gap.
 
 ### Local vs production
 
-- **Production**: project matching deployed `Info.plist` values for your build flavor.
-- **Local Supabase**: optional CLI for schema iteration—**TODO: verify** if team uses local stack or remote dev project only.
+- **Local DEBUG and Firebase distribution**: staging project.
+- **TestFlight and App Store**: production project injected by the release workflow.
+- A local Supabase stack is not part of the documented standard path; use staging unless the team deliberately establishes one.
 
 ### MCP
 
-Cursor may use Supabase MCP for migrations in some workflows; production changes still go through reviewed SQL migrations in `supabase/migrations/`.
+Supabase changes require reviewed SQL under `supabase/migrations/` and application through the Supabase MCP to the linked project. Test staging before production.
 
 ### Safety for schema changes
 
@@ -60,4 +77,4 @@ Cursor may use Supabase MCP for migrations in some workflows; production changes
 
 ## Open questions / TODOs
 
-- Full inventory of RPCs and Edge Functions: TODO: generate from Supabase project or SQL search.
+- Export or recreate missing authoritative base feed/map function definitions as migrations.

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -32,12 +32,12 @@ Matches `.cursor/rules/project.mdc` and Xcode schemes **Spot**, **SpotTests**, *
 - Auth gating and session edge cases (unit where mockable).
 - Posting flow state machine and moderation client behavior.
 - Draft behavior when testable without device-only APIs.
-- Supabase repository behavior behind protocols/mocks (**TODO: verify** mock coverage depth).
+- Supabase repository behavior behind protocols/mocks; no live Supabase calls in unit tests.
 - **Map drawer** selection / dismiss policy (`MapDiscoveryDrawerPolicyTests`, panel height tests, etc.).
 - **Data plane guard** — `DataPlaneGuardTests` ensures no legacy Firebase Firestore/Storage upload code under `Spot/`.
 - Onboarding managers (`HomeTourManagerTests`, etc.).
 - **Pro** gating helpers (`ProEntitlementChecker`, subscription manager error paths).
-- **Universal Links** parsing (`DeepLinkRouter` tests if present—**TODO: verify** file names).
+- **Universal Links** parsing in `DeepLinkRouterTests`.
 - **Private accounts** — `AuthorPrivacyCacheTests`, `FollowRequestsServiceTests`, and `PrivateAccountIntegrationTests` cover privacy filtering, follow requests, and content visibility. See [../testing/private-account-tests.md](../testing/private-account-tests.md) for details.
 
 ### Commands
@@ -66,6 +66,17 @@ Add previews for new or heavily changed UI when practical to speed design review
 - [../diagrams/testing-release-flow.md](../diagrams/testing-release-flow.md)
 - [../testing/private-account-tests.md](../testing/private-account-tests.md)
 
-## Open questions / TODOs
+### Release smoke priorities
 
-- List top 10 critical UI smoke tests by identifier: TODO: verify in `SpotUITests`.
+1. Cold launch signed out and with a restored session.
+2. Email signup, OTP recovery, login, and logout.
+3. First-run coach complete and skip paths.
+4. Home feed load, refresh, and load more.
+5. Map pin selection, replacement, and pan-away drawer dismissal.
+6. Search user/location/vibe result flows.
+7. Private profile request, accept/deny, and block visibility.
+8. Draft save/resume and one moderated Spot publish.
+9. Pro purchase/restore and gated-feature entry points.
+10. Cold/warm Universal Link with available and unavailable Spots.
+
+CI runs `SpotTests`; UI tests remain a manual/release responsibility unless a dedicated workflow is added.

--- a/docs/engineering/ugc-moderation.md
+++ b/docs/engineering/ugc-moderation.md
@@ -25,7 +25,7 @@ be verified before each App Review submission; source control alone cannot prove
 | --- | --- | --- |
 | Pre-auth Terms gate | Unchecked checkbox blocks Apple Sign-In, Get Started, Log in | `WelcomeView` + `TermsAgreementCheckboxView` |
 | Registration-step Terms gate | Unchecked checkbox blocks "Continue" on the post-Sign-in-with-Apple username/profile-photo screen | `PostAuthSetupFlowView` + `TermsAgreementCheckboxView` |
-| Post-auth update gate | Blocking sheet on launch when active terms version changes | `RootView` → `TermsUpdateGateView` |
+| Post-auth update gate | Implemented but currently disabled pending production RPC verification | `RootView` → `TermsUpdateGateView` |
 | Report a Spot | Reason picker, optional details, optional block toggle | `SpotCard` "ellipsis" menu → `ReportSheet` |
 | Report a User | Reason picker, optional details, optional block toggle | `ProfileView` "ellipsis" menu (other user) → `ProfileReportSheet` |
 | Block a User | Confirmation alert, immediate feed removal | `ProfileView` "ellipsis" menu, also reachable from `ReportSheet`/`ProfileReportSheet` toggle |

--- a/docs/engineering/ugc-moderation.md
+++ b/docs/engineering/ugc-moderation.md
@@ -14,8 +14,8 @@ runbook in `docs/operations/app-store-review-notes.md`.
 
 ## Current status
 
-Implemented and applied to production in May 2026 ahead of resubmission to App
-Review. All features below ship in the binary submitted alongside Build 1.0.0.
+Implemented in repository migrations and client code. Deployed production state must
+be verified before each App Review submission; source control alone cannot prove it.
 
 ## Details
 
@@ -58,7 +58,7 @@ All applied via Supabase migrations under `supabase/migrations/`.
 
 | File | Responsibility |
 | --- | --- |
-| `Spot/Services/Moderation/ModerationService.swift` | Wraps `submit_content_report` and `block_user_v1` RPCs |
+| `Spot/Services/Moderation/ModerationService.swift` | Wraps `submit_content_report` and an available `block_user_v1` RPC path |
 | `Spot/Services/Moderation/TermsAcceptanceService.swift` | Loads active terms, calls `record_terms_acceptance_v1` and `has_accepted_active_terms` |
 | `Spot/Services/Moderation/PreAuthTermsAgreementStore.swift` | `@MainActor ObservableObject` for the pre-auth checkbox state (transient per launch) |
 | `Spot/Models/Logs/ModerationServiceLogs.swift` | Structured logs |
@@ -84,6 +84,10 @@ Client-side, callers post `Notification.Name.homeFeedLocallyRemove` with the
 without waiting for the next feed refresh. Server-side, `can_view_author`
 already filters via `user_blocks`, so subsequent feed reads return nothing from
 that author either direction.
+
+Current report/profile UI paths use this direct-insert block implementation rather
+than `ModerationService.blockUser`. Keep the database trigger and RLS path valid
+for every insert route.
 
 ### Severe text blocklist
 

--- a/docs/engineering/universal-links.md
+++ b/docs/engineering/universal-links.md
@@ -36,9 +36,9 @@ Associated Domains in `Spot/Spot.entitlements`:
 | Spot detail (www) | `https://www.spotapp.online/s/{spotId}` | Same | Same |
 | Spot (custom scheme) | `spotapp://spot/{spotId}` | Same as universal warm path | Same |
 | Query variant | `spotapp://open?spotId={spotId}` | Same | Same |
-| Subscription return | `spotapp://subscription/return` | Triggers subscription success handling in `DeepLinkState` | **TODO: verify** exact UX |
+| Subscription return | `spotapp://subscription/return` | If authenticated and server Pro state is active, shows `ProSuccessView` over the tab shell | Yes |
 | Profile / username path | `/u/{username}` | **Not implemented** in `DeepLinkRouter` today | N/A |
-| Invite / share beyond `/s/` | — | **TODO: verify** if marketing hosts other paths | — |
+| Invite / share beyond `/s/` | — | Not implemented by `DeepLinkRouter` | — |
 
 **HTTP localhost** — `DeepLinkRouter` accepts `http://localhost` with `/s/:spotId` for local testing.
 
@@ -116,4 +116,5 @@ Simulator note: Universal Links can be finicky; **validate on device** before re
 
 ## Open questions / TODOs
 
-- Confirm Settings “test deep link” UI still exists; old doc referenced it—**not found** in quick grep: TODO: verify in Settings views.
+- No Settings deep-link test UI exists in the current source.
+- Live AASA content remains a release-time external verification.

--- a/docs/operations/app-store-rejection-july-2026-fix-guide.md
+++ b/docs/operations/app-store-rejection-july-2026-fix-guide.md
@@ -321,7 +321,7 @@ See `Spot/Services/SubscriptionManager.swift` for implementation details.
 
 - [app-store-review-notes.md](./app-store-review-notes.md) - General review notes
 - [../product/pro-subscription.md](../product/pro-subscription.md) - Product spec
-- [../engineering/subscriptions.md](../engineering/subscriptions.md) - Technical implementation (if exists)
+- [../diagrams/subscription-flow.md](../diagrams/subscription-flow.md) - Purchase and entitlement flow
 
 ---
 

--- a/docs/operations/app-store-rejection-july-2026-fix-guide.md
+++ b/docs/operations/app-store-rejection-july-2026-fix-guide.md
@@ -19,7 +19,7 @@ This document provides step-by-step instructions to fix both issues.
 
 ## Issue 1: Guideline 3.1.2(c) - Missing EULA Link
 
-### What Apple Said
+### Guideline 3.1.2(c) review message
 > The submission did not include all the required information for apps offering auto-renewable subscriptions. The following information needs to be included in the App Store metadata: a functional link to the Terms of Use (EULA).
 
 ### What's Required
@@ -82,7 +82,7 @@ The link is now visible in the App Description field on App Store Connect and wi
 
 ## Issue 2: Guideline 2.1(b) - Subscription Failed to Load on iPad
 
-### What Apple Said
+### Guideline 2.1(b) review message
 > The In-App Purchase products in the app exhibited one or more bugs which create a poor user experience. Specifically, the app failed to load subscription. Review device details: iPad Air 11-inch (M3), iPadOS 26.5.
 
 ### Root Cause

--- a/docs/operations/app-store-review-notes.md
+++ b/docs/operations/app-store-review-notes.md
@@ -16,7 +16,7 @@ Verify all **TODO** items before each submission.
 
 ### Where subscription is presented
 
-**TODO: verify** all entry points; typically Profile → Settings → Pro / paywall surfaces.
+Profile and Settings expose “Go Pro.” Feature-limit call sites route through `PaywallRouter`, and `RootView` presents `PaywallView`.
 
 ### Product ID (code)
 
@@ -34,7 +34,7 @@ Spot detail links use `https://spotapp.online/s/{spotId}` (and `www` variant). S
 
 ### Moderation / safety (Guideline 1.2)
 
-The Spot binary submitted with this review enforces all four App Review UGC requirements end-to-end. See [../engineering/ugc-moderation.md](../engineering/ugc-moderation.md) for the full system.
+The repository implements Terms acknowledgement, server text filtering, reporting, blocking, and a moderator queue. Verify deployed backend state and the known media gaps below before asserting end-to-end compliance in submission notes.
 
 | Requirement | Where to verify in the build |
 | --- | --- |
@@ -44,7 +44,7 @@ The Spot binary submitted with this review enforces all four App Review UGC requ
 | Mechanism to block abusive users | "Block User" — ellipsis menu on another user's profile, plus toggle inside the report sheets. Block writes to `user_blocks`, the `homeFeedLocallyRemove` notification removes the blocked user's spots from the feed instantly, and `can_view_author` filters server-side from then on. |
 | Act on reports within 24 hours | `moderation_queue` view (service-role) prioritizes reports for the on-call moderator; SLA tracked by `select count(*) from moderation_queue where created_at < now() - interval '24 hours'`. |
 
-Images for Spots and profile photos additionally go through Azure Content Safety scoring (`media_assets` / `media_moderation_events`); rejected uploads receive non-graphic in-app messaging.
+Spot images go through Azure Content Safety scoring (`media_assets` / `media_moderation_events`) and rejected uploads receive non-graphic messaging. **Profile photos currently upload directly to the public `avatars` bucket and bypass moderation.** This conflicts with the product safety requirement and must be resolved before representing profile-image moderation as implemented to App Review.
 
 ### Privacy / support links
 

--- a/docs/operations/documentation-audit-2026-07.md
+++ b/docs/operations/documentation-audit-2026-07.md
@@ -1,0 +1,73 @@
+# Documentation audit — 2026-07
+
+## Purpose
+
+Record the July 2026 code-to-documentation audit, what was verified from source, and what still requires deployed-system or product-owner confirmation.
+
+## Scope
+
+The audit covered repository Markdown, app launch/auth/navigation, onboarding, feed, map, Search, profile/social, publishing, media moderation, Supabase/RLS, deep links, Pro, notifications, testing, CI/CD, and release operations.
+
+## Verified and refreshed
+
+| Area | Source of truth reviewed |
+| --- | --- |
+| Launch/auth/root navigation | `AppDelegate`, `SpotApp`, `RootView`, `AuthViewModel`, auth views and credential stores |
+| First-run onboarding | `SpotFirstRunOnboardingManager`, `BottomTabNavigationView` |
+| Feed and map | `FeedRepository`, `FeedAPI`, `FeedDiversity`, `MapViewModel`, `MapViewportLoader`, drawer policy |
+| Search and Spot presentation | `SearchViewModel`, `SearchService`, `SpotSearchDataSource`, shared `SpotCard` |
+| Profiles/social/privacy | `ProfileViewModel`, `ProfileService`, follow services, `AuthorPrivacyCache` |
+| Publishing/media | `PostFlowViewModel`, `PostDraftStore`, `SpotPublishCoordinator`, `SpotSupabaseRepository` |
+| Moderation and RLS | Edge Function source and committed migrations |
+| Deep links and Pro | `DeepLinkRouter`, `DeepLinkState`, `SubscriptionManager`, feature gates |
+| Notifications | `NotificationService`, `AppDelegate`, event consumers |
+| Build/release | Xcode project, test plans, scripts, and GitHub Actions workflows |
+
+## Waiting on external verification
+
+These cannot be closed from repository code:
+
+- staging and production migration parity;
+- deployed Edge Function versions and secret presence;
+- live Auth email-confirmation templates/provider settings;
+- AASA responses from both production hosts;
+- App Store Connect product metadata, pricing, agreements, and review credentials;
+- branch protection and required-check configuration;
+- production dashboard links and operational ownership.
+
+## Confirmed implementation gaps
+
+These are not documentation TODOs; they require code/backend work:
+
+1. Profile avatars bypass image moderation and use the public `avatars` bucket.
+2. Home-feed batch signing assumes `spots`, while moderated images can use `approved_spot_images`.
+3. Failed publish draft recovery is not transactional and approved unlinked media can remain.
+4. Moderated Storage buckets are not fully covered by client account-deletion cleanup.
+5. Notification delivery is local-only; social delivery and action navigation are incomplete.
+6. The Pro map Following filter receives no followed-user IDs.
+7. Complete base definitions for some feed/map RPCs are absent from migrations.
+8. App Check is linked but not initialized.
+
+## Documentation decisions
+
+- Current behavior is documented separately from target requirements.
+- Known safety gaps are explicit in review-facing docs.
+- `docs/engineering/runtime-flows.md` is the concise code path map.
+- Product feature pages own user-facing behavior; engineering pages own boundaries and failure modes; diagrams mirror actual flows.
+- Time-bound PRDs and audits may retain future requirements, but their status must not contradict current code.
+
+## Follow-up checklist
+
+- [ ] Resolve profile-image moderation before claiming full image moderation to App Review.
+- [ ] Export missing authoritative RPC definitions into migrations.
+- [ ] Verify both Supabase projects and update this audit with evidence.
+- [ ] Validate live AASA and release metadata.
+- [ ] Add automated Markdown link validation.
+- [ ] Re-audit after the pending auth, safety, or release work lands.
+
+## Related docs
+
+- [../engineering/runtime-flows.md](../engineering/runtime-flows.md)
+- [../engineering/image-moderation.md](../engineering/image-moderation.md)
+- [../engineering/supabase-environment-strategy.md](../engineering/supabase-environment-strategy.md)
+- [documentation-maintenance.md](documentation-maintenance.md)

--- a/docs/operations/runbooks.md
+++ b/docs/operations/runbooks.md
@@ -21,8 +21,10 @@ High-level; expand with dashboard deep links as your org standardizes them.
 
 ### Verify moderation function
 
-- Supabase → Edge Functions → `moderate-image` (name **TODO: verify**) → logs and error rate.
-- Submit a test image through staging app build.
+- Supabase → Edge Functions → `moderate-image` → invocation logs and error rate.
+- Submit a safe test image through a staging build and confirm HTTP 200 with `approved=true`.
+- Exercise a policy fixture expecting 422 and a controlled unavailable-provider path expecting retryable 503.
+- Confirm the Edge Function, Azure secrets, and Storage promotion are configured separately in staging and production.
 
 ### Verify Universal Links
 
@@ -33,6 +35,20 @@ High-level; expand with dashboard deep links as your org standardizes them.
 
 - App Store Connect → agreements, tax, banking.
 - Sandbox purchase of product id **`spotPro`** (`SpotProProducts.swift`).
+
+### Verify release environment
+
+- `main` / Firebase: confirm embedded project ref is staging (`aeurigbbohyxvtsfiyul`).
+- `release/**` / TestFlight: confirm production secrets were injected for `gomdoguewaawdlvijahg`.
+- Sign in with an environment-specific account; cross-environment credentials should not work.
+- Smoke-test feed, map, Search, profile, deep link, and one controlled moderated publish.
+
+### Check orphan media
+
+- Inspect `media_assets` grouped by `status` and `linked_spot_id`.
+- Investigate old `pending`, `failed`, `rejected`, or approved-unlinked rows before deletion.
+- Storage objects require separate inspection; deleting a database row does not guarantee blob deletion.
+- No scheduled cleanup is defined in this repository, so use a reviewed, environment-specific procedure.
 
 ### Safety / moderation incident
 

--- a/docs/product/auth-reliability-prd.md
+++ b/docs/product/auth-reliability-prd.md
@@ -6,12 +6,12 @@ Make account creation, email verification, login, and session restoration reliab
 
 ## Status
 
-- **Priority:** P0 release blocker
+- **Priority:** P0 reliability requirements; implementation substantially landed, live-environment validation remains release-blocking
 - **Owner:** TODO
 - **Target:** Before release candidate approval
-- **Last reviewed:** 2026-07-27
+- **Last reviewed:** 2026-07-28
 - **Evidence basis:** Repository audit. Live staging and production Supabase configuration still requires verification.
-- **Client implementation:** In progress on the authentication reliability branch
+- **Client implementation:** Editorial auth, OTP recovery, typed username availability, email-only login, and session-preserving fresh-install handling are present
 - **Approved UX:** Option A editorial welcome plus create-account, OTP, returning-account, and email-login flow
 
 ## Problem statement
@@ -22,16 +22,15 @@ Current tester reports:
 2. Credentials for a newly created account do not work.
 3. Every attempted username is reported as taken.
 
-The repository audit found code paths that can produce all three symptoms:
+The original audit identified credible causes, but the current repository has addressed several:
 
-- `FreshInstallDetector` deliberately signs out a valid Keychain session when its UserDefaults install marker is absent.
-- Debug builds use staging while distributed Release builds are intended to use production. Sessions and accounts are scoped to the Supabase project, so switching environments looks like a logout and credentials created in one environment do not exist in the other.
-- Username availability treats every RPC error as `false`, which the UI presents as “Username is already taken.”
-- The required `is_username_available` and `resolve_login_email` RPC definitions are not present in committed migrations.
-- Pending email verification exists only in memory. Relaunching before OTP completion loses the verification screen.
-- Login collapses unconfirmed-email and most other authentication failures into “Incorrect email/username or password.”
+- `FreshInstallDetector` now preserves the Keychain session and resets only install-scoped caches.
+- DEBUG and Firebase builds use staging; TestFlight/App Store builds use production. Accounts remain environment-scoped, so artifact misrouting still looks like missing credentials.
+- Username availability uses typed outcomes and `20260727210000_username_availability_v1.sql` versions `is_username_available`.
+- Pending verification email and timestamp are stored in Keychain by `AuthVerificationRecoveryStore` with a 72-hour lifetime.
+- Login is intentionally email-only. Unverified-email failures have distinct recovery copy; a public username-to-email resolver is not part of the approved design.
 
-These findings establish credible code-level causes but do not prove which one occurred in a specific production incident. Runtime telemetry and live Supabase checks are required.
+Live staging/production Auth settings, migration parity, and upgrade behavior still require runtime verification; source review cannot prove a historical tester incident.
 
 ## Goals
 
@@ -58,9 +57,9 @@ These findings establish credible code-level causes but do not prove which one o
 
 - The Supabase SDK stores its session in Keychain and emits the local session at startup: `Spot/Supabase/Supabase.swift`.
 - `AuthViewModel` restores authentication from `supabase.auth.authStateChanges`: `Spot/Services/Auth/AuthViewModel.swift`.
-- `FreshInstallDetector.handleFreshInstall()` checks a UserDefaults marker. If the marker is missing but Keychain still contains a session, it calls `supabase.auth.signOut()`: `Spot/Utils/FreshInstallDetector.swift`.
+- `FreshInstallDetector.handleFreshInstall()` checks a UserDefaults marker and resets feed, deep-link, onboarding/permission markers, and related install-scoped caches without signing out the Supabase session.
 - Debug builds select staging. Release builds select production or an injected plist configuration. Different Supabase projects have different account stores and Keychain session keys: `Spot/Supabase/Supabase.swift`.
-- Firebase App Distribution and TestFlight workflows intend to inject production configuration: `.github/workflows/deploy.yml` and `.github/workflows/testflight.yml`.
+- Firebase App Distribution injects and validates staging configuration. TestFlight requires production configuration: `.github/workflows/deploy.yml` and `.github/workflows/testflight.yml`.
 
 A genuine in-place update should preserve both UserDefaults and Keychain. Therefore, repeated logout on every update suggests at least one of:
 
@@ -71,20 +70,20 @@ A genuine in-place update should preserve both UserDefaults and Keychain. Theref
 
 ### Username availability
 
-`SignupView.validateAndSignUp()` asks `AuthViewModel.isUsernameAvailable()`. That method catches every error and returns `false`; the view always translates `false` to “Username is already taken”:
+`SignupView` uses `AuthViewModel.usernameAvailability` to distinguish available, taken, invalid, and temporarily unavailable outcomes. Final uniqueness remains database-enforced:
 
 - `Spot/Views/Auth/SignupView.swift`
 - `Spot/Services/Auth/AuthViewModel.swift`
 
-The client invokes `is_username_available`, but no definition is committed under `supabase/migrations/`. This can make every username appear taken when the function is missing, not deployed, not granted to `anon`, or temporarily unavailable.
+The client invokes `is_username_available`, defined by `20260727210000_username_availability_v1.sql`. Deployment and grants still need verification in both projects.
 
 ### Newly created account login
 
 - Email/password signup requires a six-digit signup OTP in the current UI.
-- Pending verification email and state are memory-only in `AuthViewModel`.
-- If the app terminates before verification, relaunch returns to the signed-out welcome flow.
-- Attempting login before confirmation can return Supabase’s email-not-confirmed error, but `LoginView` presents the generic incorrect-credentials message.
-- Username login invokes `resolve_login_email`, whose definition is also absent from committed migrations.
+- Pending verification email and timestamp persist in Keychain through `AuthVerificationRecoveryStore`; passwords and OTPs are not stored.
+- Relaunch within the recovery lifetime restores `ConfirmEmailView`.
+- `LoginView` distinguishes the unverified-email case from generic invalid credentials.
+- Login accepts email only. `resolve_login_email` is intentionally not implemented because returning account email from public username resolution would create enumeration risk.
 - The profile synchronization RPC is versioned in `20260702120000_sync_current_user_security_definer_v1.sql`, but deployment to both live projects must be confirmed.
 
 ## Product requirements
@@ -310,7 +309,7 @@ The app is not authentication-ready for release until:
 | Cross-device login | Sign in with Apple and Password AutoFill now; passkeys after Supabase setup | Product/Engineering |
 | Email confirmation mode | Six-digit OTP, matching the approved UI | TODO: verify Supabase |
 | Verification recovery storage | Device-local Keychain email + timestamp only | Engineering |
-| Username normalization | One client/database contract, case-insensitive | TODO: approve with database migration |
+| Username normalization | Implemented as lowercased/trimmed with shared syntax and database uniqueness | Product/Engineering |
 
 ## Live verification checklist
 
@@ -318,7 +317,7 @@ These items cannot be established from repository code alone:
 
 - Confirm the distributed failing build’s embedded Supabase project.
 - Confirm `is_username_available` exists and is callable by the intended role in staging and production.
-- Confirm whether any `resolve_login_email` implementation exists outside migrations; remove or security-review it.
+- Confirm no deployed anonymous username-to-email resolver remains from an earlier experiment.
 - Confirm `sync_current_user_v1` is applied in both projects.
 - Confirm email confirmation and OTP template settings in both projects.
 - Reproduce the update logout while capturing structured auth and install logs.
@@ -333,6 +332,7 @@ These items cannot be established from repository code alone:
 - `Spot/Views/Auth/ConfirmEmailView.swift`
 - `Spot/Utils/FreshInstallDetector.swift`
 - `supabase/migrations/20260702120000_sync_current_user_security_definer_v1.sql`
+- `supabase/migrations/20260727210000_username_availability_v1.sql`
 - [Networking and auth](../engineering/networking-and-auth.md)
 - [Supabase environment strategy](../engineering/supabase-environment-strategy.md)
 - [Database and RLS](../engineering/database-and-rls.md)

--- a/docs/product/home-feed.md
+++ b/docs/product/home-feed.md
@@ -21,21 +21,27 @@ The **home feed** is the default discovery surface after launch: a ranked, pagin
 ### Ranking behavior
 
 - **Server-side candidate set and ranking** via `get_home_feed_v1` (authoritative for production feed).
-- **Client** signs primary images for display and manages `FeedLoadState` (initial load, load more, empty reasons, errors, refresh toasts).
+- **Client** hydrates rows, signs primary images for display, and manages `FeedLoadState` (initial load, load more, empty reasons, errors, refresh toasts).
 - **`FeedDiversity`** — after hydration, the first home page is lightly reordered using `user_feed_profiles` signal strength so a single liked vibe does not fill the entire window when other tags exist in the page (`Spot/Services/Feed/FeedDiversity.swift`).
-- **`FeedRanker`** — on-device scoring documented in tests / non-RPC experiments; not the sole source of truth for shipped feed unless product changes that.
+- **`FeedRanker`** — on-device scoring with tests but no production call site; it is not part of the shipped feed path.
 
 ### Signals (may influence ranking)
 
-Exact weighting is **server-defined** in Postgres/RPC. Likely inputs include creator relationship, vibes, recency, location, and user actions—**TODO: verify** in SQL migration or function definition for `get_home_feed_v1`.
+Exact weighting is **server-defined** in Postgres/RPC. The client passes `p_limit`, viewer latitude/longitude, a batch ID, and a seen-fallback flag. The repository does not contain the complete authoritative base definition of `get_home_feed_v1`, so exact weights cannot be reconstructed from this checkout.
 
-Plausible client/server inputs to keep in mind:
+Verified surrounding data and client inputs include:
 
 - Creator identity and follow graph
 - Vibe tags
 - Location / distance
 - Likes, bookmarks, follows
 - Impressions / dedupe (`feed_impressions` mentioned in `FeedRepository`)
+
+### Pagination and telemetry
+
+The page size is 24. Pagination is not offset-based: each load-more request asks the server for another impression-aware batch and the client deduplicates IDs. Two consecutive empty load-more results, or a partial seen-fallback page, ends pagination.
+
+`FeedEventService` records impression, two-second visibility, long dwell, and quick-skip events through `record_feed_event_v1`. The initial hydrated page is diversified on-device; subsequent pages preserve server order.
 
 ### Privacy and safety
 
@@ -54,4 +60,5 @@ Plausible client/server inputs to keep in mind:
 
 ## Open questions / TODOs
 
-- Document exact RPC parameters and scoring once reviewed in Supabase SQL: TODO: verify in database repo / migrations.
+- Commit the authoritative base feed and map RPC definitions as migrations so ranking and visibility behavior can be reviewed from source control.
+- Make home-feed image signing bucket-aware for moderated media; current batch signing assumes the legacy `spots` bucket.

--- a/docs/product/home-feed.md
+++ b/docs/product/home-feed.md
@@ -14,7 +14,7 @@ Primary implementation: `Spot/Services/Feed/FeedRepository.swift` using Supabase
 
 ## Details
 
-### Purpose
+### Experience
 
 The **home feed** is the default discovery surface after launch: a ranked, paginated list of Spots tailored to the viewer.
 

--- a/docs/product/internal-test-email-verification-prd.md
+++ b/docs/product/internal-test-email-verification-prd.md
@@ -9,7 +9,7 @@ Provide authorized internal testers with a memorable non-production verification
 - **Stage:** Discovery and proposal
 - **Priority:** P2 internal quality tooling
 - **Owner:** TODO
-- **Last reviewed:** 2026-07-27
+- **Last reviewed:** 2026-07-28
 - **Approval:** Product, Security, and Engineering approval required before implementation
 - **Implementation:** Not started
 - **Backend verification:** Supabase proof of concept still required
@@ -54,15 +54,15 @@ The closest equivalent to an internal `UT####` code is a staging-only server exc
 - `ConfirmEmailView` accepts six numeric characters and uses a number pad: `Spot/Views/Auth/ConfirmEmailView.swift`.
 - `AuthViewModel.verifySignupEmailOTP` calls `supabase.auth.verifyOTP(email:token:type:.signup)`, then completes profile setup and synchronization: `Spot/Services/Auth/AuthViewModel.swift`.
 - Verification recovery currently persists the normalized email and start time, but not the pending Supabase user ID: `Spot/Services/Auth/AuthCredentialStores.swift`.
-- Local DEBUG builds select staging, while Release builds select production or injected production configuration: `Spot/Supabase/Supabase.swift`.
+- Local DEBUG builds select staging. Release builds prefer workflow-injected configuration: Firebase injects staging and TestFlight injects production.
 
 ### Distribution
 
-- Firebase App Distribution currently builds a Release artifact and injects production Supabase configuration: `.github/workflows/deploy.yml`.
-- TestFlight builds also use production Supabase configuration: `.github/workflows/testflight.yml`.
+- Firebase App Distribution builds a Release artifact but injects and validates **staging** Supabase configuration: `.github/workflows/deploy.yml`.
+- TestFlight builds inject **production** Supabase configuration: `.github/workflows/testflight.yml`.
 - There is no dedicated `INTERNAL_TESTING` Swift compilation condition.
 
-Therefore, a `#if DEBUG` feature would work only for local DEBUG builds. It would not be available to Firebase App Distribution testers, and enabling it there before environment isolation would target production.
+Therefore, a `#if DEBUG` feature would work only for local DEBUG builds. Firebase App Distribution now targets staging, but an internal verification client still needs an explicit build/runtime gate because Firebase artifacts are Release builds.
 
 ### Supabase
 

--- a/docs/product/internal-test-email-verification-prd.md
+++ b/docs/product/internal-test-email-verification-prd.md
@@ -48,7 +48,7 @@ The closest equivalent to an internal `UT####` code is a staging-only server exc
 
 ## Current behavior and evidence
 
-### Client
+### Current client
 
 - `SignupView` calls `supabase.auth.signUp` and enters pending verification when no session is returned: `Spot/Views/Auth/SignupView.swift`.
 - `ConfirmEmailView` accepts six numeric characters and uses a number pad: `Spot/Views/Auth/ConfirmEmailView.swift`.
@@ -160,7 +160,7 @@ The following names are proposed; values must exist only in Supabase staging Fun
 
 Supabase-provided server credentials remain in the function environment. No service-role or secret key may be added to the iOS app.
 
-### Client
+### Proposed client
 
 The client implementation should:
 
@@ -197,7 +197,7 @@ If a legacy recovery record has no user ID, internal verification is unavailable
 | Firebase internal distribution | `INTERNAL_TESTING`, Release optimization | Staging | May be enabled |
 | TestFlight/App Store | Production Release | Production | Must be absent |
 
-Before this feature can serve Firebase testers, `.github/workflows/deploy.yml` must stop injecting production Supabase credentials and must define the reviewed internal-testing compilation condition. This environment change is a separate release-sensitive decision and must include artifact verification.
+Firebase already injects staging Supabase credentials. Before this feature can serve Firebase testers, the workflow must define a reviewed internal-testing compilation condition and verify both that condition and the staging project in the built artifact.
 
 ### Defense in depth
 

--- a/docs/product/map-experience.md
+++ b/docs/product/map-experience.md
@@ -27,10 +27,14 @@ Markers use branded colors from `Constants.Colors` (map marker greens, cluster f
 - Tapping a spot opens or updates the drawer.
 - Tapping a **different** spot should **replace** the selection and drawer content for the new Spot.
 - **Panning/zooming** away from the selected spot sufficiently should **dismiss** the drawer (policy encoded in map view model / coordinator—keep in sync with tests).
+- A region center change above approximately `1e-5`, or a span change above 1.5%, is meaningful. Programmatic camera changes suppress dismissal for 0.55 seconds.
+- The drawer itself uses `MapSpotPreviewCard` and the shared `SpotCard`; there is no separate full-detail navigation from the drawer.
 
 ### Pro filtering
 
-Pro-only map filters (if present) must remain **clearly gated** behind entitlement checks and covered by tests where possible.
+Pro-only filters cover vibe, saved, liked, and following. `MapFilterGate` hides filter controls for non-Pro users. Filters are applied client-side to viewport RPC results.
+
+The Following filter is a known limitation: `MapView` currently passes an empty followed-user ID set, so that filter cannot return matching markers until social graph state is wired into the map.
 
 ### Location permission
 
@@ -56,8 +60,7 @@ flowchart TD
   D -->|Yes| E[Select Spot]
   E --> F[Open spot drawer]
   F --> G{User taps another pin?}
-  G -->|Yes| H[Close existing drawer]
-  H --> I[Open drawer for new Spot]
+  G -->|Yes| H[Replace selected Spot and drawer content]
   F --> J{User pans or zooms away?}
   J -->|Yes| K[Close drawer]
   F --> L{User dismisses drawer?}
@@ -72,4 +75,4 @@ flowchart TD
 
 ## Open questions / TODOs
 
-- Exact numeric thresholds for “panned away” dismiss: see implementation next to `MapDrawerDismissReason` (or equivalent).
+- Wire followed-user IDs into the Pro Following filter.

--- a/docs/product/map-experience.md
+++ b/docs/product/map-experience.md
@@ -14,7 +14,7 @@ Map UI lives under `Spot/Views/Home/MapView.swift`, `SharedSpotMap`, `MapControl
 
 ## Details
 
-### Purpose
+### Experience
 
 The **map** lets users discover Spots near a viewport: markers (and density visualization), selection, and a **spot drawer** (bottom card) for quick preview.
 

--- a/docs/product/onboarding.md
+++ b/docs/product/onboarding.md
@@ -10,7 +10,7 @@ Product, UX, engineering, support.
 
 ## Current status
 
-Based on `Spot/Managers/HomeTourManager.swift` (`HomeTourManager`, `SpotFirstRunOnboardingManager`).
+Verified against `SpotFirstRunOnboardingManager` and its production host in `BottomTabNavigationView` on 2026-07-28.
 
 ## Details
 
@@ -20,8 +20,9 @@ Onboarding orients new users to **what a Spot is**, **vibe tags**, **likes/bookm
 
 ### Entry points and behavior
 
-1. **`HomeTourManager`** — Short tour after first session post-signup when `startIfNeeded(isFirstSessionAfterSignup:)` is true and `homeTourAccepted` is false in `UserDefaults`. Steps: username, location, vibe, like/save coach (`HomeTourManager.Step`).
-2. **`SpotFirstRunOnboardingManager`** — Longer multi-step coach (`SpotFirstRunOnboardingManager.Step`: welcome, spot card, details, vibe, like, bookmark, creator, map tab, user location, markers, marker preview, finale). Completion/skips tracked under `spotFirstRunOnboarding.*` keys in `UserDefaults`.
+`SpotFirstRunOnboardingManager` is the active production coach. `BottomTabNavigationView` evaluates it after authentication for a first-session candidate (no liked or bookmarked Spots). Steps are: welcome, Spot card, details, vibe, like, bookmark, creator, map tab, user location, markers, marker preview, and finale. Completion or skip is tracked per user under `spotFirstRunOnboarding.*` keys in `UserDefaults`.
+
+`HomeTourManager` remains in source and unit tests for migration compatibility, but `HomeTourHost` is not mounted in production navigation. The active manager migrates legacy `hasSeenHomeTour.*` state so returning users are not shown duplicate coaching.
 
 ### What onboarding teaches
 
@@ -31,13 +32,15 @@ Onboarding orients new users to **what a Spot is**, **vibe tags**, **likes/bookm
 - **Follow** creators.
 - **Map tab**, **user location**, **markers**, **marker preview** → bridge into map discovery.
 
+At the user-location step, onboarding can present the location permission sheet. Completing or skipping the coach can present the notification pre-prompt after a 600 ms delay when authorization is still undetermined. Neither permission blocks authentication or access to the tab shell.
+
 ### Pro tour
 
 The codebase includes flows for **Pro** (paywall, StoreKit). **Do not change the existing Pro purchase / tour UX** unless a task explicitly asks for it—per team rule preserved in `.cursor/rules/project.mdc`.
 
 ### Distinction: “normal” onboarding vs Pro
 
-- **Normal onboarding** — `HomeTourManager` / `SpotFirstRunOnboardingManager` for core app literacy.
+- **Normal onboarding** — `SpotFirstRunOnboardingManager` for core app literacy.
 - **Pro** — Subscription paywall and entitlements; separate from first-run coach content.
 
 ## Related docs
@@ -45,7 +48,8 @@ The codebase includes flows for **Pro** (paywall, StoreKit). **Do not change the
 - [user-flows.md](user-flows.md)
 - [map-experience.md](map-experience.md)
 - [../engineering/architecture.md](../engineering/architecture.md)
+- [../engineering/notifications.md](../engineering/notifications.md)
 
 ## Open questions / TODOs
 
-- Exact UI triggers wiring `startIfNeeded` from which screen: TODO: verify in `RootView` / tab shell.
+- None.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -39,9 +39,9 @@ A **Spot** is a user-created post: typically photos, a place, **vibe tags**, cap
 | **Post** | Multi-step flow to create and publish a Spot (media, place, vibes, publish). |
 | **Search** | Users, places, vibes. |
 | **Profile** | User’s Spots, social graph, settings, Pro entry points. |
-| **Onboarding** | First-run coach flows (`HomeTourManager`, `SpotFirstRunOnboardingManager`). |
+| **Onboarding** | Active first-run coach (`SpotFirstRunOnboardingManager`); legacy tour state is migrated. |
 | **Pro** | Subscription via StoreKit; gated features (see [pro-subscription.md](pro-subscription.md)). |
-| **Support / legal** | Settings and policy surfaces as implemented in app (exact URLs: TODO: verify in app Settings). |
+| **Support / legal** | Settings links to `spotapp.online/privacy`, `spotapp.online/terms`, and `support@spotapp.online`. |
 
 ### Product principles
 
@@ -59,4 +59,4 @@ A **Spot** is a user-created post: typically photos, a place, **vibe tags**, cap
 
 ## Open questions / TODOs
 
-- Exact legal/support URLs and in-app entry points: TODO: verify in codebase / App Store listing.
+- Confirm App Store Connect metadata matches the code-verified legal URLs before each submission.

--- a/docs/product/posting-flow.md
+++ b/docs/product/posting-flow.md
@@ -22,6 +22,8 @@ User opens **Post** tab → multi-step composer (`Spot/Views/PostFlow`) → sele
 
 Photos are chosen from the library or camera per system permissions (`Constants.UserDefaultsKeys` track permission prompts).
 
+Free accounts can publish one photo and one vibe tag. Pro accounts can publish up to five photos and five vibe tags. The publish RPC independently enforces entitlement limits.
+
 ### Location
 
 User confirms or selects a place (canonical places JSON + search: `LocationSelectionView`).
@@ -32,7 +34,9 @@ User picks from known tags and adds caption/details as the UI allows.
 
 ### Draft behavior
 
-Draft persistence (local vs server): **TODO: verify** in `PostFlowViewModel` and related persistence code.
+`PostDraftStore` persists drafts locally under Application Support, including a reserved `autosave` draft and user-saved drafts. Draft metadata is indexed locally; no server draft table is involved.
+
+Submission persists a snapshot before JPEG encoding and queueing. The composer resets as soon as `SpotPublishCoordinator` accepts the job, allowing the user to leave the Post tab while the global publish banner reports progress.
 
 ### Publish and moderation
 
@@ -43,10 +47,12 @@ Every image for Spots must pass **moderation** before being treated as approved 
 | Condition | Expected UX (high level) |
 | --- | --- |
 | Not authenticated | Block publish; route to auth. |
-| Upload fails | Error state; user can retry; draft preserved where applicable. |
+| Upload fails | Error toast; a pre-queue local snapshot normally exists. |
 | Moderation rejects | Safe message; do not publish. |
 | Supabase insert / RPC fails | Error; preserve draft where applicable. |
-| Network unavailable | Retry / offline messaging per implementation. |
+| Network unavailable | Retryable error messaging; no offline publish queue. |
+
+The coordinator has a 90-second timeout. A partial multi-image failure can leave approved but unlinked media assets. Current failure handling can also persist the already-reset composer over the earlier autosave, so the “saved to drafts” timeout copy does not guarantee full recovery. Treat this as a known implementation gap, not a recovery contract.
 
 ### Flow diagram
 
@@ -60,12 +66,13 @@ flowchart TD
   F --> G{User action}
   G -->|Save draft| H[Persist draft locally]
   G -->|Publish| I[SpotPublishCoordinator enqueue]
-  I --> J[Upload to Supabase pending_images]
-  J --> K[Edge Function moderate-image]
-  K --> L{Approved?}
-  L -->|No| M[Show blocked reason]
-  L -->|Yes| N[RPC publish_spot_with_approved_media_assets_v1]
-  N --> O[Show success / feed update]
+  I --> J[Create pending media_assets row]
+  J --> K[Upload to Supabase pending_images]
+  K --> L[Edge Function moderate-image]
+  L --> M{Approved?}
+  M -->|No| N[Show safe failure]
+  M -->|Yes| O[RPC publish_spot_with_approved_media_assets_v1]
+  O --> P[Show success / optimistic feed update]
 ```
 
 ## Related docs
@@ -76,4 +83,4 @@ flowchart TD
 
 ## Open questions / TODOs
 
-- Exact draft storage and recovery UX: TODO: verify in Post flow view models.
+- Add orphan-media cleanup and make failed-publish draft recovery transactional before promising guaranteed recovery.

--- a/docs/product/pro-subscription.md
+++ b/docs/product/pro-subscription.md
@@ -16,7 +16,7 @@ StoreKit integration: `Spot/Services/SubscriptionManager.swift`, product IDs in 
 
 ### What Pro is
 
-**Pro** is the paid subscription tier unlocking premium capabilities (exact feature list: **TODO: verify** in paywall copy and `ProEntitlementChecker` usage across features).
+**Pro** is the paid subscription tier unlocking premium creation, saving, map, and Search capabilities.
 
 ### Product ID (code)
 
@@ -28,7 +28,7 @@ StoreKit integration: `Spot/Services/SubscriptionManager.swift`, product IDs in 
 
 ### Paywall entry points
 
-Common entry points include Profile / Settings / “Go Pro” surfaces and feature gates—**TODO: verify** all `PaywallRouter` / paywall presentation call sites.
+Profile and Settings expose “Go Pro.” Feature limits route through `PaywallRouter.show()`, which posts `.showPaywall`; `RootView` owns the paywall sheet. Successful purchase can post `.showPostPurchaseProOnboarding`.
 
 ### Restore purchases
 
@@ -36,12 +36,21 @@ Common entry points include Profile / Settings / “Go Pro” surfaces and featu
 
 ### Pro-gated features
 
-Examples may include map filters or badges—**TODO: verify** by searching `hasPro`, `ProEntitlement`, or `SubscriptionManager` consumers.
+| Feature | Free | Pro |
+| --- | --- | --- |
+| Photos per Spot | 1 | Up to 5 |
+| Vibe tags per Spot | 1 | Up to 5, including composer custom-vibe support |
+| Bookmarks | 50 | Unlimited with collections UI |
+| Map filters | Hidden | Vibe, saved, liked, following |
+| Search filters | Basic grids | Location plus selected vibe tags |
+| Map user marker | Standard green ring | Gold ring |
+
+Entitlement state combines StoreKit transaction updates with server `is_pro` / `pro_until` fields. Publish limits are enforced again by the Supabase RPC.
 
 ### Subscription testing
 
 - Use **Sandbox** Apple IDs and Xcode StoreKit testing configuration.
-- **TODO: verify** StoreKit Configuration file presence in the Xcode project.
+- Local StoreKit testing uses `Spot/StoreKit/SpotDev.storekit`, which contains the yearly `spotPro` product.
 
 ### Localized price
 
@@ -55,4 +64,5 @@ Built from `SubscriptionPriceLineFormatter` + `Product` subscription period.
 
 ## Open questions / TODOs
 
-- Complete feature gate inventory and screenshot list for review: TODO: verify with product.
+- Confirm App Store Connect pricing, product metadata, and review screenshots outside the repository before release.
+- The map Following filter is visible to Pro users but does not yet receive followed-user IDs.

--- a/docs/product/profiles-and-social.md
+++ b/docs/product/profiles-and-social.md
@@ -26,11 +26,19 @@ Some profiles or content may be **private** to non-followers or pending requests
 
 ### Follow / following
 
-Follow graph and optional **follow requests** are backed by Postgres (see migrations such as `20260503100000_follow_requests_revoke_client_update.sql`). UX: request, accept, revoke—**TODO: verify** exact screens.
+Public profiles use direct follow/unfollow actions. Private profiles use request, requested/cancel, accept, and deny states backed by `follows` and `follow_requests`.
+
+`ProfileView` opens `FollowRequestsView` for the current user's pending requests and polls the pending count every eight seconds. `FollowRequestsService` paginates 24 requests at a time. `UserSpotService` mutates follow relationships, and `AuthorPrivacyCache` is invalidated after graph changes.
 
 ### Bookmarks and likes
 
 Users save Spots (**bookmarks**) and react with **likes**; both feed ranking and profile grids.
+
+Likes and bookmarks are loaded as complete ID sets rather than truly paginated grids. Pro users receive bookmark collections; free users use a flat bookmark grid and have a 50-bookmark cap.
+
+### Privacy boundary
+
+`ProfileService` reads `users_public`, determines whether the viewer is self, following, or pending, and only requests a private author's Spots when `canView` is true. Supabase RLS and `can_view_author` / `can_view_spot` remain authoritative.
 
 ## Related docs
 
@@ -39,4 +47,5 @@ Users save Spots (**bookmarks**) and react with **likes**; both feed ranking and
 
 ## Open questions / TODOs
 
-- Map each social action to concrete tables/RPCs in a future pass: TODO: verify against `SpotSupabaseRepository` and migrations.
+- Remote follow notifications are not implemented; see [notifications.md](../engineering/notifications.md).
+- Likes and bookmark lists need real pagination for large accounts.

--- a/docs/product/search-experience.md
+++ b/docs/product/search-experience.md
@@ -1,0 +1,73 @@
+# Search experience
+
+## Purpose
+
+Describe the Search tab, its result types, pagination, privacy handling, and Pro filters.
+
+## Audience
+
+Product, design, engineering, and QA.
+
+## Current status
+
+Verified against `SearchView`, `SearchViewModel`, `SearchService`, and `SpotSearchDataSource` on 2026-07-28.
+
+## Search surfaces
+
+Search has three segments:
+
+| Segment | Suggestions | Selection result |
+| --- | --- | --- |
+| Users | Prefix-filtered profiles from `users_public` | Opens the selected profile |
+| Locations | Distinct `spots.location_name` prefix matches | Opens a paginated Spot grid |
+| Vibes | Prefix matches from `vibe_tags` | Opens a paginated Spot grid |
+
+Queries are debounced by 300 ms. Search history is stored per segment by `SearchHistoryManager`.
+
+## Result and detail flow
+
+Location and vibe grids load 24 Spots at a time. Their cursor is a string-encoded offset. Because privacy filtering can remove rows after a page is fetched, `SearchViewModel` may request up to five backend pages to fill one visible page.
+
+A selected grid result is displayed as the shared `SpotCard` presentation inside Search. Spot does not have a separate `SpotDetailView`; the same card presentation is reused by feed, map, profile, Search, and deep-link surfaces.
+
+```mermaid
+flowchart TD
+  A[Open Search tab] --> B{Segment}
+  B -->|Users| C[Debounced profile suggestions]
+  B -->|Locations| D[Debounced location suggestions]
+  B -->|Vibes| E[Debounced vibe suggestions]
+  C --> F[Open profile]
+  D --> G[Load 24-Spot location grid]
+  E --> H[Load 24-Spot vibe grid]
+  G --> I[Apply authoritative RLS plus client privacy filter]
+  H --> I
+  I --> J[Select Spot]
+  J --> K[Show shared SpotCard]
+```
+
+## Privacy and safety
+
+Supabase RLS and visibility functions are authoritative. `SearchService` additionally uses `AuthorPrivacyCache` to remove blocked or non-viewable private-author results. That cache is additive protection and must never replace server enforcement.
+
+## Pro behavior
+
+Pro users can open location-grid filters and combine a location with selected vibe tags. The filter entry point is hidden for non-Pro users. A vibe result grid does not show the location-plus-vibe filter.
+
+## Loading, empty, and error states
+
+- Initial suggestions and grid loading have separate loading state.
+- Empty suggestions and empty Spot grids are represented independently.
+- Grid loading deduplicates Spot IDs across pages.
+- Privacy-filtered pages can be empty even when the backend returned rows; bounded refetching prevents an endless loop.
+
+## Known limitations
+
+- User search fetches up to roughly 400 public profiles and performs prefix filtering on-device; it is not server-paginated.
+- Likes and bookmarks displayed from profile flows are not part of Search pagination.
+
+## Related docs
+
+- [home-feed.md](home-feed.md)
+- [profiles-and-social.md](profiles-and-social.md)
+- [pro-subscription.md](pro-subscription.md)
+- [../engineering/database-and-rls.md](../engineering/database-and-rls.md)

--- a/docs/product/support-and-policies.md
+++ b/docs/product/support-and-policies.md
@@ -20,13 +20,20 @@ Spot exposes:
 - **Privacy policy** — `https://spotapp.online/privacy` (signup, paywall, Settings → Legal).
 - **Terms of Use** — `https://spotapp.online/terms` (signup, paywall, Settings → Legal).
 
-Safety workflows (block users, report content) live under profile/settings flows—implementation details in respective Swift files.
+Safety entry points:
+
+- **Report a Spot** — `SpotCard` menu → `ReportSheet`.
+- **Report a profile** — another user's profile menu → `ProfileReportSheet`.
+- **Block a user** — profile or report confirmation; the feed removes that author's Spots immediately.
+- **Manage blocks** — Settings → `BlockedUsersView`.
+- **Delete account** — Settings, confirmation, and password or Sign in with Apple reauthentication.
 
 ## Related docs
 
 - [../operations/app-store-review-notes.md](../operations/app-store-review-notes.md)
 - [../operations/incident-response.md](../operations/incident-response.md)
+- [../engineering/ugc-moderation.md](../engineering/ugc-moderation.md)
 
 ## Open questions / TODOs
 
-- Replace this section with concrete links once verified in the app bundle / website.
+- External website availability remains an operational check even though the configured URLs are verified in code.

--- a/docs/product/terminology.md
+++ b/docs/product/terminology.md
@@ -22,7 +22,7 @@ Aligned with in-app naming and common Supabase/iOS terms used in this repo.
 | **Feed** | Home scrolling list of Spots from `FeedRepository` / `get_home_feed_v1`. |
 | **Map marker / pin** | Map annotation representing one or more Spots (clustering may apply). |
 | **Spot drawer / bottom drawer** | Bottom sheet/card on the map showing the selected Spot preview. |
-| **Draft** | In-progress Spot before publish (local or server persistence: TODO: verify exact draft storage). |
+| **Draft** | Locally persisted in-progress Spot managed by `PostDraftStore` (autosave or user-saved). |
 | **Pro** | Paid subscription tier; product ID `spotPro` (yearly) in `SpotProProducts.swift`. |
 | **Universal Link** | `https` link on allowed hosts (e.g. `spotapp.online`) that opens the app via Associated Domains. |
 | **Moderation** | Automated image safety checks (Azure Content Safety in DB migrations) before approved storage paths. |

--- a/docs/product/user-flows.md
+++ b/docs/product/user-flows.md
@@ -10,51 +10,61 @@ Design, product, engineering, QA.
 
 ## Current status
 
-High-level flows match `RootView`, auth, tabs, `DeepLinkState`, and onboarding managers in the codebase.
+Verified against `SpotApp`, `RootView`, the tab shell, `DeepLinkState`, and active onboarding wiring on 2026-07-28.
 
 ## Details
 
 ### Flows covered
 
-- First launch → auth check → onboarding (if applicable) → main tabs.
-- Sign in (email flow and Sign in with Apple: see auth views under `Spot/Views/Auth`).
-- Onboarding coach (`HomeTourManager`, `SpotFirstRunOnboardingManager`).
-- Browse home feed, open Spot detail from feed.
-- Map: browse, tap pin, spot drawer, navigate to full detail if offered.
-- Create post → publish (with moderation gate).
-- Profile, follow, Pro paywall, Universal Link open.
+- First launch → branded splash → auth/session gate → required profile setup → main tabs.
+- Email signup with six-digit verification, email login, and Sign in with Apple.
+- Active first-run coach (`SpotFirstRunOnboardingManager`).
+- Home feed, map spot drawer, Search, shared Spot card presentation, and profile/social flows.
+- Create Spot → local draft → background publish → moderation gate.
+- Pro paywall and purchase return, Universal Link open, and unavailable states.
 
 ### High-level app flow
 
 ```mermaid
 flowchart TD
-  A[Launch Spot] --> B{Authenticated?}
-  B -->|No| C[Show auth / welcome screen]
-  C --> D[Sign in / Sign up]
-  D --> E[Create or load profile]
-  B -->|Yes| E
-  E --> F{Completed onboarding?}
-  F -->|No| G[Run onboarding / home tour as applicable]
-  F -->|Yes| H[Open main app]
-  G --> H
-  H --> I[Home feed]
-  H --> J[Map]
-  H --> K[Post]
-  H --> L[Profile]
+  A[Launch Spot] --> B[Branded splash]
+  B --> C{Auth state}
+  C -->|Loading| B
+  C -->|Pending verification| D[Confirm email OTP]
+  C -->|Signed out| E[Welcome or Welcome back]
+  E --> F[Email signup/login or Sign in with Apple]
+  F --> C
+  C -->|Authenticated and verified| G{Apple profile setup needed?}
+  G -->|Yes| H[Choose username and optional photo]
+  G -->|No| I[Open main tabs]
+  H --> I
+  I --> J{First-run coach needed?}
+  J -->|Yes| K[SpotFirstRunOnboarding overlay]
+  J -->|No| L[Normal app]
+  K --> L
+  L --> M[Home]
+  L --> N[Map]
+  L --> O[Post]
+  L --> P[Search]
+  L --> Q[Profile]
 ```
 
 ### Deep link (Universal Link) user intent
 
 User taps a shared Spot link → iOS opens Spot → router resolves route → Spot detail or unavailable state (see [../diagrams/universal-links-flow.md](../diagrams/universal-links-flow.md)).
 
+Spot detail is the shared `SpotCard` presentation, not a separate detail screen. Home renders it inline, Map hosts it in the spot drawer, Search and Profile show it over their grids, and deep links show it over the tab shell.
+
 ## Related docs
 
 - [onboarding.md](onboarding.md)
 - [posting-flow.md](posting-flow.md)
 - [map-experience.md](map-experience.md)
+- [search-experience.md](search-experience.md)
+- [../engineering/runtime-flows.md](../engineering/runtime-flows.md)
 - [../diagrams/README.md](../diagrams/README.md)
 - [../diagrams/app-launch-auth-flow.md](../diagrams/app-launch-auth-flow.md)
 
 ## Open questions / TODOs
 
-- Exact “Sign in with Apple only” vs email matrix: TODO: verify against `WelcomeView` / auth policy.
+- None for the top-level route map; feature-specific limitations are tracked in their respective docs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- audits the complete documentation set against current Swift, Supabase migrations/functions, Xcode configuration, tests, and GitHub Actions
- adds a code-verified runtime/source map, complete Search product flow, and July documentation audit
- refreshes launch, auth, onboarding, feed, map, posting, moderation, notifications, release, and environment diagrams/runbooks
- replaces contradictory Supabase environment planning docs with the implemented staging/production model
- records external verification items and confirmed implementation gaps, including profile-image moderation, media signing/cleanup, notification delivery/navigation, App Check initialization, and the map Following filter

## Testing
- `./scripts/validate-documentation.sh main` — passed (42 documentation files changed)
- `git diff --check main..HEAD` — passed
- complete local-link/anchor, Mermaid, table, heading, source-path, and current-state consistency audit across 57 Markdown files — passed with no remaining failures
- Xcode tests not run because this PR changes documentation only

## Checklist

### Code Quality & Testing (Required)
- [x] Added Unit Tests For New Code (not applicable: documentation-only)
- [x] All relevant validation passes locally
- [x] No breaking API changes
- [x] Confirmed no new compiler warnings introduced (no production code changed)
- [x] Changes follow existing documentation structure and style

### Documentation (Required)
- [x] Updated docs (see `docs/operations/documentation-maintenance.md`)
- [x] Updated relevant product docs
- [x] Updated architecture/engineering docs
- [x] Updated diagrams for changed flows

### Data plane
- [x] No production code or data-plane implementation changed
- [x] No schema/RLS changes

## Known follow-ups
Live Supabase parity/secrets, AASA, and App Store Connect metadata require external verification. Confirmed code/backend gaps are tracked in `docs/operations/documentation-audit-2026-07.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa952-2740-744f-8284-38371b20c9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa952-2740-744f-8284-38371b20c9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

