### PR TITLE
Unify structured logging and debug profiles

### DIFF
--- a/Spot/AppDelegate.swift
+++ b/Spot/AppDelegate.swift
@@ -14,17 +14,23 @@ import UserNotifications
 class AppDelegate: NSObject, UIApplicationDelegate {
     private var memoryWarningObserver: NSObjectProtocol?
 
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        LoggingConfig.applyFromUserDefaults()
+    }
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        LoggingConfig.configure()
+        SpotLogger.log(AppDelegateLogs.appLaunched)
+
         // Skip Firebase initialisation during unit tests – GoogleService-Info.plist
         // is not present in the repository and FirebaseApp.configure() would abort.
         if !SpotLaunchConfiguration.isUnitTestMode {
             if Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
                 FirebaseApp.configure()
                 Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
-                Crashlytics.crashlytics().log("AppDelegate didFinishLaunching")
                 #if !DEBUG
                 Analytics.setAnalyticsCollectionEnabled(true)
                 #endif
@@ -33,9 +39,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             }
         }
 
-        // Configure logging defaults.
-        LoggingConfig.configure()
-        
         // Register notification categories and set delegate
         Task { @MainActor in
             NotificationService.shared.registerNotificationCategories()

--- a/Spot/Config/LoggingDefaults.plist
+++ b/Spot/Config/LoggingDefaults.plist
@@ -2,23 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>debugLoggingEnabled</key>
-	<true/>
-	<key>logAllDebugCategories</key>
-	<false/>
-	<key>logSpotCard</key>
-	<false/>
-	<key>logPrivacy</key>
-	<false/>
-	<key>logFeedComponent</key>
-	<false/>
-	<key>logPostFlow</key>
-	<false/>
-	<key>logAuth</key>
-	<false/>
-	<key>logNetworkComponent</key>
-	<false/>
-	<key>logDeepLink</key>
-	<false/>
+	<key>loggingProfile</key>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Spot/Models/Logs/AppDelegateLogs.swift
+++ b/Spot/Models/Logs/AppDelegateLogs.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum AppDelegateLogs: SpotLog {
+    case appLaunched
     case universalLinkOnLaunch
     case customSchemeUrlOnLaunch
     case locationUpdateFailed
@@ -18,6 +19,7 @@ enum AppDelegateLogs: SpotLog {
     var tag: String { "AppDelegate" }
     var level: LogLevel {
         switch self {
+        case .appLaunched: return .info
         case .universalLinkOnLaunch: return .info
         case .customSchemeUrlOnLaunch: return .info
         case .locationUpdateFailed: return .error
@@ -28,6 +30,7 @@ enum AppDelegateLogs: SpotLog {
     }
     var message: String {
         switch self {
+        case .appLaunched: return "App launched"
         case .universalLinkOnLaunch: return "Received Universal Link on app launch"
         case .customSchemeUrlOnLaunch: return "Received custom scheme URL on app launch"
         case .locationUpdateFailed: return "Location update failed"

--- a/Spot/Models/Logs/DeepLinkRouterLogs.swift
+++ b/Spot/Models/Logs/DeepLinkRouterLogs.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum DeepLinkRouterLogs: SpotLog {
     case parsingUrl
-    case urlHostInfo
     case unknownUrlScheme
     case parsedUniversalLinkForSpot
     case invalidSpotIdInUniversalLink
@@ -30,7 +29,6 @@ enum DeepLinkRouterLogs: SpotLog {
     var level: LogLevel {
         switch self {
         case .parsingUrl: return .debug
-        case .urlHostInfo: return .debug
         case .unknownUrlScheme: return .debug
         case .parsedUniversalLinkForSpot: return .info
         case .invalidSpotIdInUniversalLink: return .debug
@@ -51,7 +49,6 @@ enum DeepLinkRouterLogs: SpotLog {
     var message: String {
         switch self {
         case .parsingUrl: return "Parsing URL"
-        case .urlHostInfo: return "URL host info"
         case .unknownUrlScheme: return "Unknown URL scheme"
         case .parsedUniversalLinkForSpot: return "Parsed Universal Link for spot"
         case .invalidSpotIdInUniversalLink: return "Invalid spot ID in Universal Link"

--- a/Spot/Models/Logs/FeedSupabaseLogs.swift
+++ b/Spot/Models/Logs/FeedSupabaseLogs.swift
@@ -30,13 +30,13 @@ enum FeedSupabaseLogs: SpotLog {
 
     var level: LogLevel {
         switch self {
-        case .rpcSucceeded, .statusFetched, .primaryImageSigned, .mapRPCSucceeded,
+        case .rpcSucceeded, .statusFetched,
              .loadInitialPreserveOldContent, .loadInitialUsedSeenFallback,
              .loadInitialAutoFallback, .loadMoreNoNewRows,
              .feedProfileFetched, .feedProfileRecomputed:
             return .info
-        case .mapRPCCancelled:
-            // Pan/zoom-driven cancels are expected; debug, not error.
+        case .primaryImageSigned, .mapRPCSucceeded, .mapRPCCancelled:
+            // Image hydration and map viewport calls can happen many times.
             return .debug
         case .rpcFailed, .statusFailed, .primaryImageSignFailed, .mapRPCFailed,
              .feedProfileFetchFailed, .feedProfileRecomputeFailed:

--- a/Spot/Models/Logs/LikesViewModelLogs.swift
+++ b/Spot/Models/Logs/LikesViewModelLogs.swift
@@ -20,10 +20,10 @@ enum LikesViewModelLogs: SpotLog {
     var level: LogLevel {
         switch self {
         case .alreadyLoading: return .debug
-        case .startingLoadInitial: return .info
-        case .fetchedSpotsFromService: return .info
+        case .startingLoadInitial: return .debug
+        case .fetchedSpotsFromService: return .debug
         case .spotWithoutIdFound: return .debug
-        case .loadedSpots: return .info
+        case .loadedSpots: return .debug
         case .loadInitialFailed: return .error
         case .loadInitialCompleted: return .info
         }

--- a/Spot/Models/Logs/LocationSelectionViewLogs.swift
+++ b/Spot/Models/Logs/LocationSelectionViewLogs.swift
@@ -32,14 +32,14 @@ enum LocationSelectionViewLogs: SpotLog {
         case .noCurrentLocationAvailable: return .debug
         case .gotCurrentLocation: return .info
         case .nearbyPlaceSearchFailed: return .error
-        case .foundNearbyPlaces: return .info
+        case .foundNearbyPlaces: return .debug
         case .searchingPlaces: return .debug
         case .anchoredPlaceMatched: return .info
         case .placesQueryFailed: return .debug
         case .searchPlacesFailed: return .error
-        case .foundLocalSearchResults: return .info
+        case .foundLocalSearchResults: return .debug
         case .noLocalResultsRetryingGlobal: return .debug
-        case .foundGlobalSearchResults: return .info
+        case .foundGlobalSearchResults: return .debug
         case .userSelectedLocation: return .info
         case .reverseGeocodeFailed: return .debug
         case .upsertPlaceFailed: return .debug

--- a/Spot/Models/Logs/MapMarkerLogs.swift
+++ b/Spot/Models/Logs/MapMarkerLogs.swift
@@ -33,9 +33,9 @@ enum MapMarkerLogs: SpotLog {
         case .markerDeselected: return .debug
         case .animationBatchStarted: return .debug
         case .animationBatchFinished: return .debug
-        case .userMarkerAvatarLoaded: return .info
-        case .userMarkerAvatarFallback: return .info
-        case .userMarkerConfigured: return .info
+        case .userMarkerAvatarLoaded: return .debug
+        case .userMarkerAvatarFallback: return .debug
+        case .userMarkerConfigured: return .debug
         case .userMarkerCustomFailed: return .error
         case .softClusterShown: return .debug
         case .overlapBucketResolved: return .debug

--- a/Spot/Models/Logs/MapViewLogs.swift
+++ b/Spot/Models/Logs/MapViewLogs.swift
@@ -47,9 +47,9 @@ enum MapViewLogs: SpotLog {
         case .visibleSpotsTrimmed: return .debug
         case .mapDrawerDismissed: return .debug
         case .mapSpotSwitchAnimated: return .debug
-        case .freshLocationRequested: return .info
-        case .freshLocationReceived: return .info
-        case .locationUpdateApplied: return .info
+        case .freshLocationRequested: return .debug
+        case .freshLocationReceived: return .debug
+        case .locationUpdateApplied: return .debug
         case .locationUpdateSkipped: return .debug
         case .memorySnapshot: return .debug
         }

--- a/Spot/Models/Logs/MapViewModelLogs.swift
+++ b/Spot/Models/Logs/MapViewModelLogs.swift
@@ -23,7 +23,7 @@ enum MapViewModelLogs: SpotLog {
         case .mapLoadedAllSpots: return .info
         case .loadAllSpotsFailed: return .error
         case .viewportFetchStarted: return .debug
-        case .viewportFetchFinished: return .info
+        case .viewportFetchFinished: return .debug
         case .viewportFetchCancelled: return .debug
         case .visibleSpotsMerged: return .debug
         case .visibleSpotsTrimmed: return .debug

--- a/Spot/Models/Logs/SearchViewModelLogs.swift
+++ b/Spot/Models/Logs/SearchViewModelLogs.swift
@@ -30,13 +30,13 @@ enum SearchViewModelLogs: SpotLog {
         switch self {
         case .searchQueryChanged: return .debug
         case .searchSegmentSwitched: return .info
-        case .searchUsersResults: return .info
-        case .searchLocationsSuggestions: return .info
-        case .searchVibesSuggestions: return .info
+        case .searchUsersResults: return .debug
+        case .searchLocationsSuggestions: return .debug
+        case .searchVibesSuggestions: return .debug
         case .openLocationGrid: return .debug
         case .openVibeGrid: return .debug
         case .openMultiVibeGrid: return .debug
-        case .gridLoadedPage: return .info
+        case .gridLoadedPage: return .debug
         case .gridLoadFailed: return .error
         case .loadedAllVibeTags: return .info
         case .applyVibeFiltersToLocation: return .debug

--- a/Spot/Models/Logs/SupabaseConfigurationLogs.swift
+++ b/Spot/Models/Logs/SupabaseConfigurationLogs.swift
@@ -1,0 +1,14 @@
+//
+//  SupabaseConfigurationLogs.swift
+//  Spot
+//
+
+import Foundation
+
+enum SupabaseConfigurationLogs: SpotLog {
+    case configurationLoaded
+
+    var tag: String { "SupabaseConfiguration" }
+    var level: LogLevel { .info }
+    var message: String { "Configuration loaded" }
+}

--- a/Spot/Services/DeepLinkRouter.swift
+++ b/Spot/Services/DeepLinkRouter.swift
@@ -34,8 +34,14 @@ final class DeepLinkRouter {
 
     // MARK: - URL Parsing
     func parseURL(_ url: URL) -> DeepLinkRoute {
-        SpotLogger.log(DeepLinkRouterLogs.parsingUrl, details: ["url": url.absoluteString])
-        SpotLogger.log(DeepLinkRouterLogs.urlHostInfo, details: ["host": url.host ?? "nil", "path": url.path, "pathComponents": url.pathComponents])
+        SpotLogger.log(
+            DeepLinkRouterLogs.parsingUrl,
+            details: [
+                "scheme": url.scheme ?? "nil",
+                "host": url.host ?? "nil",
+                "pathComponentCount": url.pathComponents.count
+            ]
+        )
 
         // Handle Universal Links (https://spotapp.online/s/:spotId, localhost for testing, or ngrok for DEBUG)
         if url.scheme == "https" && URLConfiguration.shared.isAllowedUniversalLinkHost(url.host ?? "") {

--- a/Spot/Services/Feed/FeedFlags.swift
+++ b/Spot/Services/Feed/FeedFlags.swift
@@ -12,8 +12,10 @@ struct FeedFlags {
     /// Disable any persistent deduplication across app sessions
     static var disablePersistentDedupe: Bool = false
 
-    /// Enable comprehensive logging for feed diagnostics
-    static var enableDiagnosticLogging: Bool = false
+    /// Comprehensive feed diagnostics are part of profile 4 only.
+    static var enableDiagnosticLogging: Bool {
+        SpotLogger.profile == .all
+    }
 
     /// TTL for persistent seen tracking (in hours, 0 = disabled)
     static var persistentSeenTTL: TimeInterval = 24 * 7 // 7 days

--- a/Spot/Settings.bundle/Root.plist
+++ b/Spot/Settings.bundle/Root.plist
@@ -8,97 +8,35 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
-			<string>Debug</string>
+			<string>Debug Logging</string>
 			<key>FooterText</key>
-			<string>Disables all app logs when turned off.</string>
+			<string>DEBUG builds only. App Store and TestFlight builds always emit errors only.</string>
 		</dict>
 		<dict>
 			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
+			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
-			<string>Enable App Logs</string>
+			<string>Log Profile</string>
 			<key>Key</key>
-			<string>debugLoggingEnabled</string>
+			<string>loggingProfile</string>
 			<key>DefaultValue</key>
-			<true/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>Title</key>
-			<string>Log Presets</string>
-			<key>FooterText</key>
-			<string>These are debug-only and take effect on next app launch.</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>SpotCard Logging</string>
-			<key>Key</key>
-			<string>logSpotCard</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Privacy Logging</string>
-			<key>Key</key>
-			<string>logPrivacy</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Feed Component Logging</string>
-			<key>Key</key>
-			<string>logFeedComponent</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Post Flow Logging</string>
-			<key>Key</key>
-			<string>logPostFlow</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Auth Logging</string>
-			<key>Key</key>
-			<string>logAuth</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Network Component Logging</string>
-			<key>Key</key>
-			<string>logNetworkComponent</string>
-			<key>DefaultValue</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Deep Link Logging</string>
-			<key>Key</key>
-			<string>logDeepLink</string>
-			<key>DefaultValue</key>
-			<false/>
+			<integer>1</integer>
+			<key>Titles</key>
+			<array>
+				<string>0 — Errors only</string>
+				<string>1 — Info + errors</string>
+				<string>2 — Debug + info + errors</string>
+				<string>3 — UI only</string>
+				<string>4 — All logs</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+			</array>
 		</dict>
 	</array>
 	<key>StringsTable</key>

--- a/Spot/Supabase/Supabase.swift
+++ b/Spot/Supabase/Supabase.swift
@@ -145,8 +145,13 @@ let supabase: SupabaseClient = {
     let config = SupabaseConfiguration.load()
 
     #if DEBUG || INTERNAL_TESTING
-    print("🔧 Supabase Environment: \(config.environment.displayName)")
-    print("🔧 Supabase URL: \(config.url.absoluteString)")
+    SpotLogger.log(
+        SupabaseConfigurationLogs.configurationLoaded,
+        details: [
+            "environment": config.environment.displayName,
+            "urlHost": config.url.host ?? "unknown"
+        ]
+    )
     #endif
 
     return SupabaseClient(

--- a/Spot/Utils/Constants.swift
+++ b/Spot/Utils/Constants.swift
@@ -58,18 +58,9 @@ enum Constants {
         static let lastKnownNotificationStatus = "lastKnownNotificationStatus"
         static let promptPermsOnNextLogin = "promptPermsOnNextLogin"
         static let homeTourAccepted = "homeTourAccepted"
-        static let debugLoggingEnabled = "debugLoggingEnabled"
-        static let logSpotCard = "logSpotCard"
-        static let logPrivacy = "logPrivacy"
-        static let logFeedComponent = "logFeedComponent"
-        static let logPostFlow = "logPostFlow"
-        static let logAuth = "logAuth"
-        static let logNetworkComponent = "logNetworkComponent"
-        static let logDeepLink = "logDeepLink"
+        static let loggingProfile = "loggingProfile"
         static let lastSupabaseProjectReference = "lastSupabaseProjectReference"
         static let supabaseSessionResetReason = "supabaseSessionResetReason"
-        /// When true, `SpotLogger` treats all debug categories as on (per-area toggles are ignored).
-        static let logAllDebugCategories = "logAllDebugCategories"
     }
 
     enum Legal {

--- a/Spot/Utils/LoggingConfig.swift
+++ b/Spot/Utils/LoggingConfig.swift
@@ -2,202 +2,57 @@
 //  LoggingConfig.swift
 //  Spot
 //
-//  Centralized logging: defaults from `Config/LoggingDefaults.plist`, overrides in
-//  Settings (DEBUG), and release builds limited to errors only.
+//  Root logging profile configuration.
 //
 
 import Foundation
 
 enum LoggingConfig {
-
     private static let bundledDefaultsFileName = "LoggingDefaults"
 
-    /// Register plist defaults, reset runtime flags, and apply the active scheme (DEBUG vs release).
     static func configure() {
         registerDefaultKeys()
-        resetRuntimeFlags()
 
-#if DEBUG
-        applyDevelopmentLoggingFromUserDefaults()
-#else
-        SpotLogger.setMinimumLevel(.error)
-        SpotLogger.mapOnlyLoggingEnabled = false
-#endif
+        #if DEBUG
+        applyFromUserDefaults()
+        #else
+        SpotLogger.setProfile(.errorsOnly)
+        #endif
     }
 
-    /// Re-read `UserDefaults` and reapply toggles (call after changing settings in-app).
     static func applyFromUserDefaults() {
-#if DEBUG
-        resetRuntimeFlags()
-        applyDevelopmentLoggingFromUserDefaults()
-#endif
+        #if DEBUG
+        let rawValue = UserDefaults.standard.integer(
+            forKey: Constants.UserDefaultsKeys.loggingProfile
+        )
+        SpotLogger.setProfile(LoggingProfile(rawValue: rawValue) ?? .errorsOnly)
+        #endif
     }
-
-    // MARK: - Defaults registration
 
     private static func registerDefaultKeys() {
         var defaults: [String: Any] = [
-            Constants.UserDefaultsKeys.debugLoggingEnabled: true,
-            Constants.UserDefaultsKeys.logAllDebugCategories: false,
-            Constants.UserDefaultsKeys.logSpotCard: false,
-            Constants.UserDefaultsKeys.logPrivacy: false,
-            Constants.UserDefaultsKeys.logFeedComponent: false,
-            Constants.UserDefaultsKeys.logPostFlow: false,
-            Constants.UserDefaultsKeys.logAuth: false,
-            Constants.UserDefaultsKeys.logNetworkComponent: false,
-            Constants.UserDefaultsKeys.logDeepLink: false
+            Constants.UserDefaultsKeys.loggingProfile: LoggingProfile.information.rawValue
         ]
 
-        if let fromPlist = loadBundledLoggingDefaultsPlist() {
-            for (key, value) in fromPlist {
-                defaults[key] = value
-            }
+        if let bundledDefaults = loadBundledLoggingDefaultsPlist() {
+            defaults.merge(bundledDefaults) { _, bundledValue in bundledValue }
         }
-
         UserDefaults.standard.register(defaults: defaults)
     }
 
     private static func loadBundledLoggingDefaultsPlist() -> [String: Any]? {
-        guard let url = Bundle.main.url(forResource: bundledDefaultsFileName, withExtension: "plist"),
-              let data = try? Data(contentsOf: url),
-              let root = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
-              let dict = root as? [String: Any] else {
+        guard let url = Bundle.main.url(
+            forResource: bundledDefaultsFileName,
+            withExtension: "plist"
+        ),
+        let data = try? Data(contentsOf: url),
+        let root = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ) else {
             return nil
         }
-        return dict
-    }
-
-    // MARK: - Runtime reset + DEBUG apply
-
-    private static func resetRuntimeFlags() {
-        DebugCategory.disableAll()
-        SpotLogger.enableAllDebug = false
-        SpotLogger.mapOnlyLoggingEnabled = false
-        ComponentLogging.spotCard = false
-        ComponentLogging.profileView = false
-        ComponentLogging.searchView = false
-        ComponentLogging.feedView = false
-        ComponentLogging.authorPrivacyCache = false
-        ComponentLogging.feedRepository = false
-        ComponentLogging.feedRanker = false
-        ComponentLogging.spotService = false
-        ComponentLogging.authService = false
-        ComponentLogging.imageService = false
-        ComponentLogging.deepLinkRouter = false
-        ComponentLogging.authViewModel = false
-        ComponentLogging.likesViewModel = false
-        ComponentLogging.bookmarksViewModel = false
-        ComponentLogging.postFlow = false
-        ComponentLogging.locationSelection = false
-        ComponentLogging.photoSelection = false
-        FeedFlags.enableDiagnosticLogging = false
-    }
-
-#if DEBUG
-    private static func applyDevelopmentLoggingFromUserDefaults() {
-        let ud = UserDefaults.standard
-        SpotLogger.setMinimumLevel(.debug)
-        SpotLogger.setDebugLoggingEnabled(ud.bool(forKey: Constants.UserDefaultsKeys.debugLoggingEnabled))
-
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logAllDebugCategories) {
-            SpotLogger.enableAllDebug = true
-            enableAllDebugLogging()
-            return
-        }
-
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logSpotCard) {
-            enableSpotCardLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logPrivacy) {
-            enablePrivacyLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logFeedComponent) {
-            enableFeedComponentLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logPostFlow) {
-            enablePostFlowLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logAuth) {
-            enableAuthLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logNetworkComponent) {
-            enableNetworkComponentLogging()
-        }
-        if ud.bool(forKey: Constants.UserDefaultsKeys.logDeepLink) {
-            enableDeepLinkLogging()
-        }
-    }
-#endif
-
-    // MARK: - Category-Based Presets (Simple)
-
-    static func enableUILogging() {
-        DebugCategory.enable(.ui)
-        DebugCategory.enable(.navigation)
-    }
-
-    static func enableFeedLogging() {
-        DebugCategory.enable(.feed)
-        FeedFlags.enableDiagnosticLogging = true
-    }
-
-    static func enableNetworkLogging() {
-        DebugCategory.enable(.network)
-    }
-
-    static func enableImageLogging() {
-        DebugCategory.enable(.image)
-    }
-
-    static func enableAllDebugLogging() {
-        DebugCategory.enableAll()
-        SpotLogger.enableAllDebug = true
-        FeedFlags.enableDiagnosticLogging = true
-    }
-
-    // MARK: - Component-Specific Presets (Includes component flags)
-
-    static func enableSpotCardLogging() {
-        ComponentLogging.spotCard = true
-        DebugCategory.enable(.ui)
-        DebugCategory.enable(.image)
-    }
-
-    static func enablePrivacyLogging() {
-        ComponentLogging.authorPrivacyCache = true
-        DebugCategory.enable(.privacy)
-    }
-
-    static func enableFeedComponentLogging() {
-        ComponentLogging.feedRepository = true
-        ComponentLogging.feedRanker = true
-        DebugCategory.enable(.feed)
-        FeedFlags.enableDiagnosticLogging = true
-    }
-
-    static func enablePostFlowLogging() {
-        ComponentLogging.postFlow = true
-        ComponentLogging.locationSelection = true
-        ComponentLogging.photoSelection = true
-        DebugCategory.enable(.moderation)
-        DebugCategory.enable(.location)
-    }
-
-    static func enableAuthLogging() {
-        ComponentLogging.authService = true
-        ComponentLogging.authViewModel = true
-        DebugCategory.enable(.auth)
-    }
-
-    static func enableNetworkComponentLogging() {
-        ComponentLogging.spotService = true
-        ComponentLogging.imageService = true
-        DebugCategory.enable(.network)
-        DebugCategory.enable(.image)
-    }
-
-    static func enableDeepLinkLogging() {
-        ComponentLogging.deepLinkRouter = true
-        DebugCategory.enable(.deepLink)
+        return root as? [String: Any]
     }
 }

--- a/Spot/Utils/SpotLogger.swift
+++ b/Spot/Utils/SpotLogger.swift
@@ -61,7 +61,8 @@ final class SpotLogger {
     static let shared = SpotLogger()
     private init() {}
 
-    private(set) static var profile: LoggingProfile = .errorsOnly
+    private static let profileLock = NSLock()
+    private static var activeProfile: LoggingProfile = .errorsOnly
     private static let detailsIndentation = "    "
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.spotapp.spot",
@@ -79,12 +80,20 @@ final class SpotLogger {
         "MapView",
         "MapViewModel",
         "SearchViewModel",
+        "SpotSearchDataSource",
         "SpotCard"
     ]
 
+    static var profile: LoggingProfile {
+        profileLock.lock()
+        defer { profileLock.unlock() }
+        return activeProfile
+    }
+
     static func setProfile(_ newProfile: LoggingProfile) {
-        profile = newProfile
-        FeedFlags.enableDiagnosticLogging = newProfile == .all
+        profileLock.lock()
+        activeProfile = newProfile
+        profileLock.unlock()
     }
 
     /// Emits one log through the shared logger.
@@ -167,9 +176,11 @@ final class SpotLogger {
     // MARK: - Privacy-safe detail formatting
 
     private static func formatted(_ value: Any, forKey key: String) -> String {
+        guard let value = unwrapped(value) else { return "nil" }
         let normalizedKey = key.lowercased()
 
-        if ["password", "token", "secret", "authorization", "query"]
+        if ["password", "token", "secret", "authorization", "query", "prefix",
+            "searchtext", "searchterm", "body", "payload", "responsepreview"]
             .contains(where: normalizedKey.contains) ||
             (normalizedKey.contains("email") && value is String) ||
             normalizedKey.contains("path") {
@@ -206,6 +217,13 @@ final class SpotLogger {
         default:
             return String(describing: value)
         }
+    }
+
+    private static func unwrapped(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else { return value }
+        guard let wrapped = mirror.children.first?.value else { return nil }
+        return unwrapped(wrapped)
     }
 
     private static func quoted(_ value: String) -> String {

--- a/Spot/Utils/SpotLogger.swift
+++ b/Spot/Utils/SpotLogger.swift
@@ -1,16 +1,14 @@
 import Foundation
 import os
+#if DEBUG
+import Darwin
+#endif
 
-// MARK: - SpotLog Protocol
+// MARK: - Structured log definitions
 
-/// A structured log definition. Conform an enum to this protocol to describe
-/// all log events for a given class, then emit them with `SpotLogger.log(_:details:)`.
 protocol SpotLog {
-    /// The name of the originating class, shown as the log tag.
     var tag: String { get }
-    /// Severity level for this log entry.
     var level: LogLevel { get }
-    /// Human-readable description of the event.
     var message: String { get }
 }
 
@@ -19,389 +17,326 @@ enum LogLevel: String, CaseIterable, Comparable {
     case info = "INFO"
     case error = "ERROR"
 
-    // For filtering: debug < info < error
     static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         let order: [LogLevel] = [.debug, .info, .error]
         return order.firstIndex(of: lhs)! < order.firstIndex(of: rhs)!
     }
 }
 
-/// Debug log categories for fine-grained control
-enum DebugCategory: String, CaseIterable {
-    case ui = "UI"                    // UI interactions (taps, appears, etc.)
-    case navigation = "Navigation"   // Navigation events
-    case feed = "Feed"               // Feed loading, ranking, blending
-    case network = "Network"         // API calls, remote data operations
-    case auth = "Auth"               // Authentication events
-    case image = "Image"             // Image loading, caching
-    case location = "Location"       // Location services
-    case performance = "Performance" // Performance metrics
-    case deepLink = "DeepLink"       // Deep linking
-    case moderation = "Moderation"   // Content moderation
-    case privacy = "Privacy"         // Privacy filtering
-    
-    static var enabledCategories: Set<DebugCategory> = []
-    
-    static func enable(_ category: DebugCategory) {
-        enabledCategories.insert(category)
-    }
-    
-    static func disable(_ category: DebugCategory) {
-        enabledCategories.remove(category)
-    }
-    
-    static func enableAll() {
-        enabledCategories = Set(DebugCategory.allCases)
-    }
-    
-    static func disableAll() {
-        enabledCategories.removeAll()
-    }
-    
-    var isEnabled: Bool {
-        return DebugCategory.enabledCategories.contains(self)
-    }
-}
+/// Root logging profiles exposed by the DEBUG settings screen.
+///
+/// Profile 2 intentionally omits known high-frequency debug diagnostics.
+/// Profile 4 is the explicit opt-in for those noisy events.
+enum LoggingProfile: Int, CaseIterable, Identifiable {
+    case errorsOnly = 0
+    case information = 1
+    case debugging = 2
+    case uiOnly = 3
+    case all = 4
 
-/// Component-specific logging flags for major files/components
-struct ComponentLogging {
-    // UI Components
-    static var spotCard: Bool = false
-    static var profileView: Bool = false
-    static var searchView: Bool = false
-    static var feedView: Bool = false
-    
-    // Services
-    static var authorPrivacyCache: Bool = false
-    static var feedRepository: Bool = false
-    static var feedRanker: Bool = false
-    static var spotService: Bool = false
-    static var authService: Bool = false
-    static var imageService: Bool = false
-    static var deepLinkRouter: Bool = false
-    
-    // ViewModels
-    static var authViewModel: Bool = false
-    static var likesViewModel: Bool = false
-    static var bookmarksViewModel: Bool = false
-    
-    // Post Flow
-    static var postFlow: Bool = false
-    static var locationSelection: Bool = false
-    static var photoSelection: Bool = false
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .errorsOnly: return "0 — Errors only"
+        case .information: return "1 — Info + errors"
+        case .debugging: return "2 — Debug + info + errors"
+        case .uiOnly: return "3 — UI only"
+        case .all: return "4 — All logs"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .errorsOnly: return "Failures that require investigation."
+        case .information: return "Important app activity and failures."
+        case .debugging: return "Development detail without high-frequency debug events."
+        case .uiOnly: return "Events emitted directly by SwiftUI views."
+        case .all: return "Every event, including noisy diagnostics."
+        }
+    }
 }
 
 final class SpotLogger {
     static let shared = SpotLogger()
     private init() {}
 
-    // MARK: - Configuration
-    static var minimumLevel: LogLevel = .info // Default to info, debug requires category enablement
-    static var enableAllDebug: Bool = false   // Master switch for all debug logs
-    /// When enabled, suppresses all SpotLogger output except logs needed
-    /// for map debugging: map UI/model/marker/filter logs,
-    /// LocationManager logs, and Supabase map viewport RPC logs.
-    ///
-    /// This intentionally does not affect Apple/MapKit system console
-    /// messages such as `default.csv`, `PerfPowerTelemetry`, or
-    /// `CAMetalLayer`; those are not emitted through SpotLogger.
-    static var mapOnlyLoggingEnabled: Bool = false
-    private static let defaults = UserDefaults.standard
+    private(set) static var profile: LoggingProfile = .errorsOnly
+    private static let detailsIndentation = "    "
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.spotapp.spot",
+        category: "SpotLogger"
+    )
+    private static let noisyTags: Set<String> = [
+        "AnalyticsService",
+        "DeepLinkRouter",
+        "FeedEventService",
+        "FeedSupabase",
+        "ImageService",
+        "LocationManager",
+        "LocationSelectionView",
+        "MapMarker",
+        "MapView",
+        "MapViewModel",
+        "SearchViewModel",
+        "SpotCard"
+    ]
 
-    #if DEBUG
-    static var debugLoggingEnabled: Bool {
-        get {
-            if defaults.object(forKey: Constants.UserDefaultsKeys.debugLoggingEnabled) == nil {
-                defaults.set(true, forKey: Constants.UserDefaultsKeys.debugLoggingEnabled)
-            }
-            return defaults.bool(forKey: Constants.UserDefaultsKeys.debugLoggingEnabled)
-        }
-        set {
-            defaults.set(newValue, forKey: Constants.UserDefaultsKeys.debugLoggingEnabled)
-        }
-    }
-    #endif
-
-    static func setMinimumLevel(_ level: LogLevel) {
-        minimumLevel = level
+    static func setProfile(_ newProfile: LoggingProfile) {
+        profile = newProfile
+        FeedFlags.enableDiagnosticLogging = newProfile == .all
     }
 
-    #if DEBUG
-    static func setDebugLoggingEnabled(_ isEnabled: Bool) {
-        debugLoggingEnabled = isEnabled
-    }
-    #endif
-
-    // MARK: - Structured Log Entry
-
-    /// Indentation prefix applied to each key-value pair in the details block.
-    private static let detailsIndentation = "     "
-
-    /// Emit a structured log defined by a `SpotLog`-conforming enum case.
+    /// Emits one log through the shared logger.
     ///
     /// Output format:
     /// ```
-    /// SpotLogger: <tag>
-    /// <message>
+    /// <tag> <message>
     /// [
-    ///      key: value
+    ///     key: value
     /// ]
     /// ```
-    static func log(_ entry: some SpotLog, details: [String: Any] = [:], file: String = #file, function: String = #function, line: Int = #line) {
-        guard entry.level >= minimumLevel else { return }
-        guard shouldEmit(entry: entry, details: details, file: file) else { return }
-        log(entry.level, message: body(for: entry, details: details), file: file, function: function, line: line)
+    static func log(
+        _ entry: some SpotLog,
+        details: [String: Any] = [:],
+        file: String = #file
+    ) {
+        guard shouldEmit(entry: entry, file: file) else { return }
+        emit(entry.level, message: body(for: entry, details: details))
     }
 
-    /// Returns the formatted body string for a structured log entry.
-    ///
-    /// The output begins with a `SpotLogger: <tag>` header line followed by the
-    /// entry's message. When `details` is non-empty, a sorted key-value block is
-    /// appended between `[` and `]` delimiters.
-    ///
-    /// - Parameters:
-    ///   - entry: A `SpotLog`-conforming value that provides the tag and message.
-    ///   - details: Optional structured metadata to attach to the log.
-    /// - Returns: The fully-formatted log body string.
-    ///
-    /// Exposed `internal` so it can be verified directly in unit tests.
+    /// Exposed internally so formatting and privacy behavior can be unit tested.
     static func body(for entry: some SpotLog, details: [String: Any]) -> String {
-        let header = "SpotLogger: \(entry.tag)"
-        if details.isEmpty {
-            return "\(header)\n\(entry.message)"
-        }
-        let lines = details
-            .map { key, value -> String in
-                let v: String
-                if let date = value as? Date {
-                    v = date.description
-                } else if let arr = value as? [Any] {
-                    v = arr.map { String(describing: $0) }.joined(separator: ", ")
-                } else {
-                    v = String(describing: value)
-                }
-                return "\(detailsIndentation)\(key): \(v)"
-            }
-            .sorted()
-            .joined(separator: "\n")
-        return "\(header)\n\(entry.message)\n[\n\(lines)\n]"
-    }
+        let header = "\(entry.tag) \(entry.message)"
+        guard !details.isEmpty else { return header }
 
-    // MARK: - Public Logging Methods
-    
-    // INFO - Always enabled for important events
-    static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(.info, message: composeMessage(title: "", details: ["message": message]), file: file, function: function, line: line)
-    }
-
-    static func info(_ title: String, details: [String: Any], file: String = #file, function: String = #function, line: Int = #line) {
-        log(.info, message: composeMessage(title: title, details: details), file: file, function: function, line: line)
-    }
-
-    // ERROR - Always enabled
-    static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(.error, message: composeMessage(title: "", details: ["message": message]), file: file, function: function, line: line)
-    }
-
-    static func error(_ title: String, details: [String: Any], file: String = #file, function: String = #function, line: Int = #line) {
-        log(.error, message: composeMessage(title: title, details: details), file: file, function: function, line: line)
-    }
-
-    // DEBUG - Category-based, requires explicit enablement
-    static func debug(_ category: DebugCategory, _ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        guard shouldLogDebug(category: category, file: file) else { return }
-        log(.debug, message: composeMessage(title: "", details: ["category": category.rawValue, "message": message]), file: file, function: function, line: line)
-    }
-
-    static func debug(_ category: DebugCategory, _ title: String, details: [String: Any], file: String = #file, function: String = #function, line: Int = #line) {
-        guard shouldLogDebug(category: category, file: file) else { return }
-        var enhancedDetails = details
-        enhancedDetails["category"] = category.rawValue
-        log(.debug, message: composeMessage(title: title, details: enhancedDetails), file: file, function: function, line: line)
-    }
-
-    // Convenience debug methods (backward compatibility - defaults to UI category)
-    static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        debug(.ui, message, file: file, function: function, line: line)
-    }
-
-    static func debug(_ title: String, details: [String: Any], file: String = #file, function: String = #function, line: Int = #line) {
-        debug(.ui, title, details: details, file: file, function: function, line: line)
-    }
-
-    // MARK: - Private Logging Implementation
-    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.spotapp.spot", category: "SpotLogger")
-
-    private static func shouldLogDebug(category: DebugCategory, file: String) -> Bool {
-        #if DEBUG
-        guard debugLoggingEnabled else { return false }
-        #endif
-        // Always log if master switch is on
-        if enableAllDebug { return true }
-        // Check component-specific flag
-        if isComponentEnabled(file: file) { return true }
-        // Log if category is enabled
-        return category.isEnabled
-    }
-    
-    private static func isComponentEnabled(file: String) -> Bool {
-        let fileName = URL(fileURLWithPath: file).lastPathComponent
-        switch fileName {
-        case "SpotCard.swift": return ComponentLogging.spotCard
-        case "ProfileView.swift": return ComponentLogging.profileView
-        case "SearchView.swift": return ComponentLogging.searchView
-        case "HomepageView.swift", "FeedView.swift": return ComponentLogging.feedView
-        case "AuthorPrivacyCache.swift": return ComponentLogging.authorPrivacyCache
-        case "FeedRepository.swift": return ComponentLogging.feedRepository
-        case "FeedRanker.swift": return ComponentLogging.feedRanker
-        case "SpotService.swift": return ComponentLogging.spotService
-        case "AuthService.swift": return ComponentLogging.authService
-        case "ImageService.swift": return ComponentLogging.imageService
-        case "DeepLinkRouter.swift": return ComponentLogging.deepLinkRouter
-        case "AuthViewModel.swift": return ComponentLogging.authViewModel
-        case "LikesViewModel.swift": return ComponentLogging.likesViewModel
-        case "BookmarksViewModel.swift": return ComponentLogging.bookmarksViewModel
-        case "PostFlowView.swift": return ComponentLogging.postFlow
-        case "LocationSelectionView.swift": return ComponentLogging.locationSelection
-        case "PhotoSelectionView.swift": return ComponentLogging.photoSelection
-        default: return false
-        }
-    }
-
-    private static func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
-        #if DEBUG
-        // Master "console logging" switch suppresses verbose output but never hides errors.
-        if level != .error {
-            guard debugLoggingEnabled else { return }
-        }
-        #endif
-        guard level >= minimumLevel else { return }
-        guard shouldEmitRawLog(message: message, file: file) else { return }
-        let fileName = URL(fileURLWithPath: file).lastPathComponent
-        let logMessage = "[SpotLogger][\(level.rawValue)] \(fileName):\(line) | \(function) | \(message)"
-
-        // Use unified logging so Xcode's Type filter (Debug / Info / Error) works correctly.
-        // Do NOT add a print() fallback here — print() bypasses OSLog type metadata and
-        // would appear in the Xcode console even when the Type filter excludes that level.
-        switch level {
-        case .debug:
-            logger.debug("\(logMessage, privacy: .public)")
-        case .info:
-            logger.info("\(logMessage, privacy: .public)")
-        case .error:
-            logger.error("\(logMessage, privacy: .public)")
-        }
-    }
-
-    private static func shouldEmit(entry: some SpotLog, details: [String: Any], file: String) -> Bool {
-        guard mapOnlyLoggingEnabled else { return true }
-
-        if entry.tag.hasPrefix("Map") || entry.tag == "LocationManager" {
-            return true
-        }
-
-        // The map data pipeline currently reuses FeedSupabaseLogs for
-        // `get_map_spots_v1`; keep only that subset visible.
-        if entry.tag == "FeedSupabase", entry.message.contains("get_map_spots_v1") {
-            return true
-        }
-
-        return isMapRelatedFile(file)
-    }
-
-    private static func shouldEmitRawLog(message: String, file: String) -> Bool {
-        guard mapOnlyLoggingEnabled else { return true }
-
-        if isMapRelatedFile(file) {
-            return true
-        }
-
-        if message.contains("SpotLogger: Map") ||
-            message.contains("SpotLogger: LocationManager") ||
-            message.contains("get_map_spots_v1") {
-            return true
-        }
-
-        return false
-    }
-
-    private static func isMapRelatedFile(_ file: String) -> Bool {
-        let fileName = URL(fileURLWithPath: file).lastPathComponent
-        if fileName.hasPrefix("Map") || fileName.contains("Map") {
-            return true
-        }
-        switch fileName {
-        case "SharedSpotMap.swift",
-             "LocationManager.swift",
-             "MemoryDebugLogger.swift":
-            return true
-        case "FeedAPI.swift", "MapViewportLoader.swift":
-            // The raw-message path still checks `get_map_spots_v1`; allow
-            // the structured path to preserve map viewport RPC logs.
-            return false
-        default:
-            return false
-        }
-    }
-
-    // MARK: - Compose message with JSON details
-    private static func composeMessage(title: String, details: [String: Any]) -> String {
-        // Pretty multi-line details block
         let lines = details
             .map { key, value in
-                let v: String
-                if let date = value as? Date {
-                    v = date.description
-                } else if let arr = value as? [Any] {
-                    v = arr.map { String(describing: $0) }.joined(separator: ", ")
-                } else {
-                    v = String(describing: value)
-                }
-                return "     \(key): \(v)"
+                "\(detailsIndentation)\(key): \(formatted(value, forKey: key))"
             }
             .sorted()
             .joined(separator: "\n")
-        
-        // If title is empty, only show details block
-        if title.isEmpty {
-            return "[\n\(lines)\n]"
+        return "\(header)\n[\n\(lines)\n]"
+    }
+
+    // MARK: - Filtering
+
+    static func shouldEmit(
+        level: LogLevel,
+        tag: String,
+        file: String,
+        profile: LoggingProfile
+    ) -> Bool {
+        let isUI = file.contains("/Views/")
+        switch profile {
+        case .errorsOnly:
+            return level == .error
+        case .information:
+            return level == .info || level == .error
+        case .debugging:
+            if level != .debug { return true }
+            return !noisyTags.contains(tag)
+        case .uiOnly:
+            return isUI
+        case .all:
+            return true
         }
-        return "\(title)\n[\n\(lines)\n]"
     }
 
-    // MARK: - Convenience: Logs with Spot payload
-    static func info(_ title: String, spot: Spot, details: [String: Any] = [:], file: String = #file, function: String = #function, line: Int = #line) {
-        log(.info, message: composeMessage(title: title, details: merge(details, with: spot)), file: file, function: function, line: line)
-    }
-    
-    static func error(_ title: String, spot: Spot, details: [String: Any] = [:], file: String = #file, function: String = #function, line: Int = #line) {
-        log(.error, message: composeMessage(title: title, details: merge(details, with: spot)), file: file, function: function, line: line)
-    }
-    
-    static func debug(_ category: DebugCategory, _ title: String, spot: Spot, details: [String: Any] = [:], file: String = #file, function: String = #function, line: Int = #line) {
-        guard shouldLogDebug(category: category, file: file) else { return }
-        log(.debug, message: composeMessage(title: title, details: merge(details, with: spot)), file: file, function: function, line: line)
+    private static func shouldEmit(entry: some SpotLog, file: String) -> Bool {
+        shouldEmit(level: entry.level, tag: entry.tag, file: file, profile: profile)
     }
 
-    private static func merge(_ base: [String: Any], with spot: Spot) -> [String: Any] {
-        var d = base
-        d["spotId"] = spot.safeId
-        d["userId"] = spot.userId ?? "nil"
-        d["username"] = spot.username ?? "nil"
-        d["likes"] = spot.likes ?? 0
-        d["createdAt"] = spot.createdAt ?? Date.distantPast
-        d["imageURL"] = spot.imageURL ?? "nil"
-        d["thumbnailURL"] = spot.thumbnailURL ?? "nil"
-        d["locationName"] = spot.locationName ?? "nil"
-        return d
+    // MARK: - Output
+
+    private static func emit(_ level: LogLevel, message: String) {
+        switch level {
+        case .debug:
+            logger.debug("\(message, privacy: .public)")
+        case .info:
+            logger.info("\(message, privacy: .public)")
+        case .error:
+            logger.error("\(message, privacy: .public)")
+        }
+
+        #if DEBUG
+        DebugFileLogWriter.shared.write(message)
+        #endif
+    }
+
+    // MARK: - Privacy-safe detail formatting
+
+    private static func formatted(_ value: Any, forKey key: String) -> String {
+        let normalizedKey = key.lowercased()
+
+        if ["password", "token", "secret", "authorization", "query"]
+            .contains(where: normalizedKey.contains) ||
+            (normalizedKey.contains("email") && value is String) ||
+            normalizedKey.contains("path") {
+            return "\"<redacted>\""
+        }
+        if normalizedKey.contains("latitude") || normalizedKey.contains("longitude") ||
+            normalizedKey.hasSuffix("lat") || normalizedKey.hasSuffix("lon") ||
+            normalizedKey.contains("coordinate") {
+            return "\"<redacted>\""
+        }
+        if normalizedKey.contains("url"), let value = value as? String {
+            if normalizedKey.contains("host") {
+                return quoted(value)
+            }
+            return quoted(redactedURL(value))
+        }
+        if normalizedKey.contains("userid") || normalizedKey == "uid" ||
+            normalizedKey.contains("spotid") || normalizedKey.contains("draftid") {
+            return quoted(shortIdentifier(String(describing: value)))
+        }
+
+        switch value {
+        case let string as String:
+            return quoted(redactedText(string))
+        case let date as Date:
+            return quoted(ISO8601DateFormatter().string(from: date))
+        case let array as [Any]:
+            return "[" + array.map { formatted($0, forKey: key) }.joined(separator: ", ") + "]"
+        case let dictionary as [String: Any]:
+            let contents = dictionary.keys.sorted().map { nestedKey in
+                "\(nestedKey): \(formatted(dictionary[nestedKey]!, forKey: nestedKey))"
+            }.joined(separator: ", ")
+            return "[\(contents)]"
+        default:
+            return String(describing: value)
+        }
+    }
+
+    private static func quoted(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return "\"\(escaped)\""
+    }
+
+    private static func redactedURL(_ value: String) -> String {
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme,
+              let host = components.host else {
+            return "<redacted-url>"
+        }
+        return "\(scheme)://\(host)/…"
+    }
+
+    private static func shortIdentifier(_ value: String) -> String {
+        guard value.count > 8 else { return value }
+        return "…\(value.suffix(8))"
+    }
+
+    private static func redactedText(_ value: String) -> String {
+        let patterns = [
+            (#"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#, "<redacted-email>"),
+            (#"https?://\S+"#, "<redacted-url>")
+        ]
+        return patterns.reduce(value) { result, replacement in
+            result.replacingOccurrences(
+                of: replacement.0,
+                with: replacement.1,
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
     }
 }
 
-// MARK: - DateFormatter Extension
-extension DateFormatter {
-    static let logFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }()
+#if DEBUG
+private enum DebuggerDetector {
+    static var isAttached: Bool {
+        var processInfo = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var name = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        let nameCount = name.count
+        let result = name.withUnsafeMutableBufferPointer {
+            sysctl($0.baseAddress, u_int(nameCount), &processInfo, &size, nil, 0)
+        }
+        return result == 0 && (processInfo.kp_proc.p_flag & P_TRACED) != 0
+    }
 }
+
+/// Writes DEBUG logs only when the process is not attached to Xcode.
+private final class DebugFileLogWriter {
+    static let shared = DebugFileLogWriter()
+
+    private let queue = DispatchQueue(label: "com.spotapp.debug-file-logger", qos: .utility)
+    private let fileManager = FileManager.default
+    private let maximumBytes: UInt64 = 1_000_000
+    private let retainedFiles = 3
+
+    private init() {}
+
+    func write(_ message: String) {
+        guard !DebuggerDetector.isAttached else { return }
+        queue.async {
+            self.append(message)
+        }
+    }
+
+    private func append(_ message: String) {
+        guard let fileURL = currentFileURL() else { return }
+        rotateIfNeeded(fileURL, adding: message.utf8.count + 2)
+        let data = Data("\(message)\n\n".utf8)
+
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            fileManager.createFile(
+                atPath: fileURL.path,
+                contents: data,
+                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+            )
+            return
+        }
+
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else { return }
+        handle.seekToEndOfFile()
+        handle.write(data)
+        handle.closeFile()
+    }
+
+    private func currentFileURL() -> URL? {
+        guard let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+
+        let directory = applicationSupport.appendingPathComponent("Logs", isDirectory: true)
+        do {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+            )
+            return directory.appendingPathComponent("spot-debug.txt")
+        } catch {
+            return nil
+        }
+    }
+
+    private func rotateIfNeeded(_ fileURL: URL, adding byteCount: Int) {
+        let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path)
+        let currentSize = (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
+        guard currentSize + UInt64(byteCount) > maximumBytes else { return }
+
+        let directory = fileURL.deletingLastPathComponent()
+        let oldest = directory.appendingPathComponent("spot-debug-\(retainedFiles).txt")
+        try? fileManager.removeItem(at: oldest)
+
+        for index in stride(from: retainedFiles - 1, through: 1, by: -1) {
+            let source = directory.appendingPathComponent("spot-debug-\(index).txt")
+            let destination = directory.appendingPathComponent("spot-debug-\(index + 1).txt")
+            if fileManager.fileExists(atPath: source.path) {
+                try? fileManager.moveItem(at: source, to: destination)
+            }
+        }
+
+        let firstArchive = directory.appendingPathComponent("spot-debug-1.txt")
+        try? fileManager.moveItem(at: fileURL, to: firstArchive)
+    }
+}
+#endif

--- a/Spot/Utils/SpotLogger.swift
+++ b/Spot/Utils/SpotLogger.swift
@@ -191,14 +191,15 @@ final class SpotLogger {
             normalizedKey.contains("coordinate") {
             return "\"<redacted>\""
         }
-        if normalizedKey.contains("url"), let value = value as? String {
+        if normalizedKey.contains("url") {
+            let urlValue = (value as? URL)?.absoluteString ?? (value as? String)
             if normalizedKey.contains("host") {
-                return quoted(value)
+                return quoted(urlValue ?? "<redacted-url>")
             }
-            return quoted(redactedURL(value))
+            return quoted(urlValue.map(redactedURL) ?? "<redacted-url>")
         }
-        if normalizedKey.contains("userid") || normalizedKey == "uid" ||
-            normalizedKey.contains("spotid") || normalizedKey.contains("draftid") {
+        if normalizedKey == "uid" ||
+            (normalizedKey.hasSuffix("id") && (value is String || value is UUID)) {
             return quoted(shortIdentifier(String(describing: value)))
         }
 

--- a/Spot/Views/Profile/LoggingSettingsDetailView.swift
+++ b/Spot/Views/Profile/LoggingSettingsDetailView.swift
@@ -2,7 +2,7 @@
 //  LoggingSettingsDetailView.swift
 //  Spot
 //
-//  DEBUG-only: per-area console logging toggles (non-release builds).
+//  DEBUG-only root logging profile control.
 //
 
 import SwiftUI
@@ -10,76 +10,53 @@ import SwiftUI
 #if DEBUG
 struct LoggingSettingsDetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @AppStorage(Constants.UserDefaultsKeys.loggingProfile)
+    private var loggingProfile = LoggingProfile.information.rawValue
 
-    @AppStorage(Constants.UserDefaultsKeys.debugLoggingEnabled) private var debugLoggingEnabled = true
-    @AppStorage(Constants.UserDefaultsKeys.logAllDebugCategories) private var logAllDebugCategories = false
-    @AppStorage(Constants.UserDefaultsKeys.logSpotCard) private var logSpotCard = false
-    @AppStorage(Constants.UserDefaultsKeys.logPrivacy) private var logPrivacy = false
-    @AppStorage(Constants.UserDefaultsKeys.logFeedComponent) private var logFeedComponent = false
-    @AppStorage(Constants.UserDefaultsKeys.logPostFlow) private var logPostFlow = false
-    @AppStorage(Constants.UserDefaultsKeys.logAuth) private var logAuth = false
-    @AppStorage(Constants.UserDefaultsKeys.logNetworkComponent) private var logNetworkComponent = false
-    @AppStorage(Constants.UserDefaultsKeys.logDeepLink) private var logDeepLink = false
+    private var selectedProfile: LoggingProfile {
+        LoggingProfile(rawValue: loggingProfile) ?? .errorsOnly
+    }
 
     var body: some View {
         VStack(spacing: 0) {
-            settingsTopBar(title: "Console logging", dismiss: dismiss)
+            settingsTopBar(title: "Logging", dismiss: dismiss)
             ScrollView {
                 VStack(spacing: 24) {
                     settingsSection {
                         VStack(alignment: .leading, spacing: 12) {
-                            sectionHeader("Global")
-                            Text("Release (App Store / TestFlight) builds log errors only, regardless of these settings.")
+                            sectionHeader("Log profile")
+                            Picker("Log profile", selection: $loggingProfile) {
+                                ForEach(LoggingProfile.allCases) { profile in
+                                    Text(profile.title).tag(profile.rawValue)
+                                }
+                            }
+                            .pickerStyle(.inline)
+                            .labelsHidden()
+                            .accessibilityIdentifier("settings.logging.profile")
+
+                            Text(selectedProfile.summary)
                                 .font(.system(size: 12))
                                 .foregroundColor(.gray)
                                 .fixedSize(horizontal: false, vertical: true)
-
-                            Toggle(isOn: $debugLoggingEnabled) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("Console logging")
-                                        .font(FontManager.primaryText())
-                                        .foregroundColor(Constants.Colors.primary)
-                                    Text("When off, hides debug and info in Xcode; errors still print.")
-                                        .font(.system(size: 12))
-                                        .foregroundColor(.gray)
-                                }
-                            }
-                            .tint(Constants.Colors.primary)
-                            .accessibilityIdentifier("settings.logging.masterToggle")
-
-                            Toggle(isOn: $logAllDebugCategories) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("All debug categories")
-                                        .font(FontManager.primaryText())
-                                        .foregroundColor(Constants.Colors.primary)
-                                    Text("Verbose: enables every debug path (ignores the area toggles below).")
-                                        .font(.system(size: 12))
-                                        .foregroundColor(.gray)
-                                }
-                            }
-                            .tint(Constants.Colors.primary)
-                            .disabled(!debugLoggingEnabled)
-                            .accessibilityIdentifier("settings.logging.allCategoriesToggle")
-                        }
-                    }
-
-                    settingsSection {
-                        VStack(alignment: .leading, spacing: 12) {
-                            sectionHeader("Areas")
-                            areaToggle("Feed", isOn: $logFeedComponent, id: "settings.logging.feed")
-                            areaToggle("Upload & post flow", isOn: $logPostFlow, id: "settings.logging.postFlow")
-                            areaToggle("Network & images", isOn: $logNetworkComponent, id: "settings.logging.network")
-                            areaToggle("Auth", isOn: $logAuth, id: "settings.logging.auth")
-                            areaToggle("Deep links", isOn: $logDeepLink, id: "settings.logging.deepLink")
-                            areaToggle("Privacy / author filter", isOn: $logPrivacy, id: "settings.logging.privacy")
-                            areaToggle("Spot card", isOn: $logSpotCard, id: "settings.logging.spotCard")
                         }
                     }
 
                     settingsSection {
                         VStack(alignment: .leading, spacing: 8) {
-                            sectionHeader("Defaults file")
-                            Text("Edit `Spot/Config/LoggingDefaults.plist` to change first-launch defaults for these keys.")
+                            sectionHeader("Device log file")
+                            Text(
+                                "When a DEBUG build runs without Xcode attached, the same logs are written to Application Support/Logs/spot-debug.txt. Files rotate at 1 MB and retain three archives."
+                            )
+                            .font(.system(size: 12))
+                            .foregroundColor(.gray)
+                            .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    settingsSection {
+                        VStack(alignment: .leading, spacing: 8) {
+                            sectionHeader("Release behavior")
+                            Text("App Store and TestFlight builds always use profile 0 — Errors only.")
                                 .font(.system(size: 12))
                                 .foregroundColor(.gray)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -89,36 +66,13 @@ struct LoggingSettingsDetailView: View {
                 .padding(16)
             }
         }
-        .background(Color(hex: "F5F3EF").ignoresSafeArea())
+        .background(Constants.Colors.background.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
-        .onChange(of: debugLoggingEnabled) { _, _ in apply() }
-        .onChange(of: logAllDebugCategories) { _, _ in apply() }
-        .onChange(of: logSpotCard) { _, _ in apply() }
-        .onChange(of: logPrivacy) { _, _ in apply() }
-        .onChange(of: logFeedComponent) { _, _ in apply() }
-        .onChange(of: logPostFlow) { _, _ in apply() }
-        .onChange(of: logAuth) { _, _ in apply() }
-        .onChange(of: logNetworkComponent) { _, _ in apply() }
-        .onChange(of: logDeepLink) { _, _ in apply() }
-    }
-
-    private func apply() {
-        LoggingConfig.applyFromUserDefaults()
-    }
-
-    private func areaToggle(_ title: String, isOn: Binding<Bool>, id: String) -> some View {
-        Toggle(isOn: isOn) {
-            Text(title)
-                .font(FontManager.primaryText())
-                .foregroundColor(Constants.Colors.primary)
+        .onChange(of: loggingProfile) { _, _ in
+            LoggingConfig.applyFromUserDefaults()
         }
-        .tint(Constants.Colors.primary)
-        .disabled(!debugLoggingEnabled || logAllDebugCategories)
-        .accessibilityIdentifier(id)
     }
 }
-
-// MARK: - Layout (mirrors SettingsView private helpers)
 
 private func settingsTopBar(title: String, dismiss: DismissAction) -> some View {
     HStack {
@@ -160,5 +114,11 @@ private func settingsSection<Content: View>(@ViewBuilder content: () -> Content)
     .background(Color.white)
     .cornerRadius(12)
     .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
+}
+
+#Preview {
+    NavigationStack {
+        LoggingSettingsDetailView()
+    }
 }
 #endif

--- a/Spot/Views/Profile/SettingsView.swift
+++ b/Spot/Views/Profile/SettingsView.swift
@@ -193,9 +193,9 @@ struct SettingsView: View {
                                 LoggingSettingsDetailView()
                             } label: {
                                 settingsRow(
-                                    title: "Console logging",
+                                    title: "Logging",
                                     icon: "ladybug",
-                                    subtitle: "Feed, upload, auth…"
+                                    subtitle: "Profiles 0–4 and device file"
                                 )
                             }
                             .buttonStyle(PlainButtonStyle())

--- a/SpotTests/SpotLoggerTests.swift
+++ b/SpotTests/SpotLoggerTests.swift
@@ -10,6 +10,13 @@ import Testing
 @testable import Spot
 
 struct SpotLoggerTests {
+    private enum TestLog: SpotLog {
+        case sessionRefreshFailed
+
+        var tag: String { "AuthService" }
+        var level: LogLevel { .error }
+        var message: String { "Session refresh failed" }
+    }
 
     // MARK: - SpotLog protocol conformance
 
@@ -53,15 +60,61 @@ struct SpotLoggerTests {
 
     @Test func logFormattedOutputWithoutDetails() {
         let output = SpotLogger.body(for: SpotServiceLogs.spotFetched, details: [:])
-        #expect(output == "SpotLogger: SpotService\nFetched spot")
+        #expect(output == "SpotService Fetched spot")
     }
 
     @Test func logFormattedOutputWithDetails() {
-        let output = SpotLogger.body(for: SpotServiceLogs.spotFetched, details: ["id": "abc123", "statusCode": 200])
-        #expect(output.hasPrefix("SpotLogger: SpotService\nFetched spot\n[\n"))
-        // Details are sorted alphabetically, each indented with 5 spaces
-        #expect(output.contains("     id: abc123"))
-        #expect(output.contains("     statusCode: 200"))
-        #expect(output.hasSuffix("\n]"))
+        let output = SpotLogger.body(
+            for: TestLog.sessionRefreshFailed,
+            details: [
+                "responseCode": 401,
+                "errorMessage": "Session expired",
+                "retrying": true
+            ]
+        )
+        #expect(
+            output == """
+            AuthService Session refresh failed
+            [
+                errorMessage: "Session expired"
+                responseCode: 401
+                retrying: true
+            ]
+            """
+        )
+    }
+
+    @Test func sensitiveDetailsAreRedactedOrShortened() {
+        let output = SpotLogger.body(
+            for: TestLog.sessionRefreshFailed,
+            details: [
+                "email": "person@example.com",
+                "latitude": 37.1234,
+                "signedURL": "https://example.com/private/file?token=secret",
+                "userId": "12345678-1234-1234-1234-123456789abc",
+                "errorMessage": "Failed for person@example.com at https://example.com/private"
+            ]
+        )
+
+        #expect(!output.contains("person@example.com"))
+        #expect(!output.contains("37.1234"))
+        #expect(!output.contains("token=secret"))
+        #expect(!output.contains("12345678-1234-1234-1234"))
+        #expect(output.contains("userId: \"…56789abc\""))
+    }
+
+    @Test func profilesApplyExpectedFilters() {
+        let serviceFile = "/app/Services/AuthService.swift"
+        let viewFile = "/app/Views/LoginView.swift"
+
+        #expect(SpotLogger.shouldEmit(level: .error, tag: "AuthService", file: serviceFile, profile: .errorsOnly))
+        #expect(!SpotLogger.shouldEmit(level: .info, tag: "AuthService", file: serviceFile, profile: .errorsOnly))
+        #expect(SpotLogger.shouldEmit(level: .info, tag: "AuthService", file: serviceFile, profile: .information))
+        #expect(!SpotLogger.shouldEmit(level: .debug, tag: "AuthService", file: serviceFile, profile: .information))
+        #expect(SpotLogger.shouldEmit(level: .debug, tag: "AuthService", file: serviceFile, profile: .debugging))
+        #expect(!SpotLogger.shouldEmit(level: .debug, tag: "LocationManager", file: serviceFile, profile: .debugging))
+        #expect(SpotLogger.shouldEmit(level: .debug, tag: "LoginView", file: viewFile, profile: .uiOnly))
+        #expect(!SpotLogger.shouldEmit(level: .error, tag: "AuthService", file: serviceFile, profile: .uiOnly))
+        #expect(SpotLogger.shouldEmit(level: .debug, tag: "LocationManager", file: serviceFile, profile: .all))
     }
 }

--- a/SpotTests/SpotLoggerTests.swift
+++ b/SpotTests/SpotLoggerTests.swift
@@ -92,7 +92,10 @@ struct SpotLoggerTests {
                 "latitude": 37.1234,
                 "signedURL": "https://example.com/private/file?token=secret",
                 "userId": "12345678-1234-1234-1234-123456789abc",
-                "errorMessage": "Failed for person@example.com at https://example.com/private"
+                "errorMessage": "Failed for person@example.com at https://example.com/private",
+                "prefix": "private search",
+                "bodyPreview": Optional("private response") as Any,
+                "mimeType": Optional<String>.none as Any
             ]
         )
 
@@ -100,7 +103,10 @@ struct SpotLoggerTests {
         #expect(!output.contains("37.1234"))
         #expect(!output.contains("token=secret"))
         #expect(!output.contains("12345678-1234-1234-1234"))
+        #expect(!output.contains("private search"))
+        #expect(!output.contains("private response"))
         #expect(output.contains("userId: \"…56789abc\""))
+        #expect(output.contains("mimeType: nil"))
     }
 
     @Test func profilesApplyExpectedFilters() {
@@ -113,6 +119,7 @@ struct SpotLoggerTests {
         #expect(!SpotLogger.shouldEmit(level: .debug, tag: "AuthService", file: serviceFile, profile: .information))
         #expect(SpotLogger.shouldEmit(level: .debug, tag: "AuthService", file: serviceFile, profile: .debugging))
         #expect(!SpotLogger.shouldEmit(level: .debug, tag: "LocationManager", file: serviceFile, profile: .debugging))
+        #expect(!SpotLogger.shouldEmit(level: .debug, tag: "SpotSearchDataSource", file: serviceFile, profile: .debugging))
         #expect(SpotLogger.shouldEmit(level: .debug, tag: "LoginView", file: viewFile, profile: .uiOnly))
         #expect(!SpotLogger.shouldEmit(level: .error, tag: "AuthService", file: serviceFile, profile: .uiOnly))
         #expect(SpotLogger.shouldEmit(level: .debug, tag: "LocationManager", file: serviceFile, profile: .all))

--- a/SpotTests/SpotLoggerTests.swift
+++ b/SpotTests/SpotLoggerTests.swift
@@ -91,7 +91,9 @@ struct SpotLoggerTests {
                 "email": "person@example.com",
                 "latitude": 37.1234,
                 "signedURL": "https://example.com/private/file?token=secret",
+                "assetURL": URL(string: "https://example.com/private/typed")!,
                 "userId": "12345678-1234-1234-1234-123456789abc",
+                "authorId": "abcdefab-cdef-cdef-cdef-abcdefabcdef",
                 "errorMessage": "Failed for person@example.com at https://example.com/private",
                 "prefix": "private search",
                 "bodyPreview": Optional("private response") as Any,
@@ -102,7 +104,9 @@ struct SpotLoggerTests {
         #expect(!output.contains("person@example.com"))
         #expect(!output.contains("37.1234"))
         #expect(!output.contains("token=secret"))
+        #expect(!output.contains("/private/typed"))
         #expect(!output.contains("12345678-1234-1234-1234"))
+        #expect(!output.contains("abcdefab-cdef-cdef-cdef"))
         #expect(!output.contains("private search"))
         #expect(!output.contains("private response"))
         #expect(output.contains("userId: \"…56789abc\""))

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -2,44 +2,103 @@
 
 ## Purpose
 
-Describe structured logging via `SpotLogger`, log levels, and debug categories.
+Spot uses one structured logging path for console and DEBUG device-file output.
 
-## Audience
+## Pattern
 
-Engineers debugging features and writing new services.
+Define events in a `SpotLog` enum under `Spot/Models/Logs/`. Every log file owns a
+stable component tag, severity, and message:
 
-## Current status
+```swift
+enum AuthServiceLogs: SpotLog {
+    case sessionRefreshFailed
 
-Implementation: `Spot/Utils/SpotLogger.swift`, `Spot/Utils/LoggingConfig.swift`, per-feature log enums under `Spot/Models/Logs/`.
+    var tag: String { "AuthService" }
+    var level: LogLevel { .error }
+    var message: String { "Session refresh failed" }
+}
+```
 
-## Details
+Emit only through `SpotLogger`:
 
-### Pattern
+```swift
+SpotLogger.log(
+    AuthServiceLogs.sessionRefreshFailed,
+    details: [
+        "responseCode": 401,
+        "errorMessage": "Session expired",
+        "retrying": true
+    ]
+)
+```
 
-1. Define an enum conforming to **`SpotLog`** (tag, level, message) for a component.
-2. Emit with **`SpotLogger.log(_:details:)`** (and `info` / `error` helpers as appropriate).
+Console and file output use the same format:
 
-### Levels
+```text
+AuthService Session refresh failed
+[
+    errorMessage: "Session expired"
+    responseCode: 401
+    retrying: true
+]
+```
 
-`LogLevel`: **debug**, **info**, **error** — with ordering for filtering.
+The logger does not print the source filename, line, function, severity label, or
+an additional logger prefix. Apple Unified Logging still retains severity
+metadata for Xcode filtering.
 
-### Debug categories
+## Root logging profiles
 
-`DebugCategory` includes UI, navigation, feed, network, auth, image, location, performance, deepLink, moderation, privacy. Enable per category or use master switches / `UserDefaults` keys under `Constants.UserDefaultsKeys` (e.g. `logDeepLink`, `logAllDebugCategories`).
+`LoggingConfig` reads one `loggingProfile` integer from `UserDefaults`. DEBUG
+builds expose it under Settings → Debug → Logging.
 
-### Release behavior
+| Value | Profile | Behavior |
+|---|---|---|
+| 0 | Errors only | Error events |
+| 1 | Info + errors | Info and error events |
+| 2 | Debug + info + errors | All severities except known high-frequency debug tags |
+| 3 | UI only | Events emitted directly under `Spot/Views` |
+| 4 | All logs | Every event, including high-frequency diagnostics |
 
-`LoggingConfig` sets minimum level to **errors only** in non-DEBUG builds (see `#if DEBUG` branches).
+Profile 2 suppresses debug events from analytics, deep links, feed events and
+image hydration, location, map loading/markers/views, search, and Spot cards.
+Errors and info from those components still appear. Add a tag to that
+suppression set only when its debug events are demonstrably high frequency.
 
-### Map-only mode
+Non-DEBUG builds always use profile 0 regardless of saved DEBUG settings.
+`Spot/Config/LoggingDefaults.plist` controls the first-launch DEBUG default.
 
-`SpotLogger.mapOnlyLoggingEnabled` restricts noise during map debugging (see comments in `SpotLogger`).
+## Device file
 
-## Related docs
+In a DEBUG build without an attached debugger, emitted logs are also appended to:
 
-- [architecture.md](architecture.md)
-- [troubleshooting.md](troubleshooting.md)
+```text
+Application Support/Logs/spot-debug.txt
+```
 
-## Open questions / TODOs
+The file is protected until first device unlock, rotates at 1 MB, and retains
+three archives. File writing is compiled out of release builds. When Xcode is
+attached, the file sink stays off and logs go only to Apple Unified Logging.
 
-- None.
+## Privacy and noise rules
+
+`SpotLogger` centrally redacts credentials, tokens, emails, queries, precise
+coordinates, paths, and full URLs. User and Spot identifiers are shortened.
+Error text is scrubbed for embedded emails and URLs.
+
+Call sites must still follow these rules:
+
+- Do not pass passwords, access tokens, authorization headers, or secrets.
+- Prefer response codes and stable error categories over raw server payloads.
+- Do not log events on every render, animation frame, map pan, or location fix
+  unless the event is debug severity and profile 4 is required.
+- Consolidate multiple messages for one operation into one event with details.
+- Use stable tags and messages so logs remain searchable.
+
+## Implementation
+
+- `Spot/Utils/SpotLogger.swift`
+- `Spot/Utils/LoggingConfig.swift`
+- `Spot/Config/LoggingDefaults.plist`
+- `Spot/Models/Logs/`
+- `SpotTests/SpotLoggerTests.swift`

--- a/docs/engineering/universal-links.md
+++ b/docs/engineering/universal-links.md
@@ -97,7 +97,7 @@ Simulator note: Universal Links can be finicky; **validate on device** before re
 ### Troubleshooting
 
 1. **Link opens Safari, not app** — AASA not reachable, wrong team/bundle, or entitlements not in installed build.
-2. **App opens but wrong route** — Check `DeepLinkRouter` logs (`DebugCategory.deepLink`); verify path is exactly `/s/{id}`.
+2. **App opens but wrong route** — Select logging profile 4 and check `DeepLinkRouter` logs; verify path is exactly `/s/{id}`.
 3. **Custom scheme no-op** — Confirm `CFBundleURLTypes` includes `spotapp`.
 
 ### Release checklist (links)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- replace fragmented logging toggles with one 0–4 profile in the app and Settings bundle
- standardize output as `Tag Message` followed by a sorted details dictionary
- add privacy-safe detail formatting and suppress high-frequency debug events outside the all-logs profile
- write rotating protected text logs for detached DEBUG builds
- route remaining direct app logs through `SpotLogger`
- synchronize profile state and redact optional response/search values, identifiers, and typed URLs

## Testing
- Added formatting, privacy-redaction, optional-value, typed-URL, and profile-filter unit tests
- Plist parsing passed
- Documentation and API validation passed (documentation validator emitted only its generic Supabase-path warning)
- Secret scan passed
- Xcode tests unavailable on the cloud Linux host

## Checklist

### Code Quality & Testing (Required)
- [x] Added Unit Tests For New Code
- [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`) — Xcode unavailable on host
- [x] No breaking public API changes
- [ ] Confirmed no new warnings introduced — requires Xcode build
- [x] Code follows existing patterns and style

### Documentation (Required)
- [x] Updated docs
- [x] Updated relevant product docs if user-facing behavior changed
- [x] Updated architecture/engineering docs if service/data layer changed
- [x] Updated diagrams if flows changed significantly (not applicable)

### Data plane
- [x] No data-plane changes
- [x] No schema/RLS changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa972-d19a-7573-9481-cf6582daf6b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa972-d19a-7573-9481-cf6582daf6b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

