### PR TITLE
Fix Firebase deploy CI gate timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,11 +52,14 @@ jobs:
           REPO="${GITHUB_REPOSITORY}"
           SHA="${GITHUB_SHA}"
           echo "Checking CI status for commit: ${SHA}"
-          for attempt in {1..30}; do
+          # A cold macOS test run currently takes about 12–15 minutes. Allow up
+          # to 30 minutes so deploy does not report a false failure while CI is
+          # still healthy and running.
+          for attempt in {1..90}; do
             RUN_JSON=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&event=push&per_page=1")
             COUNT=$(echo "$RUN_JSON" | jq -r '.total_count // 0')
             if [ "$COUNT" = "0" ]; then
-              echo "No CI run found yet for ${SHA} (attempt ${attempt}/30)"
+              echo "No CI run found yet for ${SHA} (attempt ${attempt}/90)"
               sleep 20
               continue
             fi
@@ -78,7 +81,7 @@ jobs:
             sleep 20
           done
 
-          echo "❌ Timed out waiting for CI completion for ${SHA}."
+          echo "❌ Timed out after 30 minutes waiting for CI completion for ${SHA}."
           exit 1
 
       - name: Configure Git

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -379,6 +379,7 @@ If Xcode Cloud starts building again:
 
 **Deploy safeguards:**
 - **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)
+- **CI gate:** Deployment waits up to 30 minutes for the `ci.yml` push run on the same source SHA to succeed
 - **Skip bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
 - **Skip CI on bumps:** `ci.yml` skips validation on `[skip ci]` commits
 - **Push before build:** The incremented build number is committed and pushed to `main` before archiving/uploading to Firebase


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- extend the Firebase deploy gate from 10 to 30 minutes
- keep deployment tied to successful CI on the exact source SHA
- document the CI gate timeout

## Testing
- pre-commit `git diff --check`
- workflow validation pending

## Checklist

### Code Quality & Testing (Required)
- [x] No production code changed; unit tests are not applicable
- [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`)
- [x] No breaking API changes
- [x] No new warnings introduced
- [x] Code follows existing workflow patterns

### Documentation (Required)
- [x] Updated `docs/engineering/ci-cd.md`
- [x] No user-facing product docs required
- [x] Updated relevant engineering documentation
- [x] No diagram update required

### Data plane
- [x] No data-plane or schema changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa991-5fbe-7729-b565-a803a806c553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa991-5fbe-7729-b565-a803a806c553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

