### PR TITLE
Clean up Firebase release notes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,7 +61,8 @@ This trigger does not depend on the separate CI workflow. Repository branch prot
 **What it does:**
 - Automatically increments build number in `CURRENT_PROJECT_VERSION` (build number `+1` only)
 - Pushes build number update to `main` before building (prevents duplicate Firebase build numbers)
-- Extracts release notes from merged PR (title + body)
+- Resolves the merged PR associated with the deployed commit
+- Converts the PR's `Changes` section to concise plain-text Firebase release notes (Markdown and checklist boilerplate are removed)
 - Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
 - Installs Apple signing assets into a temporary CI keychain (never the login keychain)
 - Archives unsigned, then exports a **signed Ad Hoc IPA** for distribution
@@ -93,6 +94,7 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 - Build number is committed and pushed before archiving to prevent duplicate Firebase builds
 - Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
 - Bump commits (`Bump build number to ... [skip ci]`) do not re-trigger CI or deploy workflows
+- Firebase App Distribution treats release notes as plain text; `scripts/format-firebase-release-notes.py` keeps the tester notes and rendered Actions summary readable
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -53,8 +53,10 @@ The workflow uses three validation scripts in `scripts/`:
 ### `deploy.yml` - Firebase App Distribution Deployment (Test ENV)
 
 **Triggers:**
-- Pushes to `main`
+- Pushes to `main` that include an app, test, build, script, backend, or workflow change
 - Manual workflow dispatch
+
+Documentation and repository-maintenance-only pushes are ignored, so they do not consume a build number or publish an unchanged IPA. A mixed change still deploys when it includes any non-ignored file. Manual dispatch remains available for an intentional rebuild.
 
 This trigger does not depend on the separate CI workflow. Repository branch protection and merge policy are responsible for preventing unvalidated changes from reaching `main`.
 
@@ -95,6 +97,7 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 - Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
 - Bump commits (`Bump build number to ... [skip ci]`) do not re-trigger CI or deploy workflows
 - Firebase App Distribution treats release notes as plain text; `scripts/format-firebase-release-notes.py` keeps the tester notes and rendered Actions summary readable
+- Documentation/Markdown, agent configuration, ignore-file, and license-only changes do not trigger a Firebase build
 
 ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - main
+    # Do not spend a build number or publish an unchanged IPA for repository
+    # maintenance. A mixed change still deploys when any non-ignored file changes.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".agents/**"
+      - ".cursor/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".gitignore"
+      - ".xcode-cloud-disabled"
+      - "LICENSE*"
   workflow_dispatch:  # Allow manual triggers
 
 # Serialize deploys so concurrent runs cannot read the same build number.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: write
+      pull-requests: read
 
     # Deploy on merges/direct pushes to main, but skip automated bump commits.
     if: |
@@ -119,33 +120,47 @@ jobs:
       - name: Extract release notes from merged PR
         id: release_notes
         run: |
-          # Get the last merged PR info
-          LAST_PR=$(gh pr list --state merged --limit 1 --json number,title,body,mergedAt --jq '.[0]')
+          set -euo pipefail
+
+          # Resolve the PR associated with the deployed commit. Using the latest
+          # merged PR can attach unrelated notes when merges happen close together.
+          LAST_PR=$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null)] | first // empty' \
+              || true
+          )
 
           if [ -z "$LAST_PR" ] || [ "$LAST_PR" = "null" ]; then
-            echo "No recent PR found, using commit message"
-            NOTES="Build ${{ steps.increment_build.outputs.new_build }}: $(git log -1 --pretty=%s)"
-            echo "$NOTES" > release_notes.txt
-          else
-            PR_NUMBER=$(echo "$LAST_PR" | jq -r '.number')
-            PR_TITLE=$(echo "$LAST_PR" | jq -r '.title')
-            PR_BODY=$(echo "$LAST_PR" | jq -r '.body' | head -c 500)
-
-            # Create release notes with proper formatting
+            echo "No merged PR is associated with ${SOURCE_SHA}; using its commit message"
             {
-              echo "Build ${{ steps.increment_build.outputs.new_build }} - PR #${PR_NUMBER}: ${PR_TITLE}"
-              echo ""
-              echo "${PR_BODY}"
+              echo "Build ${{ steps.increment_build.outputs.new_build }}"
+              echo "$(git log -1 --pretty=%s "$SOURCE_SHA")"
               echo ""
               echo "Commit: ${SOURCE_SHA}"
-              echo "Date: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            } > release_notes.txt
+          else
+            PR_NUMBER=$(jq -r '.number' <<< "$LAST_PR")
+            PR_TITLE=$(jq -r '.title' <<< "$LAST_PR")
+            jq -r '.body // ""' <<< "$LAST_PR" \
+              | ./scripts/format-firebase-release-notes.py \
+              > "$RUNNER_TEMP/formatted_release_body.txt"
+
+            {
+              echo "Build ${{ steps.increment_build.outputs.new_build }} • PR #${PR_NUMBER}"
+              echo "${PR_TITLE}"
+              if [ -s "$RUNNER_TEMP/formatted_release_body.txt" ]; then
+                echo ""
+                cat "$RUNNER_TEMP/formatted_release_body.txt"
+              fi
+              echo ""
+              echo "Commit: ${SOURCE_SHA}"
             } > release_notes.txt
           fi
 
-          # Also output for GitHub
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          cat release_notes.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Firebase release notes:"
+          cat release_notes.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -429,9 +444,13 @@ jobs:
           echo "**Commit**: ${SOURCE_SHA}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release Notes" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          cat release_notes.txt >> $GITHUB_STEP_SUMMARY || echo "No release notes" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          if [ -f release_notes.txt ]; then
+            while IFS= read -r line; do
+              printf '> %s\n' "$line"
+            done < release_notes.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "> No release notes" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Clean up keychain and provisioning profile
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ Packages/
 .swiftpm/
 .build/
 
+# Python tooling
+__pycache__/
+*.py[cod]
+
 # CocoaPods
 Pods/
 

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -73,10 +73,12 @@ See `.github/workflows/README.md` for detailed workflow documentation.
 #### Deployment workflow: `deploy.yml`
 
 **Triggers:**
-- Push to `main`
+- Push to `main` with at least one non-documentation/non-housekeeping file change
 - Manual workflow dispatch
 
 The workflow trigger is not technically gated on the separate CI workflow succeeding. Branch protection and merge policy must enforce validation before code reaches `main`.
+
+Documentation, Markdown, agent configuration, ignore-file, and license-only pushes are filtered out before a workflow run is created. Mixed changes still deploy when they contain any app, test, build, script, backend, or workflow change. Manual dispatch bypasses the push path filter for intentional rebuilds.
 
 **Environment:**
 - Runner: macOS 15
@@ -105,6 +107,7 @@ The workflow trigger is not technically gated on the separate CI workflow succee
 - Removes Markdown, automated PR metadata, testing details, and checklist boilerplate because Firebase App Distribution displays release notes as plain text
 - Uploads to Firebase App Distribution with testers group
 - Skips re-deploy on bump commits (`Bump build number to … [skip ci]`)
+- Skips documentation and repository-maintenance-only pushes so they do not increment the build number or publish an unchanged IPA
 
 **Required secrets:**
 - `GOOGLE_SERVICE_INFO_PLIST_BASE64` - Firebase GoogleService-Info.plist file (base64 encoded)
@@ -381,7 +384,7 @@ If Xcode Cloud starts building again:
 
 **Deploy safeguards:**
 - **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)
-- **CI gate:** Deployment waits up to 30 minutes for the `ci.yml` push run on the same source SHA to succeed
+- **Path filter:** Documentation and repository-maintenance-only pushes do not create Firebase deploy runs
 - **Skip bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
 - **Skip CI on bumps:** `ci.yml` skips validation on `[skip ci]` commits
 - **Push before build:** The incremented build number is committed and pushed to `main` before archiving/uploading to Firebase

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -88,7 +88,7 @@ The workflow trigger is not technically gated on the separate CI workflow succee
 1. **Checkout:** Pull repository code with full history
 2. **Version Management:** Auto-increment build number
 3. **Version Commit:** Push build number update back to `main`
-4. **Release Notes:** Extract PR information for release notes
+4. **Release Notes:** Resolve the PR associated with the deployed commit and convert its `Changes` section to plain text
 5. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
 6. **Supabase Configuration:** Inject and verify staging project credentials
 7. **Code Signing:** Install certificates and provisioning profiles
@@ -101,7 +101,8 @@ The workflow trigger is not technically gated on the separate CI workflow succee
 - Pins Firebase-distributed internal builds to staging Supabase project `aeurigbbohyxvtsfiyul`; the workflow fails if another project URL is embedded
 - Defines `INTERNAL_TESTING` through the Spot target's `SPOT_DISTRIBUTION_CONDITION` setting; it is not applied to Swift Package targets
 - Builds signed IPA for distribution
-- Generates release notes from merged PR title and description
+- Generates concise release notes from the associated merged PR title and `Changes` section
+- Removes Markdown, automated PR metadata, testing details, and checklist boilerplate because Firebase App Distribution displays release notes as plain text
 - Uploads to Firebase App Distribution with testers group
 - Skips re-deploy on bump commits (`Bump build number to … [skip ci]`)
 
@@ -368,7 +369,7 @@ If Xcode Cloud starts building again:
 4. **Deployment workflow triggers** (`deploy.yml`):
    - Build number auto-increments (e.g., 7 → 8)
    - **Build number is pushed to `main` before archive/upload** so a failed deploy cannot leave the repo stale and cause duplicate Firebase build numbers
-   - Release notes generated from PR
+   - Plain-text release notes generated from the merged PR associated with the deployed commit
    - App is built and signed
    - IPA uploaded to Firebase App Distribution
 5. Testers receive notification in Firebase App Distribution

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -125,6 +125,21 @@ Increments the build number (`CURRENT_PROJECT_VERSION`) in the Xcode project.
 
 **Note:** This script is also run automatically by the `deploy.yml` workflow on every deployment.
 
+### `format-firebase-release-notes.py`
+
+Converts a GitHub pull request body from Markdown to concise plain text for Firebase App Distribution.
+
+```bash
+printf '## Changes\n- Improve release notes\n' \
+  | ./scripts/format-firebase-release-notes.py
+```
+
+The formatter prefers the `Changes` section, removes automation metadata and Markdown decoration, omits testing/checklist sections, and limits the result to 1,200 characters. Run its tests with:
+
+```bash
+python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+```
+
 ## Running Locally
 
 All scripts can be run locally before pushing to verify your changes will pass CI:
@@ -163,6 +178,7 @@ These scripts are integrated into GitHub Actions workflows:
 
 ### Deployment (`.github/workflows/deploy.yml`)
 - **Build number increment** runs automatically
+- **Firebase release notes** are formatted as plain text
 - Builds and signs the app
 - Uploads to Firebase App Distribution
 - Commits build number change back to main

--- a/scripts/format-firebase-release-notes.py
+++ b/scripts/format-firebase-release-notes.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Convert a pull request body into concise Firebase release-note text."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import sys
+
+
+CHANGES_HEADINGS = {"change", "changes", "summary", "what changed", "what's changed"}
+
+
+def _changes_section(markdown: str) -> str:
+    """Prefer the PR's changes section and omit testing/checklist boilerplate."""
+    lines = markdown.splitlines()
+    start: int | None = None
+    level: int | None = None
+
+    for index, line in enumerate(lines):
+        match = re.match(r"^\s*(#{1,6})\s+(.+?)\s*#*\s*$", line)
+        if not match:
+            continue
+
+        heading = re.sub(r"[*_`]", "", match.group(2)).strip().casefold()
+        if start is None and heading in CHANGES_HEADINGS:
+            start = index + 1
+            level = len(match.group(1))
+            continue
+
+        if start is not None and len(match.group(1)) <= level:
+            return "\n".join(lines[start:index])
+
+    if start is not None:
+        return "\n".join(lines[start:])
+    return markdown
+
+
+def _plain_text(markdown: str) -> str:
+    text = re.sub(r"<!--.*?-->", "", markdown, flags=re.DOTALL)
+    text = _changes_section(text)
+
+    # Remove non-release metadata commonly appended by automation.
+    text = re.sub(r"<(?:div|picture)\b.*?</(?:div|picture)>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+
+    # Keep link labels, but discard image/link destinations and Markdown decoration.
+    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"^\s*#{1,6}\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*[-*+]\s+\[[ xX]\]\s+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*[-*+]\s+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*\d+[.)]\s+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*>\s?", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*```[^\n]*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"[*_~`]", "", text)
+    text = html.unescape(text)
+
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.splitlines()]
+    compact: list[str] = []
+    for line in lines:
+        if line or (compact and compact[-1]):
+            compact.append(line)
+    return "\n".join(compact).strip()
+
+
+def format_release_notes(markdown: str, max_characters: int = 1200) -> str:
+    """Return clean plain text, truncated at a line boundary when possible."""
+    plain = _plain_text(markdown)
+    if len(plain) <= max_characters:
+        return plain
+
+    truncated = plain[: max_characters - 1].rstrip()
+    last_break = truncated.rfind("\n")
+    if last_break >= max_characters // 2:
+        truncated = truncated[:last_break].rstrip()
+    return f"{truncated}…"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-characters", type=int, default=1200)
+    args = parser.parse_args()
+    if args.max_characters < 2:
+        parser.error("--max-characters must be at least 2")
+
+    formatted = format_release_notes(sys.stdin.read(), args.max_characters)
+    if formatted:
+        print(formatted)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/format-firebase-release-notes.py
+++ b/scripts/format-firebase-release-notes.py
@@ -48,12 +48,12 @@ def _plain_text(markdown: str) -> str:
     # Keep link labels, but discard image/link destinations and Markdown decoration.
     text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
-    text = re.sub(r"^\s*#{1,6}\s+", "", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*[-*+]\s+\[[ xX]\]\s+", "• ", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*[-*+]\s+", "• ", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*\d+[.)]\s+", "• ", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*>\s?", "", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*```[^\n]*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*#{1,6}[ \t]+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*[-*+][ \t]+\[[ xX]\][ \t]+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*[-*+][ \t]+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*\d+[.)][ \t]+", "• ", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*>[ \t]?", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]*```[^\n]*$", "", text, flags=re.MULTILINE)
     text = re.sub(r"[*_~`]", "", text)
     text = html.unescape(text)
 

--- a/scripts/tests/test_format_firebase_release_notes.py
+++ b/scripts/tests/test_format_firebase_release_notes.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "format-firebase-release-notes.py"
+SPEC = importlib.util.spec_from_file_location("firebase_release_notes", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FormatFirebaseReleaseNotesTests(unittest.TestCase):
+    def test_extracts_changes_and_removes_markdown(self) -> None:
+        markdown = """\
+<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
+## Changes
+- Add **clean** release notes
+- Keep [`useful details`](https://example.com)
+
+## Testing
+- [x] Pipeline passed
+
+## Checklist
+- [ ] All boilerplate
+<!-- CURSOR_AGENT_PR_BODY_END -->
+<div><a href="https://example.com">Open in Web</a></div>
+"""
+
+        result = MODULE.format_release_notes(markdown)
+
+        self.assertEqual(
+            result,
+            "• Add clean release notes\n• Keep useful details",
+        )
+        self.assertNotIn("Testing", result)
+        self.assertNotIn("[x]", result)
+        self.assertNotIn("**", result)
+        self.assertNotIn("Open in Web", result)
+
+    def test_cleans_body_without_changes_heading(self) -> None:
+        markdown = """\
+Fixes the `drawer` behavior.
+
+1. First item
+2. Second item
+"""
+
+        self.assertEqual(
+            MODULE.format_release_notes(markdown),
+            "Fixes the drawer behavior.\n\n• First item\n• Second item",
+        )
+
+    def test_truncates_at_a_line_boundary(self) -> None:
+        markdown = "## Changes\n- " + ("a" * 30) + "\n- " + ("b" * 30)
+
+        result = MODULE.format_release_notes(markdown, max_characters=40)
+
+        self.assertEqual(result, "• " + ("a" * 30) + "…")
+        self.assertLessEqual(len(result), 40)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- format Firebase App Distribution notes as concise plain text instead of exposing raw PR Markdown
- resolve release notes from the PR associated with the deployed commit rather than the latest merged PR
- render clean notes in the GitHub Actions build summary
- skip Firebase deploy runs for documentation and repository-maintenance-only pushes while preserving mixed-change and manual deployments
- add formatter unit coverage and update pipeline documentation

## Testing
- formatter unit tests pass (3 tests)
- all GitHub Actions workflow files passed `actionlint` before the path-filter update; updated workflow validation pending
- documentation validation, secret scan, and diff checks pass
- associated-PR lookup and formatting verified against deployed commit `8c9d591`
- latest two Firebase deploys and matching CI runs on `main` succeeded; the earlier Xcode dependency failure was fixed by PR #66
- PR validation is running for this branch

## Checklist

### Code Quality & Testing (Required)
- [x] Added focused tests for release-note formatting
- [x] No production app behavior changed
- [x] No breaking API changes

### Documentation (Required)
- [x] Updated workflow and CI/CD documentation
- [x] Updated the scripts reference

### Data plane
- [x] No data-plane or schema changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fabd9-64c3-7ddf-8b4c-22a76a1487e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fabd9-64c3-7ddf-8b4c-22a76a1487e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

