### PR TITLE
Redesign Create a Spot photo workflow

### DIFF
--- a/Spot/Models/PostComposerPhoto.swift
+++ b/Spot/Models/PostComposerPhoto.swift
@@ -6,20 +6,151 @@
 //  reuse the wrong view when reordering or replacing images.
 //
 
+import Foundation
 import UIKit
+
+enum PostComposerPhotoSource: String, Codable, Sendable {
+    case gallery
+    case camera
+    case legacyDraft
+}
+
+enum PostComposerPhotoProcessingState: String, Codable, Sendable {
+    case idle
+    case processing
+    case ready
+    case failed
+    case unavailable
+}
+
+struct PostComposerPhotoCrop: Codable, Equatable, Sendable {
+    var normalizedX: CGFloat
+    var normalizedY: CGFloat
+    var normalizedWidth: CGFloat
+    var normalizedHeight: CGFloat
+    var aspectRatio: String?
+
+    static let fullImage = PostComposerPhotoCrop(
+        normalizedX: 0,
+        normalizedY: 0,
+        normalizedWidth: 1,
+        normalizedHeight: 1,
+        aspectRatio: nil
+    )
+}
+
+struct PostComposerPhotoAdjustments: Codable, Equatable, Sendable {
+    var brightness: Double
+    var contrast: Double
+    var saturation: Double
+    var warmth: Double
+
+    static let neutral = PostComposerPhotoAdjustments(
+        brightness: 0,
+        contrast: 0,
+        saturation: 0,
+        warmth: 0
+    )
+
+    var isNeutral: Bool { self == .neutral }
+}
+
+struct PostComposerPhotoEdits: Codable, Equatable, Sendable {
+    var rotationQuarterTurns: Int
+    var straightenDegrees: Double
+    var flipHorizontal: Bool
+    var flipVertical: Bool
+    var crop: PostComposerPhotoCrop
+    var adjustments: PostComposerPhotoAdjustments
+
+    static let neutral = PostComposerPhotoEdits(
+        rotationQuarterTurns: 0,
+        straightenDegrees: 0,
+        flipHorizontal: false,
+        flipVertical: false,
+        crop: .fullImage,
+        adjustments: .neutral
+    )
+
+    var isNeutral: Bool { self == .neutral }
+
+    mutating func normalize() {
+        rotationQuarterTurns = ((rotationQuarterTurns % 4) + 4) % 4
+        straightenDegrees = min(15, max(-15, straightenDegrees))
+        crop.normalizedX = min(0.99, max(0, crop.normalizedX))
+        crop.normalizedY = min(0.99, max(0, crop.normalizedY))
+        crop.normalizedWidth = min(1 - crop.normalizedX, max(0.01, crop.normalizedWidth))
+        crop.normalizedHeight = min(1 - crop.normalizedY, max(0.01, crop.normalizedHeight))
+        adjustments.brightness = min(1, max(-1, adjustments.brightness))
+        adjustments.contrast = min(1, max(-1, adjustments.contrast))
+        adjustments.saturation = min(1, max(-1, adjustments.saturation))
+        adjustments.warmth = min(1, max(-1, adjustments.warmth))
+    }
+}
 
 struct PostComposerPhoto: Identifiable {
     let id: UUID
+    var originalImage: UIImage
     var image: UIImage
+    var source: PostComposerPhotoSource
+    var edits: PostComposerPhotoEdits
+    var processingState: PostComposerPhotoProcessingState
+    var processingError: String?
+    var createdAt: Date
+    var renderRevision: UUID
 
-    init(id: UUID = UUID(), image: UIImage) {
+    init(
+        id: UUID = UUID(),
+        image: UIImage,
+        originalImage: UIImage? = nil,
+        source: PostComposerPhotoSource = .gallery,
+        edits: PostComposerPhotoEdits = .neutral,
+        processingState: PostComposerPhotoProcessingState = .ready,
+        processingError: String? = nil,
+        createdAt: Date = Date(),
+        renderRevision: UUID = UUID()
+    ) {
         self.id = id
+        self.originalImage = originalImage ?? image
         self.image = image
+        self.source = source
+        self.edits = edits
+        self.processingState = processingState
+        self.processingError = processingError
+        self.createdAt = createdAt
+        self.renderRevision = renderRevision
     }
+
+    var pixelWidth: Int { Int(originalImage.size.width * originalImage.scale) }
+    var pixelHeight: Int { Int(originalImage.size.height * originalImage.scale) }
+    var hasBlockingError: Bool { processingState == .failed || processingState == .unavailable }
+    var isReadyForUpload: Bool { processingState == .ready || processingState == .idle }
 }
 
 extension PostComposerPhoto: Equatable {
     static func == (lhs: PostComposerPhoto, rhs: PostComposerPhoto) -> Bool {
-        lhs.id == rhs.id && lhs.image === rhs.image
+        lhs.id == rhs.id &&
+            lhs.image === rhs.image &&
+            lhs.edits == rhs.edits &&
+            lhs.processingState == rhs.processingState &&
+            lhs.processingError == rhs.processingError &&
+            lhs.renderRevision == rhs.renderRevision
+    }
+}
+
+enum PostComposerPhotoOperations {
+    static func reordered(_ photos: [PostComposerPhoto], from source: Int, to destination: Int) -> [PostComposerPhoto] {
+        guard source != destination,
+              photos.indices.contains(source),
+              photos.indices.contains(destination) else { return photos }
+        var result = photos
+        let photo = result.remove(at: source)
+        result.insert(photo, at: destination)
+        return result
+    }
+
+    static func makingCover(_ photos: [PostComposerPhoto], id: UUID) -> [PostComposerPhoto] {
+        guard let source = photos.firstIndex(where: { $0.id == id }), source != 0 else { return photos }
+        return reordered(photos, from: source, to: 0)
     }
 }

--- a/Spot/Services/Spots/PostDraftStore.swift
+++ b/Spot/Services/Spots/PostDraftStore.swift
@@ -24,6 +24,7 @@ struct PostComposerDraftSummary: Codable, Identifiable, Equatable {
 }
 
 struct PostComposerDraft: Codable, Identifiable {
+    let schemaVersion: Int?
     let id: String
     let step: Int
     let status: PostComposerDraftStatus
@@ -34,10 +35,31 @@ struct PostComposerDraft: Codable, Identifiable {
     let address: String?
     let isCustomName: Bool
     let imageFileNames: [String]
+    let photoRecords: [PostComposerDraftPhoto]?
     let updatedAt: Date
 }
 
+struct PostComposerDraftPhoto: Codable, Equatable {
+    let id: UUID
+    let originalFileName: String
+    let previewFileName: String
+    let source: PostComposerPhotoSource
+    let edits: PostComposerPhotoEdits
+    let processingState: PostComposerPhotoProcessingState
+    let processingError: String?
+    let createdAt: Date
+}
+
+struct PostComposerDraftLoadResult {
+    let draft: PostComposerDraft
+    let photos: [PostComposerPhoto]
+    let location: LocationData?
+
+    var images: [UIImage] { photos.map(\.image) }
+}
+
 enum PostDraftStore {
+    private static let currentSchemaVersion = 2
     private static let draftIndexFileName = "post-composer-drafts-index.json"
     private static let autosavedDraftID = "autosave"
 
@@ -62,8 +84,12 @@ enum PostDraftStore {
         draftsDirectory.appendingPathComponent("post-composer-draft-\(draftID).json")
     }
 
-    private static func imageFileName(draftID: String, index: Int) -> String {
-        "draft_\(draftID)_image_\(index).jpg"
+    private static func originalImageFileName(draftID: String, photoID: UUID, revision: String) -> String {
+        "draft_\(draftID)_photo_\(photoID.uuidString)_\(revision)_original.jpg"
+    }
+
+    private static func previewImageFileName(draftID: String, photoID: UUID, revision: String) -> String {
+        "draft_\(draftID)_photo_\(photoID.uuidString)_\(revision)_preview.jpg"
     }
 
     private static func loadIndex() -> [PostComposerDraftSummary] {
@@ -95,34 +121,46 @@ enum PostDraftStore {
 
     static func save(
         step: Int,
-        images: [UIImage],
+        photos: [PostComposerPhoto],
         selectedLocation: LocationData?,
         selectedVibes: [String],
         draftID: String? = nil,
         status: PostComposerDraftStatus = .autosaved
-    ) -> String {
+    ) -> String? {
         let resolvedID = draftID ?? (status == .autosaved ? autosavedDraftID : UUID().uuidString)
-        deleteImageFiles(for: resolvedID)
+        let previousDraft = (try? Data(contentsOf: draftFileURL(for: resolvedID)))
+            .flatMap { try? JSONDecoder().decode(PostComposerDraft.self, from: $0) }
+        let revision = UUID().uuidString
 
         var imageNames: [String] = []
-        for (index, image) in images.enumerated() {
-            let fileName = imageFileName(draftID: resolvedID, index: index)
-            let url = draftsDirectory.appendingPathComponent(fileName)
-            guard let data = image.spot_jpegDataOpaque(compressionQuality: 0.78) else { continue }
-            do {
-                try data.write(to: url, options: .atomic)
-            } catch {
-                SpotLogger.log(PostDraftStoreLogs.draftImageWriteFailed, details: [
-                    "draftId": resolvedID,
-                    "fileName": fileName,
-                    "error": error.localizedDescription
-                ])
-                continue
+        var stagedFileNames: [String] = []
+        var photoRecords: [PostComposerDraftPhoto] = []
+        for photo in photos {
+            let originalName = originalImageFileName(draftID: resolvedID, photoID: photo.id, revision: revision)
+            let previewName = previewImageFileName(draftID: resolvedID, photoID: photo.id, revision: revision)
+            stagedFileNames.append(contentsOf: [originalName, previewName])
+            guard
+                write(photo.originalImage, fileName: originalName, draftID: resolvedID),
+                write(photo.image, fileName: previewName, draftID: resolvedID)
+            else {
+                removeFiles(stagedFileNames)
+                return nil
             }
-            imageNames.append(fileName)
+            imageNames.append(previewName)
+            photoRecords.append(PostComposerDraftPhoto(
+                id: photo.id,
+                originalFileName: originalName,
+                previewFileName: previewName,
+                source: photo.source,
+                edits: photo.edits,
+                processingState: photo.processingState,
+                processingError: photo.processingError,
+                createdAt: photo.createdAt
+            ))
         }
 
         let draft = PostComposerDraft(
+            schemaVersion: currentSchemaVersion,
             id: resolvedID,
             step: step,
             status: status,
@@ -133,24 +171,31 @@ enum PostDraftStore {
             address: selectedLocation?.address,
             isCustomName: selectedLocation?.isCustomName ?? false,
             imageFileNames: imageNames,
+            photoRecords: photoRecords,
             updatedAt: Date()
         )
 
-        if let encoded = try? JSONEncoder().encode(draft) {
-            do {
-                try encoded.write(to: draftFileURL(for: resolvedID), options: .atomic)
-            } catch {
-                SpotLogger.log(PostDraftStoreLogs.draftWriteFailed, details: ["draftId": resolvedID, "error": error.localizedDescription])
-            }
-        } else {
+        guard let encoded = try? JSONEncoder().encode(draft) else {
             SpotLogger.log(PostDraftStoreLogs.draftWriteFailed, details: ["draftId": resolvedID, "error": "encode_failed"])
+            removeFiles(allImageFileNames(in: draft))
+            return nil
+        }
+        do {
+            try encoded.write(to: draftFileURL(for: resolvedID), options: .atomic)
+        } catch {
+            SpotLogger.log(PostDraftStoreLogs.draftWriteFailed, details: ["draftId": resolvedID, "error": error.localizedDescription])
+            removeFiles(allImageFileNames(in: draft))
+            return nil
         }
 
         upsertSummary(for: draft)
+        if let previousDraft {
+            removeFiles(allImageFileNames(in: previousDraft))
+        }
         return resolvedID
     }
 
-    static func loadDraft(id: String) -> (draft: PostComposerDraft, images: [UIImage], location: LocationData?)? {
+    static func loadDraft(id: String) -> PostComposerDraftLoadResult? {
         guard let raw = try? Data(contentsOf: draftFileURL(for: id)) else {
             SpotLogger.log(PostDraftStoreLogs.draftReadFailed, details: ["draftId": id])
             return nil
@@ -160,18 +205,7 @@ enum PostDraftStore {
             return nil
         }
 
-        let images: [UIImage] = draft.imageFileNames.compactMap { fileName in
-            let url = draftsDirectory.appendingPathComponent(fileName)
-            guard let data = try? Data(contentsOf: url) else {
-                SpotLogger.log(PostDraftStoreLogs.draftImageReadFailed, details: ["draftId": id, "fileName": fileName, "reason": "data_read_failed"])
-                return nil
-            }
-            guard let image = UIImage(data: data) else {
-                SpotLogger.log(PostDraftStoreLogs.draftImageReadFailed, details: ["draftId": id, "fileName": fileName, "reason": "image_decode_failed"])
-                return nil
-            }
-            return image
-        }
+        let photos = restorePhotos(from: draft)
 
         var location: LocationData?
         if
@@ -187,10 +221,10 @@ enum PostDraftStore {
             )
         }
 
-        return (draft, images, location)
+        return PostComposerDraftLoadResult(draft: draft, photos: photos, location: location)
     }
 
-    static func loadAutosavedDraft() -> (draft: PostComposerDraft, images: [UIImage], location: LocationData?)? {
+    static func loadAutosavedDraft() -> PostComposerDraftLoadResult? {
         loadDraft(id: autosavedDraftID)
     }
 
@@ -203,7 +237,7 @@ enum PostDraftStore {
 
     static func deleteDraft(id: String) {
         if let draft = (try? Data(contentsOf: draftFileURL(for: id))).flatMap({ try? JSONDecoder().decode(PostComposerDraft.self, from: $0) }) {
-            for fileName in draft.imageFileNames {
+            for fileName in allImageFileNames(in: draft) {
                 let url = draftsDirectory.appendingPathComponent(fileName)
                 try? FileManager.default.removeItem(at: url)
             }
@@ -228,13 +262,103 @@ enum PostDraftStore {
 }
 
 private extension PostDraftStore {
-    static func deleteImageFiles(for draftID: String) {
-        guard
-            let raw = try? Data(contentsOf: draftFileURL(for: draftID)),
-            let existing = try? JSONDecoder().decode(PostComposerDraft.self, from: raw)
-        else { return }
+    static func write(_ image: UIImage, fileName: String, draftID: String) -> Bool {
+        guard let data = image.spot_jpegDataOpaque(compressionQuality: 0.88) else { return false }
+        do {
+            try data.write(to: draftsDirectory.appendingPathComponent(fileName), options: .atomic)
+            return true
+        } catch {
+            SpotLogger.log(PostDraftStoreLogs.draftImageWriteFailed, details: [
+                "draftId": draftID,
+                "fileName": fileName,
+                "error": error.localizedDescription
+            ])
+            return false
+        }
+    }
 
-        for fileName in existing.imageFileNames {
+    static func restorePhotos(from draft: PostComposerDraft) -> [PostComposerPhoto] {
+        if let records = draft.photoRecords {
+            return records.map { record in
+                let original = loadImage(fileName: record.originalFileName, draftID: draft.id)
+                let preview = loadImage(fileName: record.previewFileName, draftID: draft.id)
+                let fallback = preview ?? original ?? unavailablePlaceholder()
+                let renderedAfterInterruptedSave: UIImage? = {
+                    guard let original,
+                          preview == nil || record.processingState == .processing else { return nil }
+                    return try? PostPhotoProcessor.render(original: original, edits: record.edits)
+                }()
+                let restoredState: PostComposerPhotoProcessingState
+                let restoredError: String?
+                if original == nil {
+                    restoredState = .unavailable
+                    restoredError = "This photo is no longer available on this device."
+                } else if record.processingState == .processing || preview == nil {
+                    restoredState = renderedAfterInterruptedSave == nil ? .failed : .ready
+                    restoredError = renderedAfterInterruptedSave == nil
+                        ? "We couldn’t prepare this photo."
+                        : nil
+                } else {
+                    restoredState = record.processingState
+                    restoredError = record.processingError
+                }
+                return PostComposerPhoto(
+                    id: record.id,
+                    image: renderedAfterInterruptedSave ?? fallback,
+                    originalImage: original ?? fallback,
+                    source: record.source,
+                    edits: record.edits,
+                    processingState: restoredState,
+                    processingError: restoredError,
+                    createdAt: record.createdAt
+                )
+            }
+        }
+        return draft.imageFileNames.map { fileName in
+            guard let image = loadImage(fileName: fileName, draftID: draft.id) else {
+                return PostComposerPhoto(
+                    image: unavailablePlaceholder(),
+                    source: .legacyDraft,
+                    processingState: .unavailable,
+                    processingError: "This photo is no longer available on this device."
+                )
+            }
+            return PostComposerPhoto(image: image, source: .legacyDraft)
+        }
+    }
+
+    static func loadImage(fileName: String, draftID: String) -> UIImage? {
+        let url = draftsDirectory.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url), let image = UIImage(data: data) else {
+            SpotLogger.log(PostDraftStoreLogs.draftImageReadFailed, details: [
+                "draftId": draftID,
+                "fileName": fileName,
+                "reason": "read_or_decode_failed"
+            ])
+            return nil
+        }
+        return image
+    }
+
+    static func unavailablePlaceholder() -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: CGSize(width: 320, height: 240), format: format).image { context in
+            UIColor.secondarySystemBackground.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 320, height: 240))
+        }
+    }
+
+    static func allImageFileNames(in draft: PostComposerDraft) -> [String] {
+        if let records = draft.photoRecords {
+            return records.flatMap { [$0.originalFileName, $0.previewFileName] }
+        }
+        return draft.imageFileNames
+    }
+
+    static func removeFiles(_ fileNames: [String]) {
+        for fileName in Set(fileNames) {
             try? FileManager.default.removeItem(at: draftsDirectory.appendingPathComponent(fileName))
         }
     }

--- a/Spot/Services/Spots/PostPhotoProcessor.swift
+++ b/Spot/Services/Spots/PostPhotoProcessor.swift
@@ -1,0 +1,186 @@
+import CoreImage
+import ImageIO
+import UniformTypeIdentifiers
+import UIKit
+
+enum PostPhotoImportError: LocalizedError, Equatable {
+    case unsupportedMedia
+    case video
+    case unreadable
+    case decodeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .video:
+            return "Videos can’t be added to a Spot. Choose a photo instead."
+        case .unsupportedMedia:
+            return "This file isn’t a supported photo."
+        case .unreadable, .decodeFailed:
+            return "This photo couldn’t be opened."
+        }
+    }
+}
+
+enum PostPhotoProcessor {
+    static let previewMaxPixelSize: CGFloat = 1_600
+    private static let context = CIContext(options: [.cacheIntermediates: false])
+
+    static func importImage(
+        data: Data,
+        source: PostComposerPhotoSource
+    ) throws -> PostComposerPhoto {
+        guard !data.isEmpty else { throw PostPhotoImportError.unreadable }
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetCount(imageSource) > 0 else {
+            throw PostPhotoImportError.unsupportedMedia
+        }
+        guard let type = CGImageSourceGetType(imageSource) as String?,
+              UTTypeConformance.conformsToImage(type) else {
+            throw PostPhotoImportError.unsupportedMedia
+        }
+
+        let options: CFDictionary = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: previewMaxPixelSize,
+            kCGImageSourceShouldCacheImmediately: true
+        ] as CFDictionary
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options) else {
+            throw PostPhotoImportError.decodeFailed
+        }
+        let normalized = UIImage(cgImage: cgImage, scale: 1, orientation: .up)
+        return PostComposerPhoto(
+            image: normalized,
+            originalImage: normalized,
+            source: source
+        )
+    }
+
+    static func importCameraImage(_ image: UIImage) throws -> PostComposerPhoto {
+        guard let normalized = normalizeOrientationAndResize(image, maxPixelSize: previewMaxPixelSize) else {
+            throw PostPhotoImportError.decodeFailed
+        }
+        return PostComposerPhoto(
+            image: normalized,
+            originalImage: normalized,
+            source: .camera
+        )
+    }
+
+    static func render(original: UIImage, edits proposedEdits: PostComposerPhotoEdits) throws -> UIImage {
+        var edits = proposedEdits
+        edits.normalize()
+        guard var result = normalizeOrientationAndResize(original, maxPixelSize: previewMaxPixelSize) else {
+            throw PostPhotoImportError.decodeFailed
+        }
+
+        result = transform(
+            result,
+            quarterTurns: edits.rotationQuarterTurns,
+            straightenDegrees: edits.straightenDegrees,
+            flipHorizontal: edits.flipHorizontal,
+            flipVertical: edits.flipVertical
+        )
+
+        let crop = edits.crop
+        let pixelWidth = CGFloat(result.cgImage?.width ?? Int(result.size.width))
+        let pixelHeight = CGFloat(result.cgImage?.height ?? Int(result.size.height))
+        let cropRect = CGRect(
+            x: crop.normalizedX * pixelWidth,
+            y: crop.normalizedY * pixelHeight,
+            width: crop.normalizedWidth * pixelWidth,
+            height: crop.normalizedHeight * pixelHeight
+        ).integral.intersection(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+        guard !cropRect.isEmpty, let cropped = result.cgImage?.cropping(to: cropRect) else {
+            throw PostPhotoImportError.decodeFailed
+        }
+        result = UIImage(cgImage: cropped, scale: 1, orientation: .up)
+        return applyAdjustments(edits.adjustments, to: result) ?? result
+    }
+
+    static func normalizeOrientationAndResize(_ image: UIImage, maxPixelSize: CGFloat) -> UIImage? {
+        let orientedSize = image.size
+        guard orientedSize.width > 0, orientedSize.height > 0 else { return nil }
+        let scale = min(1, maxPixelSize / max(orientedSize.width, orientedSize.height))
+        let target = CGSize(
+            width: max(1, floor(orientedSize.width * scale)),
+            height: max(1, floor(orientedSize.height * scale))
+        )
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: target, format: format).image { _ in
+            UIColor.black.setFill()
+            UIRectFill(CGRect(origin: .zero, size: target))
+            image.draw(in: CGRect(origin: .zero, size: target))
+        }
+    }
+
+    private static func transform(
+        _ image: UIImage,
+        quarterTurns: Int,
+        straightenDegrees: Double,
+        flipHorizontal: Bool,
+        flipVertical: Bool
+    ) -> UIImage {
+        let radians = CGFloat(quarterTurns) * (.pi / 2) + CGFloat(straightenDegrees) * (.pi / 180)
+        var transform = CGAffineTransform(rotationAngle: radians)
+        transform = transform.scaledBy(
+            x: flipHorizontal ? -1 : 1,
+            y: flipVertical ? -1 : 1
+        )
+        let sourceRect = CGRect(origin: .zero, size: image.size)
+        let bounds = sourceRect.applying(transform).standardized
+        let outputSize = CGSize(width: max(1, bounds.width), height: max(1, bounds.height))
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: outputSize, format: format).image { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(origin: .zero, size: outputSize))
+            context.cgContext.translateBy(x: outputSize.width / 2, y: outputSize.height / 2)
+            context.cgContext.concatenate(transform)
+            image.draw(
+                in: CGRect(
+                    x: -image.size.width / 2,
+                    y: -image.size.height / 2,
+                    width: image.size.width,
+                    height: image.size.height
+                )
+            )
+        }
+    }
+
+    private static func applyAdjustments(
+        _ adjustments: PostComposerPhotoAdjustments,
+        to image: UIImage
+    ) -> UIImage? {
+        guard !adjustments.isNeutral, let input = CIImage(image: image) else { return image }
+        let controls = CIFilter(name: "CIColorControls")
+        controls?.setValue(input, forKey: kCIInputImageKey)
+        controls?.setValue(adjustments.brightness * 0.35, forKey: kCIInputBrightnessKey)
+        controls?.setValue(1 + adjustments.contrast, forKey: kCIInputContrastKey)
+        controls?.setValue(1 + adjustments.saturation, forKey: kCIInputSaturationKey)
+        guard var output = controls?.outputImage else { return nil }
+
+        if adjustments.warmth != 0 {
+            let temperature = CIFilter(name: "CITemperatureAndTint")
+            temperature?.setValue(output, forKey: kCIInputImageKey)
+            temperature?.setValue(
+                CIVector(x: CGFloat(6_500 - adjustments.warmth * 2_000), y: 0),
+                forKey: "inputNeutral"
+            )
+            temperature?.setValue(CIVector(x: 6_500, y: 0), forKey: "inputTargetNeutral")
+            output = temperature?.outputImage ?? output
+        }
+
+        guard let cgImage = context.createCGImage(output, from: output.extent) else { return nil }
+        return UIImage(cgImage: cgImage, scale: 1, orientation: .up)
+    }
+}
+
+private enum UTTypeConformance {
+    static func conformsToImage(_ uti: String) -> Bool {
+        UTType(uti)?.conforms(to: .image) == true
+    }
+}

--- a/Spot/ViewModels/PostFlowViewModel.swift
+++ b/Spot/ViewModels/PostFlowViewModel.swift
@@ -16,7 +16,7 @@ class PostFlowViewModel: ObservableObject {
     /// Stable per-slot ids for `PhotoSelectionView` / `TabView` (reorder-safe).
     @Published var selectedPhotos: [PostComposerPhoto] = []
 
-    /// Drafts, validation, and publish still consume `[UIImage]`.
+    /// Publishing consumes the current non-destructive rendered previews.
     var selectedImages: [UIImage] {
         get { selectedPhotos.map(\.image) }
         set { selectedPhotos = newValue.map { PostComposerPhoto(image: $0) } }
@@ -55,7 +55,10 @@ class PostFlowViewModel: ObservableObject {
 
     var canProceedToNextStep: Bool {
         switch currentStep {
-        case 1: return !selectedImages.isEmpty
+        case 1:
+            return !selectedPhotos.isEmpty &&
+                selectedPhotos.count <= maximumPhotoCount &&
+                selectedPhotos.allSatisfy(\.isReadyForUpload)
         case 2: return selectedLocation != nil
         case 3: return !selectedVibes.isEmpty
         default: return false
@@ -67,7 +70,17 @@ class PostFlowViewModel: ObservableObject {
     }
 
     var canSubmitPost: Bool {
-        !selectedImages.isEmpty && selectedLocation != nil && !selectedVibes.isEmpty
+        !selectedPhotos.isEmpty &&
+            selectedPhotos.count <= maximumPhotoCount &&
+            selectedPhotos.allSatisfy(\.isReadyForUpload) &&
+            selectedLocation != nil &&
+            !selectedVibes.isEmpty
+    }
+
+    var maximumPhotoCount: Int {
+        authViewModel?.isPro == true
+            ? Constants.PostLimits.maxProPostImages
+            : Constants.PostLimits.maxFreePostImages
     }
 
     func goBack() {
@@ -195,20 +208,22 @@ class PostFlowViewModel: ObservableObject {
     }
 
     func persistDraftSnapshot() {
-        activeDraftID = PostDraftStore.save(
+        if let savedDraftID = PostDraftStore.save(
             step: currentStep,
-            images: selectedImages,
+            photos: selectedPhotos,
             selectedLocation: selectedLocation,
             selectedVibes: selectedVibes,
             draftID: activeDraftID,
             status: .autosaved
-        )
+        ) {
+            activeDraftID = savedDraftID
+        }
         refreshDrafts()
     }
 
     func loadPersistedDraftIfAvailable() -> Bool {
         guard let loaded = PostDraftStore.loadAutosavedDraft() else { return false }
-        selectedImages = loaded.images
+        selectedPhotos = loaded.photos
         selectedLocation = loaded.location
         selectedVibes = loaded.draft.vibeTags
         selectedVibe = loaded.draft.vibeTags.first ?? ""
@@ -261,14 +276,18 @@ class PostFlowViewModel: ObservableObject {
             showToastWith(message: "Add photos, location, or vibes before saving.", isError: true)
             return false
         }
-        activeDraftID = PostDraftStore.save(
+        guard let savedDraftID = PostDraftStore.save(
             step: currentStep,
-            images: selectedImages,
+            photos: selectedPhotos,
             selectedLocation: selectedLocation,
             selectedVibes: selectedVibes,
             draftID: activeDraftID == "autosave" ? nil : activeDraftID,
             status: .saved
-        )
+        ) else {
+            showToastWith(message: "Could not save this draft. Please try again.", isError: true)
+            return false
+        }
+        activeDraftID = savedDraftID
         VibeTagUsageStore.recordUsage(tags: selectedVibes)
         PostDraftStore.clearAutosave()
         resetComposerForDraftExit()
@@ -282,7 +301,7 @@ class PostFlowViewModel: ObservableObject {
             showToastWith(message: "Could not open that draft.", isError: true)
             return
         }
-        selectedImages = loaded.images
+        selectedPhotos = loaded.photos
         selectedLocation = loaded.location
         selectedVibes = loaded.draft.vibeTags
         selectedVibe = loaded.draft.vibeTags.first ?? ""

--- a/Spot/Views/PostFlow/PhotoSelectionView.swift
+++ b/Spot/Views/PostFlow/PhotoSelectionView.swift
@@ -1,352 +1,913 @@
-import SwiftUI
+import AVFoundation
+import Photos
 import PhotosUI
+import SwiftUI
+import UniformTypeIdentifiers
 import UIKit
-import ImageIO
-
-private let postImageMaxPixelSize: CGFloat = 1600
 
 private enum GalleryPickMode: Equatable {
     case add
-    case replace
+    case replace(UUID)
+}
+
+private struct RemovedPhoto {
+    let photo: PostComposerPhoto
+    let index: Int
 }
 
 struct PhotoSelectionView: View {
-    @EnvironmentObject var authVM: AuthViewModel
-    @EnvironmentObject var permissionManager: PermissionManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @EnvironmentObject private var authVM: AuthViewModel
+    @EnvironmentObject private var permissionManager: PermissionManager
     @Binding var selectedPhotos: [PostComposerPhoto]
     let draftCount: Int
     let onOpenDrafts: () -> Void
-    /// Called when a non‑Pro user selects multiple photos at once (only the first is kept).
     var onFreeTierGalleryOverflow: (() -> Void)?
-    /// Programmatic gallery picker — shown only after the user taps
-    /// Choose from Gallery / Replace and, when needed, completes the
-    /// contextual `PhotoPermissionView` pre-prompt (`notDetermined`).
+
+    @State private var activePhotoID: UUID?
+    @State private var editorPhoto: PostComposerPhoto?
     @State private var galleryPickerItems: [PhotosPickerItem] = []
-    @State private var showGalleryPicker = false
     @State private var galleryPickMode: GalleryPickMode = .add
+    @State private var showGalleryPicker = false
+    @State private var showAddSourceSheet = false
     @State private var showPhotoLibraryPrePrompt = false
+    @State private var showCameraPrePrompt = false
     @State private var showCamera = false
     @State private var showPhotoSettingsAlert = false
     @State private var showCameraSettingsAlert = false
-    @State private var selectedPhotoIndex: Int = 0
-    /// True while the contextual Camera pre-prompt sheet is presented.
-    /// Apple App Review requires the custom `CameraPermissionView` to
-    /// appear BEFORE the native iOS dialog the first time the user taps
-    /// Take a Photo. Tapping Continue on the pre-prompt fires the
-    /// native dialog; swiping the sheet down is treated as a soft skip
-    /// and the composer simply stays on the photo step (the user can
-    /// still pick from gallery).
-    @State private var showCameraPrePrompt = false
+    @State private var showDeleteConfirmation = false
+    @State private var showReplaceWarning = false
+    @State private var isOpeningPicker = false
+    @State private var isImporting = false
+    @State private var importCount = 0
+    @State private var errorMessage: String?
+    @State private var retryGalleryMode: GalleryPickMode?
+    @State private var removedPhoto: RemovedPhoto?
+    @State private var undoTask: Task<Void, Never>?
+    @State private var draggedPhotoID: UUID?
 
     var body: some View {
-        VStack(spacing: 20) {
-            // Header
-            HStack(alignment: .center) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Create a Spot")
-                        .font(FontManager.sectionHeader())
-                        .foregroundColor(Constants.Colors.primary)
-                    Text(selectedPhotos.isEmpty ? "Start with photos, or continue a saved draft." : "Review, reorder, replace, and add photos.")
-                        .font(FontManager.primaryText())
-                        .foregroundColor(.gray)
-                }
-                Spacer()
-                Button(action: onOpenDrafts) {
-                    VStack(spacing: 2) {
-                        Text("Drafts")
-                            .font(.caption.weight(.semibold))
-                        Text("\(draftCount)")
-                            .font(.caption2)
-                    }
-                    .foregroundColor(Constants.Colors.primary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.white)
-                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(Constants.Colors.primary, lineWidth: 1))
-                    .cornerRadius(10)
-                }
-                .buttonStyle(PlainButtonStyle())
-                .accessibilityIdentifier("posting.draftsButton")
-            }
-            .padding(.horizontal, 24)
-
+        VStack(spacing: 18) {
+            header
             if selectedPhotos.isEmpty {
-                VStack(spacing: 14) {
-                    Image(systemName: "photo.stack")
-                        .font(.system(size: 28))
-                        .foregroundColor(Constants.Colors.primary)
-                    Text("Add at least one photo to continue")
-                        .font(FontManager.primaryText())
-                        .foregroundColor(.gray)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 200)
-                    .background(Color.white)
-                    .cornerRadius(16)
-                    .overlay(RoundedRectangle(cornerRadius: 16).stroke(style: StrokeStyle(lineWidth: 1, dash: [6])).foregroundColor(Constants.Colors.primary))
-                    .padding(.horizontal, 24)
+                emptyState
             } else {
-                VStack(spacing: 12) {
-                    let previewWidth = max(SpotMediaLayoutMetrics.screenWidth - 48, 1)
-                    let previewHeight = postingPreviewCarouselHeight(width: previewWidth)
-
-                    TabView(selection: $selectedPhotoIndex) {
-                        ForEach(Array(selectedPhotos.enumerated()), id: \.element.id) { idx, photo in
-                            Image(uiImage: photo.image)
-                                .resizable()
-                                .scaledToFill()
-                                .tag(idx)
-                                .frame(maxWidth: .infinity)
-                                .frame(height: previewHeight)
-                                .clipped()
-                                .cornerRadius(16)
-                                .padding(.horizontal, 24)
-                        }
-                    }
-                    .tabViewStyle(.page(indexDisplayMode: .never))
-                    .frame(height: previewHeight)
-
-                    Text("The first photo sets how your Spot appears in the feed. Drag thumbnails to reorder.")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 24)
-
-                    HStack {
-                        Text("\(selectedPhotoIndex + 1) of \(selectedPhotos.count)")
-                            .font(.caption)
-                            .foregroundColor(.gray)
-                        Spacer()
-                        Button(action: openGalleryReplaceIfPermitted) {
-                            Label("Replace", systemImage: "arrow.triangle.2.circlepath")
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .font(.caption.weight(.semibold))
-                        .foregroundColor(Constants.Colors.primary)
-
-                        Button {
-                            deleteSelectedImage()
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .font(.caption.weight(.semibold))
-                        .foregroundColor(.red)
-                    }
-                    .padding(.horizontal, 24)
-
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 10) {
-                            ForEach(Array(selectedPhotos.enumerated()), id: \.element.id) { idx, photo in
-                                VStack(spacing: 6) {
-                                    Button {
-                                        selectedPhotoIndex = idx
-                                    } label: {
-                                        Image(uiImage: photo.image)
-                                            .resizable()
-                                            .scaledToFill()
-                                            .frame(width: 62, height: 62)
-                                            .clipped()
-                                            .cornerRadius(10)
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 10)
-                                                    .stroke(idx == selectedPhotoIndex ? Constants.Colors.primary : Color.clear, lineWidth: 2)
-                                            )
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
-
-                                    HStack(spacing: 4) {
-                                        Button { moveImage(from: idx, to: idx - 1) } label: {
-                                            Image(systemName: "arrow.left.circle")
-                                        }
-                                        .disabled(idx == 0)
-                                        Button { moveImage(from: idx, to: idx + 1) } label: {
-                                            Image(systemName: "arrow.right.circle")
-                                        }
-                                        .disabled(idx == selectedPhotos.count - 1)
-                                    }
-                                    .foregroundColor(Constants.Colors.primary)
-                                    .font(.caption)
-                                }
-                            }
-                        }
-                        .padding(.horizontal, 24)
-                    }
-                }
+                managementWorkspace
             }
-
-            // Additional actions
-            VStack(spacing: 20) {
-                // Gallery — contextual pre-prompt before the system Photos UI
-                // when status is `.notDetermined` (same pattern as Take Photo).
-                Button(action: openGalleryAddIfPermitted) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "photo.on.rectangle")
-                            .font(.system(size: 24))
-                            .foregroundColor(Constants.Colors.primary)
-
-                        Text("Choose from Gallery")
-                            .font(FontManager.primaryText())
-                            .foregroundColor(Constants.Colors.primary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.white)
-                    .cornerRadius(16)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(Constants.Colors.primary, lineWidth: 1)
-                    )
+            if isImporting {
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("Adding \(importCount) photo\(importCount == 1 ? "" : "s")…")
                 }
-                .buttonStyle(PlainButtonStyle())
-                .disabled(photoSelectionDisabled || selectedPhotos.count >= maxPhotoCount)
-
-                if photoSelectionDisabled {
-                    Button("Open iOS Settings") {
-                        showPhotoSettingsAlert = true
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .font(FontManager.primaryText())
-                    .foregroundColor(Constants.Colors.primary)
-                }
-
-                // Divider
-                HStack {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(height: 1)
-                    Text("or")
-                        .font(FontManager.primaryText())
-                        .foregroundColor(.gray)
-                        .padding(.horizontal, 16)
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(height: 1)
-                }
-                .padding(.horizontal, 32)
-
-                // Camera Button
-                Button(action: { openCameraIfPermitted() }) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "camera")
-                            .font(.system(size: 24))
-                            .foregroundColor(Constants.Colors.primary)
-
-                        Text("Take a Photo")
-                            .font(FontManager.primaryText())
-                            .foregroundColor(Constants.Colors.primary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.white)
-                    .cornerRadius(16)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(Constants.Colors.primary, lineWidth: 1)
-                    )
-                }
-                .buttonStyle(PlainButtonStyle())
-                .buttonStyle(PlainButtonStyle())
+                .font(.caption)
+                .foregroundStyle(Constants.Colors.primary)
+                .accessibilityElement(children: .combine)
             }
-            .padding(.horizontal, 24)
-
-            Spacer()
+            if permissionManager.photoStatus == .limited {
+                Button("Manage Photo Access") {
+                    permissionManager.openPhotoSettings()
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Constants.Colors.primary)
+                .frame(minHeight: 44)
+                .accessibilityHint("Opens Settings to change which photos Spot can access")
+            }
+            if selectedPhotos.isEmpty {
+                Text("Add at least one photo to continue.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
+        .padding(.bottom, 12)
         .accessibilityIdentifier("posting.photoStepRoot")
         .onAppear {
             permissionManager.updatePermissionStatuses()
+            repairActiveSelection()
         }
+        .onChange(of: selectedPhotos) { _, _ in repairActiveSelection() }
         .photosPicker(
             isPresented: $showGalleryPicker,
             selection: $galleryPickerItems,
             maxSelectionCount: galleryPickerMaxSelectionCount,
-            matching: .images
+            matching: .images,
+            preferredItemEncoding: .compatible
         )
-        .task(id: galleryPickerItems) {
-            guard !galleryPickerItems.isEmpty else { return }
-            let mode = galleryPickMode
-            let items = galleryPickerItems
-            galleryPickerItems = []
-            showGalleryPicker = false
-
-            switch mode {
-            case .add:
-                var newImages: [UIImage] = []
-                let maxCount = maxPhotoCount
-                let pickerCount = items.count
-                for item in items.prefix(maxCount) {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let uiImage = downsampledPostImage(from: data, maxPixelSize: postImageMaxPixelSize) {
-                        newImages.append(uiImage)
-                    }
-                }
-                if !newImages.isEmpty {
-                    SpotLogger.log(PhotoSelectionViewLogs.photosSelectedFromGallery, details: ["count": newImages.count])
-                    let available = max(0, maxPhotoCount - selectedPhotos.count)
-                    if available > 0 {
-                        selectedPhotos.append(contentsOf: newImages.prefix(available).map { PostComposerPhoto(image: $0) })
-                        selectedPhotoIndex = max(0, selectedPhotos.count - 1)
-                        if !authVM.isPro, maxPhotoCount == 1, pickerCount > 1 {
-                            onFreeTierGalleryOverflow?()
-                            AnalyticsService.shared.logEvent("post_multiple_images_upsell_shown", parameters: [:])
-                        }
-                    }
-                } else {
-                    SpotLogger.log(PhotoSelectionViewLogs.loadPhotosFailed)
-                }
-            case .replace:
-                guard let item = items.first else { return }
-                guard selectedPhotoIndex >= 0, selectedPhotoIndex < selectedPhotos.count else { return }
-                if let data = try? await item.loadTransferable(type: Data.self),
-                   let uiImage = downsampledPostImage(from: data, maxPixelSize: postImageMaxPixelSize) {
-                    let id = selectedPhotos[selectedPhotoIndex].id
-                    selectedPhotos[selectedPhotoIndex] = PostComposerPhoto(id: id, image: uiImage)
-                }
+        .onChange(of: showGalleryPicker) { _, presented in
+            guard !presented else { return }
+            isOpeningPicker = false
+            if galleryPickerItems.isEmpty {
+                AnalyticsService.shared.logEvent("spot_photo_picker_cancelled", parameters: [:])
             }
         }
-        .sheet(isPresented: $showCamera) {
-            CameraView(selectedPhotos: $selectedPhotos, maxCount: maxPhotoCount)
+        .onChange(of: galleryPickerItems) { _, items in
+            guard !items.isEmpty else { return }
+            let mode = galleryPickMode
+            Task { await importPickerItems(items, mode: mode) }
         }
-        .sheet(isPresented: $showCameraPrePrompt) {
-            CameraPermissionView(
-                authDestination: .signup,
-                showsBackButton: false,
-                onComplete: {
-                    showCameraPrePrompt = false
-                    permissionManager.updatePermissionStatuses()
-                    switch permissionManager.cameraStatus {
-                    case .authorized:
-                        showCamera = true
-                    case .denied, .restricted:
-                        showCameraSettingsAlert = true
-                    default:
-                        break
+        .confirmationDialog("Add Photos", isPresented: $showAddSourceSheet, titleVisibility: .visible) {
+            Button("Choose from Photos") { openGalleryAddIfPermitted() }
+            Button("Take a Photo") { openCameraIfPermitted() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(remainingCapacityText)
+        }
+        .alert("Photo Library Access Is Off", isPresented: $showPhotoSettingsAlert) {
+            Button("Open Settings") { permissionManager.openPhotoSettings() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Photo access is needed to choose images for your Spot.")
+        }
+        .alert("Camera Access Is Off", isPresented: $showCameraSettingsAlert) {
+            Button("Open Settings") { permissionManager.openCameraSettings() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Camera access is needed to take a new photo.")
+        }
+        .alert("Remove this photo from your Spot?", isPresented: $showDeleteConfirmation) {
+            Button("Keep Photo", role: .cancel) {}
+            Button("Remove", role: .destructive) { removeActivePhoto() }
+        }
+        .alert("Replace Photo", isPresented: $showReplaceWarning) {
+            Button("Cancel", role: .cancel) {}
+            Button("Replace", role: .destructive) { openGalleryReplaceIfPermitted() }
+        } message: {
+            Text("Replacing this photo will remove its current edits.")
+        }
+        .alert("Photo Error", isPresented: errorBinding) {
+            if let retryGalleryMode {
+                Button("Try Again") {
+                    switch retryGalleryMode {
+                    case .add: openGalleryAddIfPermitted()
+                    case .replace: openGalleryReplaceIfPermitted()
                     }
                 }
-            )
-            .environmentObject(permissionManager)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "We couldn’t open your photo library. Please try again.")
         }
         .sheet(isPresented: $showPhotoLibraryPrePrompt) {
             PhotoPermissionView(
                 authDestination: .signup,
                 showsBackButton: false,
-                onComplete: {
-                    finishPhotoLibraryPrePromptAndOpenPickerIfAllowed()
-                }
+                onComplete: finishPhotoPermissionPrompt
             )
             .environmentObject(permissionManager)
         }
-        .alert("Photo Library Access Is Off", isPresented: $showPhotoSettingsAlert) {
-            Button("Open iOS Settings") { permissionManager.openPhotoSettings() }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Photo library access is off. You can update access in iOS Settings or continue without adding photos.")
+        .sheet(isPresented: $showCameraPrePrompt) {
+            CameraPermissionView(
+                authDestination: .signup,
+                showsBackButton: false,
+                onComplete: finishCameraPermissionPrompt
+            )
+            .environmentObject(permissionManager)
         }
-        .alert("Camera Access Is Off", isPresented: $showCameraSettingsAlert) {
-            Button("Open iOS Settings") { permissionManager.openCameraSettings() }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Camera access is off. You can update access in iOS Settings or choose a photo from your library.")
+        .sheet(isPresented: $showCamera) {
+            SpotPhotoCameraView { result in
+                showCamera = false
+                handleCameraResult(result)
+            }
+            .ignoresSafeArea()
+        }
+        .fullScreenCover(item: $editorPhoto) { photo in
+            SpotPhotoEditorView(photo: photo) { edits in
+                saveEdits(edits, for: photo.id)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let removedPhoto {
+                HStack {
+                    Text("Photo removed")
+                    Spacer()
+                    Button("Undo") { undoRemoval(removedPhoto) }
+                        .fontWeight(.semibold)
+                }
+                .font(.subheadline)
+                .foregroundStyle(Constants.Colors.buttonText)
+                .padding()
+                .background(Constants.Colors.primary)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .padding()
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .onDisappear {
+            undoTask?.cancel()
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Create a Spot")
+                    .font(FontManager.sectionHeader())
+                    .foregroundStyle(Constants.Colors.primary)
+                Text("Start by adding photos of this place.")
+                    .font(FontManager.primaryText())
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(action: onOpenDrafts) {
+                VStack(spacing: 2) {
+                    Text("Drafts").font(.caption.weight(.semibold))
+                    Text("\(draftCount)").font(.caption2)
+                }
+                .foregroundStyle(Constants.Colors.primary)
+                .frame(minWidth: 48, minHeight: 44)
+                .padding(.horizontal, 6)
+                .background(.white)
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Constants.Colors.primary))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("posting.draftsButton")
+            .accessibilityLabel("Drafts, \(draftCount)")
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            VStack(spacing: 12) {
+                Image(systemName: "photo.on.rectangle.angled")
+                    .font(.system(size: 34))
+                    .foregroundStyle(Constants.Colors.primary)
+                Text("Add photos")
+                    .font(FontManager.sectionHeader())
+                    .foregroundStyle(Constants.Colors.primary)
+                Text("Choose up to \(maxPhotoCount) photo\(maxPhotoCount == 1 ? "" : "s"). You can crop, rotate, and reorder them before posting.")
+                    .font(FontManager.primaryText())
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                primaryGalleryButton
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity)
+            .background(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .overlay(RoundedRectangle(cornerRadius: 18).stroke(Constants.Colors.primary.opacity(0.15)))
+
+            Text("or")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            secondaryCameraButton(title: "Take a Photo")
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var primaryGalleryButton: some View {
+        Button(action: openGalleryAddIfPermitted) {
+            Label(isOpeningPicker ? "Opening Photos…" : "Choose Photos", systemImage: "photo.stack")
+                .font(FontManager.buttonText())
+                .foregroundStyle(Constants.Colors.buttonText)
+                .frame(maxWidth: .infinity, minHeight: 52)
+                .background(Constants.Colors.primary)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(SpotPressedButtonStyle())
+        .disabled(isOpeningPicker || isImporting)
+        .accessibilityIdentifier("posting.choosePhotosButton")
+        .accessibilityHint(remainingCapacityText)
+    }
+
+    private var managementWorkspace: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text("\(activePhotoIndex + 1) of \(selectedPhotos.count)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Constants.Colors.primary)
+                Spacer()
+                Button("Edit") { openEditor() }
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Constants.Colors.primary)
+                    .frame(minHeight: 44)
+                    .accessibilityLabel("Edit photo \(activePhotoIndex + 1) of \(selectedPhotos.count)")
+                Menu {
+                    photoActionMenu
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.title3)
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Photo actions")
+            }
+            .padding(.horizontal, 24)
+
+            if let activePhoto {
+                ZStack(alignment: .topLeading) {
+                    Color.black.opacity(0.9)
+                    Image(uiImage: activePhoto.image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                        .onTapGesture { openEditor() }
+                        .accessibilityLabel("Edit photo \(activePhotoIndex + 1) of \(selectedPhotos.count)")
+                        .accessibilityAddTraits(.isButton)
+                    if activePhotoIndex == 0 {
+                        coverBadge.padding(12)
+                    }
+                    if activePhoto.processingState == .processing {
+                        ProgressView()
+                            .tint(.white)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                    if activePhoto.processingState == .failed || activePhoto.processingState == .unavailable {
+                        VStack(spacing: 10) {
+                            Text(activePhoto.processingState == .unavailable
+                                ? "This photo is no longer available on this device."
+                                : "We couldn’t prepare this photo.")
+                                .font(.subheadline.weight(.semibold))
+                                .multilineTextAlignment(.center)
+                            HStack {
+                                Button("Replace") { prepareReplacement() }
+                                Button("Remove", role: .destructive) { requestDelete() }
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                        .foregroundStyle(.white)
+                        .padding()
+                        .background(.black.opacity(0.75))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+                .frame(height: activePreviewHeight)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .padding(.horizontal, 24)
+            }
+
+            Text("Hold and drag photos to reorder. The first photo is the cover.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            thumbnailTray
+
+            if selectedPhotos.count < maxPhotoCount {
+                secondaryCameraButton(title: "Take another photo")
+                    .padding(.horizontal, 24)
+            } else if selectedPhotos.count == maxPhotoCount {
+                Text("Maximum of \(maxPhotoCount) photos reached.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Constants.Colors.primary)
+            } else {
+                Text("Remove \(selectedPhotos.count - maxPhotoCount) photo\(selectedPhotos.count - maxPhotoCount == 1 ? "" : "s") to continue.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var thumbnailTray: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 10) {
+                ForEach(Array(selectedPhotos.enumerated()), id: \.element.id) { index, photo in
+                    thumbnail(photo, index: index)
+                }
+                if selectedPhotos.count < maxPhotoCount {
+                    Button {
+                        showAddSourceSheet = true
+                    } label: {
+                        VStack(spacing: 6) {
+                            Image(systemName: "plus").font(.title3)
+                            Text("Add").font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(Constants.Colors.primary)
+                        .frame(width: 80, height: 80)
+                        .background(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Constants.Colors.primary.opacity(0.4)))
+                    }
+                    .buttonStyle(SpotPressedButtonStyle())
+                    .accessibilityLabel("Add more photos")
+                    .accessibilityHint(remainingCapacityText)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func thumbnail(_ photo: PostComposerPhoto, index: Int) -> some View {
+        Menu {
+            Button("Edit Photo") {
+                activePhotoID = photo.id
+                openEditor()
+            }
+            if index > 0 {
+                Button("Make Cover") { makeCover(photo.id) }
+            }
+            Button("Move Left") { move(photo.id, by: -1) }
+                .disabled(index == 0)
+            Button("Move Right") { move(photo.id, by: 1) }
+                .disabled(index == selectedPhotos.count - 1)
+            Button("Move to Start") { move(photo.id, to: 0) }
+                .disabled(index == 0)
+            Button("Move to End") { move(photo.id, to: selectedPhotos.count - 1) }
+                .disabled(index == selectedPhotos.count - 1)
+            Button("Remove Photo", role: .destructive) {
+                activePhotoID = photo.id
+                requestDelete()
+            }
+        } label: {
+            ZStack(alignment: .bottomLeading) {
+                Image(uiImage: photo.image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 80, height: 80)
+                    .clipped()
+                if index == 0 {
+                    Text("Cover")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(Constants.Colors.buttonText)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 3)
+                        .background(Constants.Colors.primary)
+                        .clipShape(Capsule())
+                        .padding(4)
+                }
+                if photo.processingState == .processing {
+                    ProgressView().tint(.white).frame(width: 80, height: 80)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(photo.id == activePhotoID ? Constants.Colors.primary : .clear, lineWidth: 3)
+            )
+            .contentShape(Rectangle())
+        } primaryAction: {
+            activePhotoID = photo.id
+        }
+        .accessibilityLabel("Photo \(index + 1) of \(selectedPhotos.count)\(index == 0 ? ", cover photo" : "")")
+        .accessibilityHint("Double tap to select. Actions include editing and reordering.")
+        .draggable(photo.id.uuidString) {
+            Image(uiImage: photo.image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 80, height: 80)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .onAppear {
+                    draggedPhotoID = photo.id
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
+        }
+        .dropDestination(for: String.self) { items, _ in
+            guard let raw = items.first,
+                  let sourceID = UUID(uuidString: raw),
+                  let source = selectedPhotos.firstIndex(where: { $0.id == sourceID }) else { return false }
+            move(sourceID, to: index)
+            draggedPhotoID = nil
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            return source != index
+        } isTargeted: { _ in }
+    }
+
+    @ViewBuilder
+    private var photoActionMenu: some View {
+        Button("Edit Photo") { openEditor() }
+        if activePhotoIndex != 0 {
+            Button("Make Cover") { makeActivePhotoCover() }
+        }
+        Button("Replace Photo") { prepareReplacement() }
+        Button("Delete Photo", role: .destructive) { requestDelete() }
+    }
+
+    private var coverBadge: some View {
+        Label("Cover", systemImage: "star.fill")
+            .font(.caption.weight(.bold))
+            .foregroundStyle(Constants.Colors.buttonText)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 6)
+            .background(Constants.Colors.primary)
+            .clipShape(Capsule())
+    }
+
+    private func secondaryCameraButton(title: String) -> some View {
+        Button(action: openCameraIfPermitted) {
+            Label(title, systemImage: "camera")
+                .font(FontManager.primaryText())
+                .foregroundStyle(Constants.Colors.primary)
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .background(.white)
+                .overlay(RoundedRectangle(cornerRadius: 16).stroke(Constants.Colors.primary))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(SpotPressedButtonStyle())
+        .disabled(selectedPhotos.count >= maxPhotoCount || showCamera)
+        .accessibilityLabel(title)
+    }
+}
+
+private extension PhotoSelectionView {
+    var maxPhotoCount: Int {
+        authVM.isPro ? Constants.PostLimits.maxProPostImages : Constants.PostLimits.maxFreePostImages
+    }
+
+    var remainingCapacityText: String {
+        let remaining = max(0, maxPhotoCount - selectedPhotos.count)
+        return remaining == 1 ? "You can add 1 more photo." : "You can add \(remaining) more photos."
+    }
+
+    var galleryPickerMaxSelectionCount: Int {
+        switch galleryPickMode {
+        case .add: max(1, maxPhotoCount - selectedPhotos.count)
+        case .replace: 1
+        }
+    }
+
+    var activePhotoIndex: Int {
+        guard let activePhotoID,
+              let index = selectedPhotos.firstIndex(where: { $0.id == activePhotoID }) else { return 0 }
+        return index
+    }
+
+    var activePhoto: PostComposerPhoto? {
+        guard selectedPhotos.indices.contains(activePhotoIndex) else { return nil }
+        return selectedPhotos[activePhotoIndex]
+    }
+
+    var activePreviewHeight: CGFloat {
+        guard let activePhoto else { return 300 }
+        let ratio = activePhoto.image.size.width / max(activePhoto.image.size.height, 1)
+        return min(390, max(230, (UIScreen.main.bounds.width - 48) / ratio))
+    }
+
+    var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: {
+                if !$0 {
+                    errorMessage = nil
+                    retryGalleryMode = nil
+                }
+            }
+        )
+    }
+
+    func repairActiveSelection() {
+        guard !selectedPhotos.isEmpty else {
+            activePhotoID = nil
+            return
+        }
+        if activePhotoID == nil || !selectedPhotos.contains(where: { $0.id == activePhotoID }) {
+            activePhotoID = selectedPhotos.first?.id
+        }
+    }
+
+    func beginPickerPresentation(mode: GalleryPickMode) {
+        guard !isOpeningPicker else { return }
+        isOpeningPicker = true
+        galleryPickMode = mode
+        galleryPickerItems = []
+        AnalyticsService.shared.logEvent("spot_photo_picker_opened", parameters: [
+            "mode": mode == .add ? "add" : "replace",
+            "remaining": max(0, maxPhotoCount - selectedPhotos.count)
+        ])
+        showGalleryPicker = true
+    }
+
+    func openGalleryAddIfPermitted() {
+        guard selectedPhotos.count < maxPhotoCount else {
+            errorMessage = "You can add up to \(maxPhotoCount) photos."
+            return
+        }
+        guard !isOpeningPicker, !isImporting else { return }
+        permissionManager.updatePermissionStatuses()
+        switch permissionManager.photoStatus {
+        case .authorized, .limited:
+            beginPickerPresentation(mode: .add)
+        case .notDetermined:
+            galleryPickMode = .add
+            showPhotoLibraryPrePrompt = true
+        case .denied, .restricted:
+            showPhotoSettingsAlert = true
+            AnalyticsService.shared.logEvent("spot_photo_permission_denied", parameters: [:])
+        @unknown default:
+            showPhotoSettingsAlert = true
+        }
+    }
+
+    func openGalleryReplaceIfPermitted() {
+        guard let activePhotoID, !isOpeningPicker, !isImporting else { return }
+        permissionManager.updatePermissionStatuses()
+        switch permissionManager.photoStatus {
+        case .authorized, .limited:
+            beginPickerPresentation(mode: .replace(activePhotoID))
+        case .notDetermined:
+            galleryPickMode = .replace(activePhotoID)
+            showPhotoLibraryPrePrompt = true
+        case .denied, .restricted:
+            showPhotoSettingsAlert = true
+        @unknown default:
+            showPhotoSettingsAlert = true
+        }
+    }
+
+    func finishPhotoPermissionPrompt() {
+        permissionManager.updatePermissionStatuses()
+        showPhotoLibraryPrePrompt = false
+        let status = permissionManager.photoStatus
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(350))
+            switch status {
+            case .authorized, .limited:
+                beginPickerPresentation(mode: galleryPickMode)
+            case .denied, .restricted:
+                showPhotoSettingsAlert = true
+            default:
+                isOpeningPicker = false
+            }
+        }
+    }
+
+    func importPickerItems(_ items: [PhotosPickerItem], mode: GalleryPickMode) async {
+        isImporting = true
+        importCount = items.count
+        defer {
+            isImporting = false
+            importCount = 0
+            isOpeningPicker = false
+            galleryPickerItems = []
+        }
+
+        var imported: [PostComposerPhoto] = []
+        for item in items {
+            do {
+                if item.supportedContentTypes.contains(where: { $0.conforms(to: .movie) }) &&
+                    !item.supportedContentTypes.contains(where: { $0.conforms(to: .image) }) {
+                    throw PostPhotoImportError.video
+                }
+                guard let data = try await item.loadTransferable(type: Data.self) else {
+                    throw PostPhotoImportError.unreadable
+                }
+                imported.append(try PostPhotoProcessor.importImage(data: data, source: .gallery))
+            } catch {
+                SpotLogger.log(PhotoSelectionViewLogs.loadPhotosFailed, details: [
+                    "action": mode == .add ? "add" : "replace",
+                    "permission": String(describing: permissionManager.photoStatus),
+                    "platform": UIDevice.current.systemVersion,
+                    "error": error.localizedDescription
+                ])
+                errorMessage = (error as? LocalizedError)?.errorDescription ??
+                    "We couldn’t open your photo library. Please try again."
+                retryGalleryMode = mode
+            }
+        }
+
+        guard !imported.isEmpty else {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            AnalyticsService.shared.logEvent("spot_photo_picker_failed", parameters: ["category": "import"])
+            return
+        }
+        switch mode {
+        case .add:
+            let available = max(0, maxPhotoCount - selectedPhotos.count)
+            let accepted = Array(imported.prefix(available))
+            selectedPhotos.append(contentsOf: accepted)
+            activePhotoID = accepted.first?.id
+            if imported.count > available {
+                errorMessage = "You can add up to \(maxPhotoCount) photos."
+                AnalyticsService.shared.logEvent("spot_photo_max_reached", parameters: [:])
+            }
+            if !authVM.isPro, items.count > 1 {
+                onFreeTierGalleryOverflow?()
+            }
+            AnalyticsService.shared.logEvent("spot_photos_added", parameters: [
+                "count": accepted.count,
+                "source": "gallery"
+            ])
+        case let .replace(photoID):
+            guard let replacement = imported.first,
+                  let index = selectedPhotos.firstIndex(where: { $0.id == photoID }) else { return }
+            selectedPhotos[index] = PostComposerPhoto(
+                id: photoID,
+                image: replacement.image,
+                originalImage: replacement.originalImage,
+                source: .gallery
+            )
+            activePhotoID = photoID
+            AnalyticsService.shared.logEvent("spot_photo_replaced", parameters: [:])
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        SpotLogger.log(PhotoSelectionViewLogs.photosSelectedFromGallery, details: ["count": imported.count])
+    }
+
+    func openCameraIfPermitted() {
+        guard selectedPhotos.count < maxPhotoCount else {
+            errorMessage = "You can add up to \(maxPhotoCount) photos."
+            return
+        }
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            errorMessage = "The camera isn’t available on this device."
+            retryGalleryMode = nil
+            return
+        }
+        permissionManager.updatePermissionStatuses()
+        switch permissionManager.cameraStatus {
+        case .authorized:
+            showCamera = true
+            AnalyticsService.shared.logEvent("spot_camera_opened", parameters: [:])
+        case .notDetermined:
+            showCameraPrePrompt = true
+        case .denied, .restricted:
+            showCameraSettingsAlert = true
+            AnalyticsService.shared.logEvent("spot_photo_permission_denied", parameters: ["type": "camera"])
+        @unknown default:
+            showCameraSettingsAlert = true
+        }
+    }
+
+    func finishCameraPermissionPrompt() {
+        permissionManager.updatePermissionStatuses()
+        showCameraPrePrompt = false
+        let status = permissionManager.cameraStatus
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(350))
+            if status == .authorized {
+                showCamera = true
+            } else if status == .denied || status == .restricted {
+                showCameraSettingsAlert = true
+            }
+        }
+    }
+
+    func handleCameraResult(_ result: Result<UIImage, Error>?) {
+        guard let result else {
+            AnalyticsService.shared.logEvent("spot_camera_cancelled", parameters: [:])
+            return
+        }
+        do {
+            let photo = try PostPhotoProcessor.importCameraImage(result.get())
+            guard selectedPhotos.count < maxPhotoCount else { return }
+            selectedPhotos.append(photo)
+            activePhotoID = photo.id
+            SpotLogger.log(PhotoSelectionViewLogs.photoCapturedWithCamera)
+            AnalyticsService.shared.logEvent("spot_photo_captured", parameters: [:])
+        } catch {
+            SpotLogger.log(PhotoSelectionViewLogs.capturePhotoFailed, details: ["error": error.localizedDescription])
+            errorMessage = "We couldn’t prepare this photo."
+        }
+    }
+
+    func openEditor() {
+        guard let activePhoto else { return }
+        guard activePhoto.processingState != .unavailable else {
+            errorMessage = "This photo is no longer available on this device."
+            retryGalleryMode = nil
+            return
+        }
+        editorPhoto = activePhoto
+        AnalyticsService.shared.logEvent("spot_photo_edit_opened", parameters: [:])
+    }
+
+    func saveEdits(_ edits: PostComposerPhotoEdits, for photoID: UUID) {
+        guard let index = selectedPhotos.firstIndex(where: { $0.id == photoID }) else { return }
+        let original = selectedPhotos[index].originalImage
+        let revision = UUID()
+        selectedPhotos[index].edits = edits
+        selectedPhotos[index].processingState = .processing
+        selectedPhotos[index].processingError = nil
+        selectedPhotos[index].renderRevision = revision
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                Result { try PostPhotoProcessor.render(original: original, edits: edits) }
+            }.value
+            guard let currentIndex = selectedPhotos.firstIndex(where: { $0.id == photoID }),
+                  selectedPhotos[currentIndex].renderRevision == revision else { return }
+            switch result {
+            case let .success(image):
+                selectedPhotos[currentIndex].image = image
+                selectedPhotos[currentIndex].processingState = .ready
+            case let .failure(error):
+                selectedPhotos[currentIndex].processingState = .failed
+                selectedPhotos[currentIndex].processingError = error.localizedDescription
+                errorMessage = "We couldn’t prepare this photo."
+                AnalyticsService.shared.logEvent("spot_photo_processing_failed", parameters: [:])
+            }
+        }
+    }
+
+    func prepareReplacement() {
+        guard let activePhoto else { return }
+        if activePhoto.edits.isNeutral {
+            openGalleryReplaceIfPermitted()
+        } else {
+            showReplaceWarning = true
+        }
+    }
+
+    func requestDelete() {
+        if selectedPhotos.count == 1 {
+            showDeleteConfirmation = true
+        } else {
+            removeActivePhoto()
+        }
+    }
+
+    func removeActivePhoto() {
+        guard selectedPhotos.indices.contains(activePhotoIndex) else { return }
+        let index = activePhotoIndex
+        let photo = selectedPhotos.remove(at: index)
+        activePhotoID = selectedPhotos.isEmpty ? nil : selectedPhotos[min(index, selectedPhotos.count - 1)].id
+        removedPhoto = RemovedPhoto(photo: photo, index: index)
+        AnalyticsService.shared.logEvent("spot_photo_removed", parameters: ["wasCover": index == 0])
+        undoTask?.cancel()
+        undoTask = Task {
+            try? await Task.sleep(for: .seconds(4))
+            guard !Task.isCancelled else { return }
+            withAnimation(reduceMotion ? nil : .easeOut) { removedPhoto = nil }
+        }
+    }
+
+    func undoRemoval(_ removal: RemovedPhoto) {
+        undoTask?.cancel()
+        let index = min(removal.index, selectedPhotos.count)
+        selectedPhotos.insert(removal.photo, at: index)
+        activePhotoID = removal.photo.id
+        removedPhoto = nil
+    }
+
+    func makeActivePhotoCover() {
+        guard let activePhotoID else { return }
+        makeCover(activePhotoID)
+    }
+
+    func makeCover(_ id: UUID) {
+        selectedPhotos = PostComposerPhotoOperations.makingCover(selectedPhotos, id: id)
+        activePhotoID = id
+        AnalyticsService.shared.logEvent("spot_photo_made_cover", parameters: [:])
+    }
+
+    func move(_ id: UUID, by offset: Int) {
+        guard let source = selectedPhotos.firstIndex(where: { $0.id == id }) else { return }
+        move(id, to: min(max(0, source + offset), selectedPhotos.count - 1))
+    }
+
+    func move(_ id: UUID, to destination: Int) {
+        guard let source = selectedPhotos.firstIndex(where: { $0.id == id }) else { return }
+        selectedPhotos = PostComposerPhotoOperations.reordered(selectedPhotos, from: source, to: destination)
+        activePhotoID = id
+        AnalyticsService.shared.logEvent("spot_photo_reordered", parameters: [
+            "from": source,
+            "to": destination
+        ])
+    }
+}
+
+private struct SpotPressedButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .opacity(configuration.isPressed ? 0.82 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+struct SpotPhotoCameraView: UIViewControllerRepresentable {
+    let onComplete: (Result<UIImage, Error>?) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(onComplete: onComplete) }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = .camera
+        picker.mediaTypes = [UTType.image.identifier]
+        picker.cameraCaptureMode = .photo
+        picker.allowsEditing = false
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onComplete: (Result<UIImage, Error>?) -> Void
+
+        init(onComplete: @escaping (Result<UIImage, Error>?) -> Void) {
+            self.onComplete = onComplete
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            guard (info[.mediaType] as? String).map({ UTType($0)?.conforms(to: .image) == true }) ?? true,
+                  let image = info[.originalImage] as? UIImage else {
+                onComplete(.failure(PostPhotoImportError.video))
+                return
+            }
+            onComplete(.success(image))
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            SpotLogger.log(PhotoSelectionViewLogs.cameraCancelled)
+            onComplete(nil)
         }
     }
 }
@@ -366,225 +927,15 @@ private struct PhotoSelectionPreviewHost: View {
     }
 
     var body: some View {
-        PhotoSelectionView(selectedPhotos: $photos, draftCount: 2, onOpenDrafts: {}, onFreeTierGalleryOverflow: nil)
-            .environmentObject(authVM)
-            .environmentObject(PermissionManager.shared)
-    }
-}
-
-private extension PhotoSelectionView {
-    var galleryPickerMaxSelectionCount: Int {
-        switch galleryPickMode {
-        case .add:
-            return max(1, maxPhotoCount - selectedPhotos.count)
-        case .replace:
-            return 1
-        }
-    }
-
-    /// **Choose from Gallery** — show `PhotoPermissionView` when status is
-    /// still `.notDetermined`, then the system picker.
-    func openGalleryAddIfPermitted() {
-        guard selectedPhotos.count < maxPhotoCount else { return }
-        permissionManager.updatePermissionStatuses()
-        if photoSelectionDisabled {
-            showPhotoSettingsAlert = true
-            return
-        }
-        switch permissionManager.photoStatus {
-        case .authorized, .limited:
-            galleryPickMode = .add
-            showGalleryPicker = true
-        case .notDetermined:
-            galleryPickMode = .add
-            showPhotoLibraryPrePrompt = true
-        case .denied, .restricted:
-            showPhotoSettingsAlert = true
-        @unknown default:
-            showPhotoSettingsAlert = true
-        }
-    }
-
-    /// **Replace** — same contextual gate as add.
-    func openGalleryReplaceIfPermitted() {
-        guard !selectedPhotos.isEmpty else { return }
-        permissionManager.updatePermissionStatuses()
-        if photoSelectionDisabled {
-            showPhotoSettingsAlert = true
-            return
-        }
-        switch permissionManager.photoStatus {
-        case .authorized, .limited:
-            galleryPickMode = .replace
-            showGalleryPicker = true
-        case .notDetermined:
-            galleryPickMode = .replace
-            showPhotoLibraryPrePrompt = true
-        case .denied, .restricted:
-            showPhotoSettingsAlert = true
-        @unknown default:
-            showPhotoSettingsAlert = true
-        }
-    }
-
-    func finishPhotoLibraryPrePromptAndOpenPickerIfAllowed() {
-        showPhotoLibraryPrePrompt = false
-        permissionManager.updatePermissionStatuses()
-        switch permissionManager.photoStatus {
-        case .authorized, .limited:
-            showGalleryPicker = true
-        case .denied, .restricted:
-            showPhotoSettingsAlert = true
-        default:
-            break
-        }
-    }
-
-    /// Stable-height carousel matching feed clamps; cover = first photo.
-    func postingPreviewCarouselHeight(width: CGFloat) -> CGFloat {
-        guard let cover = selectedPhotos.first else {
-            return SpotMediaAspectRatio.mediaHeight(
-                containerWidth: width,
-                displayRatio: SpotMediaAspectRatio.fallbackRatio,
-                minHeight: SpotMediaPresentationContext.postingPreview.minMediaHeight,
-                maxHeight: SpotMediaPresentationContext.postingPreview.maxMediaHeight
+        ScrollView {
+            PhotoSelectionView(
+                selectedPhotos: $photos,
+                draftCount: 2,
+                onOpenDrafts: {}
             )
         }
-        let pxW = Int(cover.image.size.width * cover.image.scale)
-        let pxH = Int(cover.image.size.height * cover.image.scale)
-        let ratio = SpotMediaAspectRatio.display(width: pxW, height: pxH)
-        return SpotMediaAspectRatio.mediaHeight(
-            containerWidth: width,
-            displayRatio: ratio,
-            minHeight: SpotMediaPresentationContext.postingPreview.minMediaHeight,
-            maxHeight: SpotMediaPresentationContext.postingPreview.maxMediaHeight
-        )
-    }
-
-    var maxPhotoCount: Int { authVM.isPro ? 5 : 1 }
-
-    var photoSelectionDisabled: Bool {
-        permissionManager.photoStatus == .denied || permissionManager.photoStatus == .restricted
-    }
-
-    func moveImage(from: Int, to: Int) {
-        guard from != to, from >= 0, to >= 0, from < selectedPhotos.count, to < selectedPhotos.count else { return }
-        let slot = selectedPhotos.remove(at: from)
-        selectedPhotos.insert(slot, at: to)
-        if selectedPhotoIndex == from {
-            selectedPhotoIndex = to
-        } else if from < selectedPhotoIndex && to >= selectedPhotoIndex {
-            selectedPhotoIndex -= 1
-        } else if from > selectedPhotoIndex && to <= selectedPhotoIndex {
-            selectedPhotoIndex += 1
-        }
-    }
-
-    func deleteSelectedImage() {
-        guard selectedPhotoIndex >= 0, selectedPhotoIndex < selectedPhotos.count else { return }
-        selectedPhotos.remove(at: selectedPhotoIndex)
-        selectedPhotoIndex = max(0, min(selectedPhotoIndex, selectedPhotos.count - 1))
-    }
-
-    /// User tapped Take a Photo. On the first tap (when camera authorization
-    /// is `.notDetermined`) we present the contextual `CameraPermissionView`
-    /// pre-prompt — the native iOS dialog only fires after the user taps
-    /// Continue inside that screen. This matches Apple App Review's request
-    /// for a contextual, in-app explanation before the system prompt is
-    /// shown, and leaves the rest of the composer fully usable if the user
-    /// dismisses the pre-prompt without making a decision.
-    func openCameraIfPermitted() {
-        permissionManager.updatePermissionStatuses()
-        switch permissionManager.cameraStatus {
-        case .authorized:
-            showCamera = true
-        case .notDetermined:
-            showCameraPrePrompt = true
-        case .denied, .restricted:
-            showCameraSettingsAlert = true
-        @unknown default:
-            showCameraSettingsAlert = true
-        }
-    }
-}
-
-private func downsampledPostImage(from data: Data, maxPixelSize: CGFloat) -> UIImage? {
-    let sourceOptions: CFDictionary = [kCGImageSourceShouldCache: false] as CFDictionary
-    guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else { return nil }
-    let options: CFDictionary = [
-        kCGImageSourceCreateThumbnailFromImageAlways: true,
-        kCGImageSourceCreateThumbnailWithTransform: true,
-        kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
-    ] as CFDictionary
-    guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else { return nil }
-    return UIImage(cgImage: cgImage)
-}
-
-private func resizedPostImage(_ image: UIImage, maxPixelSize: CGFloat) -> UIImage? {
-    let width = image.size.width
-    let height = image.size.height
-    let longestEdge = max(width, height)
-    guard longestEdge > maxPixelSize else { return image }
-    let ratio = maxPixelSize / longestEdge
-    let target = CGSize(width: floor(width * ratio), height: floor(height * ratio))
-    let format = UIGraphicsImageRendererFormat.default()
-    format.scale = 1
-    format.opaque = true
-    let renderer = UIGraphicsImageRenderer(size: target, format: format)
-    return renderer.image { _ in
-        image.draw(in: CGRect(origin: .zero, size: target))
-    }
-}
-
-// MARK: - Camera View
-struct CameraView: UIViewControllerRepresentable {
-    @Binding var selectedPhotos: [PostComposerPhoto]
-    let maxCount: Int
-    @Environment(\.dismiss) var dismiss
-
-    func makeUIViewController(context: Context) -> UIImagePickerController {
-        let picker = UIImagePickerController()
-        picker.delegate = context.coordinator
-        picker.sourceType = .camera
-        return picker
-    }
-
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
-
-    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-        let parent: CameraView
-
-        init(_ parent: CameraView) {
-            self.parent = parent
-        }
-
-        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-            if let image = info[.originalImage] as? UIImage {
-                SpotLogger.log(PhotoSelectionViewLogs.photoCapturedWithCamera)
-                let normalized = resizedPostImage(image, maxPixelSize: postImageMaxPixelSize) ?? image
-                let photo = PostComposerPhoto(image: normalized)
-                var imgs = parent.selectedPhotos
-                if parent.maxCount <= 1 {
-                    imgs = [photo]
-                } else if imgs.count < parent.maxCount {
-                    imgs.append(photo)
-                } else {
-                    imgs[parent.maxCount - 1] = photo
-                }
-                parent.selectedPhotos = imgs
-            } else {
-                SpotLogger.log(PhotoSelectionViewLogs.capturePhotoFailed)
-            }
-            parent.dismiss()
-        }
-
-        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-            SpotLogger.log(PhotoSelectionViewLogs.cameraCancelled)
-            parent.dismiss()
-        }
+        .background(Constants.Colors.background)
+        .environmentObject(authVM)
+        .environmentObject(PermissionManager.shared)
     }
 }

--- a/Spot/Views/PostFlow/SpotPhotoEditorView.swift
+++ b/Spot/Views/PostFlow/SpotPhotoEditorView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+import UIKit
+
+struct SpotPhotoEditorView: View {
+    enum Tool: String, CaseIterable, Identifiable {
+        case crop = "Crop"
+        case rotate = "Rotate"
+        case adjust = "Adjust"
+        var id: Self { self }
+    }
+
+    private struct CropOption: Identifiable {
+        let title: String
+        let ratio: CGFloat?
+        var id: String { title }
+    }
+
+    let photo: PostComposerPhoto
+    let onSave: (PostComposerPhotoEdits) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var edits: PostComposerPhotoEdits
+    @State private var preview: UIImage
+    @State private var selectedTool: Tool = .crop
+    @State private var renderTask: Task<Void, Never>?
+    @State private var showResetConfirmation = false
+    @State private var cropGestureStart: PostComposerPhotoCrop?
+    @State private var canvasSize: CGSize = CGSize(width: 400, height: 400)
+
+    private let cropOptions = [
+        CropOption(title: "Free", ratio: nil),
+        CropOption(title: "Original", ratio: 0),
+        CropOption(title: "1:1", ratio: 1),
+        CropOption(title: "4:5", ratio: 4 / 5),
+        CropOption(title: "5:4", ratio: 5 / 4),
+        CropOption(title: "3:4", ratio: 3 / 4),
+        CropOption(title: "4:3", ratio: 4 / 3),
+        CropOption(title: "16:9", ratio: 16 / 9),
+        CropOption(title: "9:16", ratio: 9 / 16)
+    ]
+
+    init(photo: PostComposerPhoto, onSave: @escaping (PostComposerPhotoEdits) -> Void) {
+        self.photo = photo
+        self.onSave = onSave
+        _edits = State(initialValue: photo.edits)
+        _preview = State(initialValue: photo.image)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ZStack {
+                    Color.black.opacity(0.92)
+                    Image(uiImage: preview)
+                        .resizable()
+                        .scaledToFit()
+                        .background {
+                            GeometryReader { proxy in
+                                Color.clear
+                                    .onAppear { canvasSize = proxy.size }
+                                    .onChange(of: proxy.size) { _, size in canvasSize = size }
+                            }
+                        }
+                        .gesture(cropGesture)
+                        .accessibilityLabel("Photo editing preview")
+                    if selectedTool == .crop ||
+                        (selectedTool == .rotate && abs(edits.straightenDegrees) > 0.01) {
+                        PhotoEditorGrid()
+                            .padding(28)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                VStack(spacing: 14) {
+                    Picker("Editing tool", selection: $selectedTool) {
+                        ForEach(Tool.allCases) { tool in
+                            Label(tool.rawValue, systemImage: icon(for: tool)).tag(tool)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    toolControls
+                        .frame(minHeight: 132, alignment: .top)
+                }
+                .padding(16)
+                .background(Constants.Colors.background)
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        AnalyticsService.shared.logEvent("spot_photo_edit_cancelled", parameters: [:])
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .principal) {
+                    Text("Edit Photo")
+                        .font(FontManager.sectionHeader())
+                        .foregroundStyle(Constants.Colors.primary)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        var normalized = edits
+                        normalized.normalize()
+                        onSave(normalized)
+                        AnalyticsService.shared.logEvent("spot_photo_edit_saved", parameters: [
+                            "hasCrop": normalized.crop != .fullImage,
+                            "hasOrientation": normalized.rotationQuarterTurns != 0 ||
+                                normalized.straightenDegrees != 0 ||
+                                normalized.flipHorizontal ||
+                                normalized.flipVertical,
+                            "hasAdjustments": !normalized.adjustments.isNeutral
+                        ])
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+            .tint(Constants.Colors.primary)
+            .safeAreaInset(edge: .bottom) {
+                Button("Reset") {
+                    if edits.isNeutral {
+                        edits = .neutral
+                        schedulePreviewRender()
+                    } else {
+                        showResetConfirmation = true
+                    }
+                }
+                .font(FontManager.primaryText())
+                .foregroundStyle(Constants.Colors.primary)
+                .frame(minHeight: 44)
+                .accessibilityLabel("Reset photo edits")
+                .padding(.bottom, 4)
+            }
+            .alert("Reset all edits to this photo?", isPresented: $showResetConfirmation) {
+                Button("Keep Editing", role: .cancel) {}
+                Button("Reset", role: .destructive) {
+                    edits = .neutral
+                    schedulePreviewRender()
+                }
+            }
+            .onDisappear { renderTask?.cancel() }
+        }
+    }
+
+    @ViewBuilder
+    private var toolControls: some View {
+        switch selectedTool {
+        case .crop:
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(cropOptions) { option in
+                        Button(option.title) {
+                            applyCrop(option)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(edits.crop.aspectRatio == option.title ? Constants.Colors.primary : .gray)
+                        .frame(minHeight: 44)
+                    }
+                }
+            }
+            Text("Choose an aspect ratio. Free keeps the current crop.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    editorIconButton("Move crop left", icon: "arrow.left") { adjustCrop(dx: -0.03) }
+                    editorIconButton("Move crop right", icon: "arrow.right") { adjustCrop(dx: 0.03) }
+                    editorIconButton("Move crop up", icon: "arrow.up") { adjustCrop(dy: -0.03) }
+                    editorIconButton("Move crop down", icon: "arrow.down") { adjustCrop(dy: 0.03) }
+                    editorIconButton("Zoom crop in", icon: "plus.magnifyingglass") { adjustCrop(scale: 0.9) }
+                    editorIconButton("Zoom crop out", icon: "minus.magnifyingglass") { adjustCrop(scale: 1.1) }
+                }
+            }
+        case .rotate:
+            HStack(spacing: 12) {
+                editorIconButton("Rotate photo counterclockwise", icon: "rotate.left") {
+                    edits.rotationQuarterTurns -= 1
+                    schedulePreviewRender()
+                }
+                editorIconButton("Rotate photo clockwise", icon: "rotate.right") {
+                    edits.rotationQuarterTurns += 1
+                    schedulePreviewRender()
+                }
+                editorIconButton("Flip photo horizontally", icon: "arrow.left.and.right.righttriangle.left.righttriangle.right") {
+                    edits.flipHorizontal.toggle()
+                    schedulePreviewRender()
+                }
+                editorIconButton("Flip photo vertically", icon: "arrow.up.and.down.righttriangle.up.righttriangle.down") {
+                    edits.flipVertical.toggle()
+                    schedulePreviewRender()
+                }
+            }
+            labeledSlider(
+                title: "Straighten",
+                value: $edits.straightenDegrees,
+                range: -15...15,
+                valueText: "\(Int(edits.straightenDegrees.rounded()))°"
+            )
+        case .adjust:
+            ScrollView {
+                VStack(spacing: 12) {
+                    labeledSlider(title: "Brightness", value: $edits.adjustments.brightness, range: -1...1)
+                    labeledSlider(title: "Contrast", value: $edits.adjustments.contrast, range: -1...1)
+                    labeledSlider(title: "Saturation", value: $edits.adjustments.saturation, range: -1...1)
+                    labeledSlider(title: "Warmth", value: $edits.adjustments.warmth, range: -1...1)
+                }
+            }
+        }
+    }
+
+    private func icon(for tool: Tool) -> String {
+        switch tool {
+        case .crop: "crop"
+        case .rotate: "rotate.right"
+        case .adjust: "slider.horizontal.3"
+        }
+    }
+
+    private func editorIconButton(
+        _ label: String,
+        icon: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .frame(width: 46, height: 44)
+                .background(Constants.Colors.primary.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: Constants.Layout.CornerRadius.small))
+        }
+        .accessibilityLabel(label)
+    }
+
+    private func labeledSlider(
+        title: String,
+        value: Binding<Double>,
+        range: ClosedRange<Double>,
+        valueText: String? = nil
+    ) -> some View {
+        VStack(spacing: 2) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text(valueText ?? String(format: "%.2f", value.wrappedValue))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                if abs(value.wrappedValue) > 0.001 {
+                    Button {
+                        value.wrappedValue = 0
+                        schedulePreviewRender()
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                            .frame(width: 32, height: 32)
+                    }
+                    .accessibilityLabel("Reset \(title)")
+                }
+            }
+            .font(.caption)
+            Slider(
+                value: Binding(
+                    get: { value.wrappedValue },
+                    set: {
+                        value.wrappedValue = $0
+                        schedulePreviewRender()
+                    }
+                ),
+                in: range
+            )
+            .tint(Constants.Colors.primary)
+            .accessibilityLabel(title)
+        }
+    }
+
+    private func applyCrop(_ option: CropOption) {
+        guard let ratio = option.ratio else {
+            edits.crop.aspectRatio = option.title
+            schedulePreviewRender()
+            return
+        }
+        let sourceRatio = transformedSourceRatio
+        let targetRatio = ratio == 0 ? sourceRatio : ratio
+        if targetRatio > sourceRatio {
+            let height = sourceRatio / targetRatio
+            edits.crop = PostComposerPhotoCrop(
+                normalizedX: 0,
+                normalizedY: (1 - height) / 2,
+                normalizedWidth: 1,
+                normalizedHeight: height,
+                aspectRatio: option.title
+            )
+        } else {
+            let width = targetRatio / sourceRatio
+            edits.crop = PostComposerPhotoCrop(
+                normalizedX: (1 - width) / 2,
+                normalizedY: 0,
+                normalizedWidth: width,
+                normalizedHeight: 1,
+                aspectRatio: option.title
+            )
+        }
+        schedulePreviewRender()
+    }
+
+    private var transformedSourceRatio: CGFloat {
+        let width = photo.originalImage.size.width
+        let height = photo.originalImage.size.height
+        let radians = CGFloat(edits.rotationQuarterTurns) * (.pi / 2) +
+            CGFloat(edits.straightenDegrees) * (.pi / 180)
+        let transformedWidth = abs(width * cos(radians)) + abs(height * sin(radians))
+        let transformedHeight = abs(width * sin(radians)) + abs(height * cos(radians))
+        return transformedWidth / max(transformedHeight, 1)
+    }
+
+    private func adjustCrop(dx: CGFloat = 0, dy: CGFloat = 0, scale: CGFloat = 1) {
+        let centerX = edits.crop.normalizedX + edits.crop.normalizedWidth / 2 + dx
+        let centerY = edits.crop.normalizedY + edits.crop.normalizedHeight / 2 + dy
+        edits.crop.normalizedWidth *= scale
+        edits.crop.normalizedHeight *= scale
+        edits.crop.normalizedX = centerX - edits.crop.normalizedWidth / 2
+        edits.crop.normalizedY = centerY - edits.crop.normalizedHeight / 2
+        edits.crop.aspectRatio = "Free"
+        edits.normalize()
+        schedulePreviewRender()
+    }
+
+    private var cropGesture: some Gesture {
+        SimultaneousGesture(
+            DragGesture()
+                .onChanged { value in
+                    guard selectedTool == .crop else { return }
+                    let start = cropGestureStart ?? edits.crop
+                    if cropGestureStart == nil { cropGestureStart = start }
+                    edits.crop.normalizedX = start.normalizedX -
+                        value.translation.width / max(1, canvasSize.width) * start.normalizedWidth
+                    edits.crop.normalizedY = start.normalizedY -
+                        value.translation.height / max(1, canvasSize.height) * start.normalizedHeight
+                    edits.crop.aspectRatio = "Free"
+                    edits.normalize()
+                    schedulePreviewRender()
+                }
+                .onEnded { _ in cropGestureStart = nil },
+            MagnificationGesture()
+                .onChanged { scale in
+                    guard selectedTool == .crop else { return }
+                    let start = cropGestureStart ?? edits.crop
+                    if cropGestureStart == nil { cropGestureStart = start }
+                    let width = start.normalizedWidth / scale
+                    let height = start.normalizedHeight / scale
+                    let centerX = start.normalizedX + start.normalizedWidth / 2
+                    let centerY = start.normalizedY + start.normalizedHeight / 2
+                    edits.crop.normalizedWidth = width
+                    edits.crop.normalizedHeight = height
+                    edits.crop.normalizedX = centerX - width / 2
+                    edits.crop.normalizedY = centerY - height / 2
+                    edits.crop.aspectRatio = "Free"
+                    edits.normalize()
+                    schedulePreviewRender()
+                }
+                .onEnded { _ in cropGestureStart = nil }
+        )
+    }
+
+    private func schedulePreviewRender() {
+        renderTask?.cancel()
+        let original = photo.originalImage
+        let editsSnapshot = edits
+        renderTask = Task {
+            try? await Task.sleep(for: .milliseconds(80))
+            guard !Task.isCancelled else { return }
+            let rendered = await Task.detached(priority: .userInitiated) {
+                try? PostPhotoProcessor.render(original: original, edits: editsSnapshot)
+            }.value
+            guard !Task.isCancelled, let rendered else { return }
+            preview = rendered
+        }
+    }
+}
+
+private struct PhotoEditorGrid: View {
+    var body: some View {
+        GeometryReader { geometry in
+            Path { path in
+                for fraction in [CGFloat(1.0 / 3.0), CGFloat(2.0 / 3.0)] {
+                    path.move(to: CGPoint(x: geometry.size.width * fraction, y: 0))
+                    path.addLine(to: CGPoint(x: geometry.size.width * fraction, y: geometry.size.height))
+                    path.move(to: CGPoint(x: 0, y: geometry.size.height * fraction))
+                    path.addLine(to: CGPoint(x: geometry.size.width, y: geometry.size.height * fraction))
+                }
+                path.addRect(CGRect(origin: .zero, size: geometry.size))
+            }
+            .stroke(.white.opacity(0.75), lineWidth: 1)
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/SpotTests/PostComposerPhotoTests.swift
+++ b/SpotTests/PostComposerPhotoTests.swift
@@ -1,0 +1,173 @@
+import Testing
+import UIKit
+@testable import Spot
+
+struct PostComposerPhotoTests {
+    @Test func reorderingPreservesStableIdentityAndMakesCover() {
+        let first = PostComposerPhoto(image: testImage(.red))
+        let second = PostComposerPhoto(image: testImage(.green))
+        let third = PostComposerPhoto(image: testImage(.blue))
+
+        let reordered = PostComposerPhotoOperations.reordered(
+            [first, second, third],
+            from: 2,
+            to: 0
+        )
+
+        #expect(reordered.map(\.id) == [third.id, first.id, second.id])
+        #expect(PostComposerPhotoOperations.makingCover(reordered, id: second.id).first?.id == second.id)
+    }
+
+    @Test func invalidReorderLeavesPhotosUnchanged() {
+        let photos = [
+            PostComposerPhoto(image: testImage(.red)),
+            PostComposerPhoto(image: testImage(.blue))
+        ]
+
+        #expect(PostComposerPhotoOperations.reordered(photos, from: -1, to: 0).map(\.id) == photos.map(\.id))
+        #expect(PostComposerPhotoOperations.reordered(photos, from: 0, to: 8).map(\.id) == photos.map(\.id))
+    }
+
+    @Test func editNormalizationClampsAllValues() {
+        var edits = PostComposerPhotoEdits(
+            rotationQuarterTurns: -5,
+            straightenDegrees: 99,
+            flipHorizontal: true,
+            flipVertical: false,
+            crop: PostComposerPhotoCrop(
+                normalizedX: -1,
+                normalizedY: 2,
+                normalizedWidth: 4,
+                normalizedHeight: -2,
+                aspectRatio: "1:1"
+            ),
+            adjustments: PostComposerPhotoAdjustments(
+                brightness: 4,
+                contrast: -4,
+                saturation: 2,
+                warmth: -2
+            )
+        )
+
+        edits.normalize()
+
+        #expect(edits.rotationQuarterTurns == 3)
+        #expect(edits.straightenDegrees == 15)
+        #expect(edits.crop.normalizedX == 0)
+        #expect(edits.crop.normalizedY == 0.99)
+        #expect(edits.crop.normalizedWidth == 1)
+        #expect(abs(edits.crop.normalizedHeight - 0.01) < 0.0001)
+        #expect(edits.adjustments.brightness == 1)
+        #expect(edits.adjustments.contrast == -1)
+        #expect(edits.adjustments.saturation == 1)
+        #expect(edits.adjustments.warmth == -1)
+    }
+
+    @Test func resetEditsRestoresNeutralState() {
+        var photo = PostComposerPhoto(image: testImage(.red))
+        photo.edits.rotationQuarterTurns = 1
+        photo.edits.adjustments.brightness = 0.5
+        #expect(!photo.edits.isNeutral)
+
+        photo.edits = .neutral
+
+        #expect(photo.edits.isNeutral)
+        #expect(photo.edits.crop == .fullImage)
+    }
+
+    @Test func processorRejectsNonImageAndNormalizesCameraOrientation() throws {
+        #expect(throws: PostPhotoImportError.self) {
+            _ = try PostPhotoProcessor.importImage(
+                data: Data("not an image".utf8),
+                source: .gallery
+            )
+        }
+
+        let source = testImage(.red, size: CGSize(width: 1_000, height: 500))
+        let imported = try PostPhotoProcessor.importCameraImage(source)
+        #expect(imported.image.imageOrientation == .up)
+        #expect(imported.source == .camera)
+        #expect(imported.pixelWidth == 1_000)
+        #expect(imported.pixelHeight == 500)
+    }
+
+    @Test func processingAppliesRotationCropAndAdjustments() throws {
+        let source = testImage(.orange, size: CGSize(width: 400, height: 200))
+        var edits = PostComposerPhotoEdits.neutral
+        edits.rotationQuarterTurns = 1
+        edits.crop = PostComposerPhotoCrop(
+            normalizedX: 0,
+            normalizedY: 0.25,
+            normalizedWidth: 1,
+            normalizedHeight: 0.5,
+            aspectRatio: "1:1"
+        )
+        edits.adjustments.contrast = 0.2
+
+        let rendered = try PostPhotoProcessor.render(original: source, edits: edits)
+
+        #expect(rendered.imageOrientation == .up)
+        #expect(rendered.size.width > 0)
+        #expect(rendered.size.height > 0)
+        #expect(rendered !== source)
+    }
+
+    @Test func legacyDraftDecodesWithoutPhotoMetadata() throws {
+        let json = """
+        {
+          "id": "legacy",
+          "step": 1,
+          "status": "autosaved",
+          "vibeTags": [],
+          "isCustomName": false,
+          "imageFileNames": ["draft_legacy_image_0.jpg"],
+          "updatedAt": 0
+        }
+        """
+
+        let draft = try JSONDecoder().decode(PostComposerDraft.self, from: Data(json.utf8))
+
+        #expect(draft.id == "legacy")
+        #expect(draft.schemaVersion == nil)
+        #expect(draft.photoRecords == nil)
+        #expect(draft.imageFileNames == ["draft_legacy_image_0.jpg"])
+    }
+
+    @Test func draftPhotoMetadataRoundTripsStableIdentityAndEdits() throws {
+        var edits = PostComposerPhotoEdits.neutral
+        edits.rotationQuarterTurns = 3
+        edits.flipHorizontal = true
+        edits.adjustments.warmth = 0.4
+        let record = PostComposerDraftPhoto(
+            id: UUID(),
+            originalFileName: "original.jpg",
+            previewFileName: "preview.jpg",
+            source: .camera,
+            edits: edits,
+            processingState: .ready,
+            processingError: nil,
+            createdAt: Date(timeIntervalSinceReferenceDate: 1_000)
+        )
+
+        let decoded = try JSONDecoder().decode(
+            PostComposerDraftPhoto.self,
+            from: JSONEncoder().encode(record)
+        )
+
+        #expect(decoded == record)
+        #expect(decoded.edits.rotationQuarterTurns == 3)
+        #expect(decoded.source == .camera)
+    }
+
+    private func testImage(
+        _ color: UIColor,
+        size: CGSize = CGSize(width: 40, height: 30)
+    ) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/docs/product/posting-flow.md
+++ b/docs/product/posting-flow.md
@@ -20,7 +20,9 @@ User opens **Post** tab → multi-step composer (`Spot/Views/PostFlow`) → sele
 
 ### Media
 
-Photos are chosen from the library or camera per system permissions (`Constants.UserDefaultsKeys` track permission prompts).
+Photos are chosen from an image-only multi-select library picker or the still-image camera. The first ordered photo is the cover. The photo workspace supports previewing, adding, replacing, removing, accessible reordering, and making any photo the cover.
+
+Each photo has a stable ID and non-destructive edit instructions. Crop, quarter-turn rotation, straightening, horizontal/vertical flip, brightness, contrast, saturation, and warmth are rendered from an orientation-normalized original. The original is retained until publication so edits can be reset or changed without repeatedly recompressing an earlier render. Picker filtering, client decoding, JPEG upload encoding, storage MIME restrictions, and moderation provide layered video exclusion.
 
 Free accounts can publish one photo and one vibe tag. Pro accounts can publish up to five photos and five vibe tags. The publish RPC independently enforces entitlement limits.
 
@@ -34,7 +36,7 @@ User picks from known tags and adds caption/details as the UI allows.
 
 ### Draft behavior
 
-`PostDraftStore` persists drafts locally under Application Support, including a reserved `autosave` draft and user-saved drafts. Draft metadata is indexed locally; no server draft table is involved.
+`PostDraftStore` persists drafts locally under Application Support, including a reserved `autosave` draft and user-saved drafts. Draft schema version 2 stores each photo's stable ID, durable original and rendered preview, source, ordered position, non-destructive edit instructions, and processing state. Version 1 drafts are migrated lazily when loaded: their known file order is retained, stable IDs are generated, and neutral edits are supplied. A missing version-2 photo file restores as an unavailable item that can be replaced or removed instead of crashing. Draft metadata is indexed locally; no server draft table is involved.
 
 Submission persists a snapshot before JPEG encoding and queueing. The composer resets as soon as `SpotPublishCoordinator` accepts the job, allowing the user to leave the Post tab while the global publish banner reports progress.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- Fixes the intermittent gallery presentation race by waiting for the permission pre-prompt sheet to dismiss before presenting the image-only `PhotosPicker`, guarding duplicate launches, and surfacing import errors with retry.
- Replaces the arrow-based layout with an active preview, cover badge, sortable 80pt thumbnail tray, add-photo source sheet, direct thumbnail selection, drag/drop ordering, and accessible move/make-cover actions.
- Adds image-only multi-selection and append/replace behavior while preserving the existing entitlement limits: one photo for free accounts and five for Pro accounts.
- Adds a strongly typed stable-ID photo model and non-destructive edit state for crop presets/free crop, clockwise/counterclockwise rotation, ±15° straightening, horizontal/vertical flip, brightness, contrast, saturation, warmth, reset, and cancel/done semantics.
- Normalizes EXIF orientation through ImageIO on gallery import and normalizes camera images before all previews, draft renders, and JPEG upload preparation.
- Adds draft schema v2 with stable IDs, ordered original/preview records, edit instructions, source and processing state. Legacy image arrays migrate lazily with neutral edits; missing files restore as blocked replace/remove items.
- Prevents video entry through `.images` picker filtering, explicit still-camera media types/mode, returned-content UTType checks, ImageIO decoding, and the existing JPEG-only upload/storage/moderation path.
- Makes draft writes transactional at the file-set level so a failed replacement save retains the prior valid draft.
- Adds focused tests for stable reordering/cover behavior, edit normalization/reset, image rejection, orientation import, rendering, legacy draft decoding, and metadata round trips.
- Updates posting-flow documentation.

Original gallery failure: the permission pre-prompt dismissal and `PhotosPicker` presentation were triggered in the same SwiftUI update cycle; picker/asset failures were also logged without user-visible recovery.

No dependency was added.

Known limitations:
- This Linux cloud environment does not include Xcode, Swift, an iOS Simulator, or physical iOS devices, so Apple-platform build/tests and manual device checks were not run here.
- The project is iOS-only; Android testing is not applicable.
- Imported reversible working originals are orientation-normalized and bounded to the existing 1600px composer pipeline rather than retaining a separate full-resolution library asset.

## Testing
- `git diff --check` — passed.
- Static Swift 5 / iOS 17 API review — no definite compile blockers found.
- `xcodebuild -scheme SpotTests test` — not run (`xcodebuild` is unavailable on this Linux runner).
- Manual iPhone, limited-library, denied-camera, HEIC, panorama, and unusual-EXIF checks — not run; required before merge.

## Checklist

### Code Quality & Testing (Required)
- [x] Added unit tests for new model and processing logic
- [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`) — Xcode unavailable in runner
- [x] No intentional breaking public API changes
- [ ] Confirmed no new warnings introduced — requires Xcode build
- [x] Code follows existing patterns and style

### Documentation (Required)
- [x] Updated docs
- [x] Updated relevant product docs
- [x] Updated architecture/data behavior documentation in posting-flow docs
- [x] Existing posting-flow diagram remains accurate at its current abstraction

### Data plane
- [x] No Firebase data plane changes
- [x] Posting continues through `SpotPublishCoordinator` / `SpotSupabaseRepository`
- [x] No schema/RLS changes required
- [ ] `DataPlaneGuardTests` pass — Xcode unavailable in runner
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd46a-f2a1-7252-8e45-5df48dabadfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd46a-f2a1-7252-8e45-5df48dabadfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

