### PR TITLE
Fix misleading PR coverage reporting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Checklist
 
 ### Code Quality & Testing (Required)
-- [ ] Added Unit Tests For New Code (80% minimum coverage on changed files)
+- [ ] Added unit tests for new logic (CI enforces 80% of changed executable lines in non-view production files once the 10-line floor is met)
 - [ ] All tests pass locally (`xcodebuild -scheme SpotTests test`)
 - [ ] No breaking API changes (or documented if intentional)
 - [ ] Confirmed no new warnings introduced
@@ -33,7 +33,7 @@ See [docs/engineering/data-plane.md](docs/engineering/data-plane.md).
 
 The following checks run automatically on every PR:
 
-✅ **Code Coverage**: Enforces 80% minimum coverage on all changed production files  
+✅ **Code Coverage**: Enforces 80% minimum coverage on changed executable lines in non-view production files
 ✅ **API Stability**: Detects potential breaking changes to public APIs  
 ✅ **Documentation**: Validates documentation updates for significant changes  
 ✅ **Unit Tests**: All tests must pass before merge

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,6 +43,12 @@ The workflow uses three validation scripts in `scripts/`:
    - Fails PR if coverage threshold not met
    - Shows detailed per-file coverage breakdown
 
+The PR comment also includes an informational unit-test scope percentage from
+`scripts/summarize-xccov.py`. It includes non-view `Spot.app` production files
+only; package dependencies, test targets, and SwiftUI views are excluded. This
+avoids presenting the root `xccov` aggregate—which includes linked packages—as
+if it represented the app's test coverage.
+
 **Test output:**
 - Test results are formatted with `xcbeautify` for readable output
 - Test results (`.xcresult` bundles) are uploaded as artifacts for 7 days

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,18 +93,24 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             test | xcbeautify
       
-      - name: Extract overall coverage
+      - name: Extract unit-test scope coverage
         id: coverage
         if: always()
         run: |
           if [ -d "TestResults.xcresult" ]; then
-            PCT=$(xcrun xccov view --report --json TestResults.xcresult | jq -r '.lineCoverage')
-            PCT_HUMAN=$(awk -v p="$PCT" 'BEGIN { printf "%.1f", (p * 100) }')
-            echo "Overall project line coverage: ${PCT_HUMAN}%"
-            echo "percent=${PCT_HUMAN}" >> "$GITHUB_OUTPUT"
-          else
-            echo "percent=unknown" >> "$GITHUB_OUTPUT"
+            if xcrun xccov view --report --json TestResults.xcresult > coverage-report.json &&
+              SUMMARY=$(python3 scripts/summarize-xccov.py coverage-report.json); then
+              PERCENT=$(jq -r '.percent' <<< "$SUMMARY")
+              COVERED=$(jq -r '.coveredLines' <<< "$SUMMARY")
+              EXECUTABLE=$(jq -r '.executableLines' <<< "$SUMMARY")
+              echo "Spot unit-test scope coverage: ${PERCENT}% (${COVERED}/${EXECUTABLE} lines)"
+              echo "percent=${PERCENT}" >> "$GITHUB_OUTPUT"
+              echo "covered=${COVERED}" >> "$GITHUB_OUTPUT"
+              echo "executable=${EXECUTABLE}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
+          echo "percent=unknown" >> "$GITHUB_OUTPUT"
       
       - name: Validate Code Coverage
         id: coverage_validation
@@ -130,6 +136,8 @@ jobs:
         with:
           name: coverage-reports
           path: |
+            coverage-report.json
+            coverage-report.txt
             ~/Library/Developer/Xcode/DerivedData/**/ProfileData
           retention-days: 7
       
@@ -140,8 +148,14 @@ jobs:
             echo "## Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Extract overall coverage
-            xcrun xccov view --report TestResults.xcresult | head -20 >> $GITHUB_STEP_SUMMARY || echo "Coverage data not available" >> $GITHUB_STEP_SUMMARY
+            PERCENT="${{ steps.coverage.outputs.percent }}"
+            if [ -n "$PERCENT" ] && [ "$PERCENT" != "unknown" ]; then
+              echo "**Spot unit-test scope:** ${PERCENT}% (${{ steps.coverage.outputs.covered }}/${{ steps.coverage.outputs.executable }} executable lines)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "This informational metric includes non-view production Swift files in Spot.app. Package dependencies, tests, and SwiftUI views are excluded." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Coverage data not available" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
       
       - name: Comment PR with results
@@ -153,7 +167,7 @@ jobs:
             
             const testsOutcome = '${{ steps.tests.outcome }}';
             const coverageOutcome = '${{ steps.coverage_validation.outcome }}';
-            const overallCoverage = '${{ steps.coverage.outputs.percent }}';
+            const unitScopeCoverage = '${{ steps.coverage.outputs.percent }}';
             
             const icon = (outcome) => outcome === 'success'
               ? '✅'
@@ -164,12 +178,13 @@ jobs:
             comment += `### Tests: ${icon(testsOutcome)}\n\n`;
             
             comment += '### Coverage\n';
-            if (overallCoverage && overallCoverage !== 'unknown' && overallCoverage !== '') {
-              comment += `**Overall project line coverage: ${overallCoverage}%**\n\n`;
+            if (unitScopeCoverage && unitScopeCoverage !== 'unknown' && unitScopeCoverage !== '') {
+              comment += `**Spot unit-test scope coverage (informational): ${unitScopeCoverage}%**\n\n`;
             } else {
-              comment += 'Overall coverage data was not available for this run.\n\n';
+              comment += 'Unit-test scope coverage data was not available for this run.\n\n';
             }
-            comment += `**Changed-files coverage check (80% minimum): ${icon(coverageOutcome)}**\n\n`;
+            comment += 'This metric excludes package dependencies, test targets, and `Spot/Views/`; those previously made the project aggregate misleading.\n\n';
+            comment += `**Changed-line coverage gate (80% minimum): ${icon(coverageOutcome)}**\n\n`;
             
             // Include the per-changed-file coverage breakdown when available.
             try {

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -248,6 +248,14 @@ CI collects code coverage data on every run and **enforces coverage requirements
 
 The gate measures **changed-line coverage**, not whole-file coverage. The question it asks is "are the lines this PR wrote tested?" rather than "is this entire file well tested?". Whole-file thresholds punish any edit to a legacy low-coverage file — a four-line threading fix in a 341-line Supabase repository would have required retro-covering the whole repository to land, which pushes people toward not touching those files at all.
 
+CI also reports an informational **Spot unit-test scope** metric. It is a
+line-weighted summary of non-view production Swift files in the `Spot.app`
+target. The summary intentionally excludes package dependencies, test targets,
+and `Spot/Views/`, so it describes the code the unit-test job can meaningfully
+exercise. Do not use the root `xccov` `lineCoverage` value: that aggregate mixes
+Spot code with linked Firebase, Supabase, and transitive package targets and
+therefore produces a misleadingly low percentage.
+
 **Coverage Requirements:**
 - **80% of the executable lines a PR adds or modifies** must be covered
 - Applies to files under `Spot/`, excluding tests and `Spot/Views/`
@@ -283,7 +291,8 @@ xcrun simctl delete "$SIM"
 
 **Coverage reports:**
 - Uploaded as artifacts (retained for 7 days)
-- Summary posted to PR as comment
+- Unit-test scope summary and changed-line gate result posted to the PR
+- Raw `xccov` JSON and changed-line details included in the coverage artifact
 - Full report available in GitHub Actions logs
 
 **Exemptions:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,14 +21,26 @@ Enforces minimum code coverage requirements on changed files in pull requests.
 **What it does:**
 - Extracts coverage data using `xcrun xccov`
 - Identifies changed Swift files via `git diff`
-- Calculates line coverage for each changed file
-- Fails if any file is below the threshold
+- Calculates coverage for changed executable lines in non-view `Spot/` files
+- Fails if an enforced file is below the threshold (files enter enforcement at 10 changed executable lines)
 - Provides detailed per-file coverage breakdown
 
 **Requirements:**
 - `jq` for JSON parsing
 - `git` for diff comparison
 - `xcrun` with xccov
+
+### `summarize-xccov.py`
+
+Calculates the informational unit-test scope metric shown in CI. It selects the
+`Spot.app` target and computes weighted line coverage for non-view production
+Swift files. Package dependencies, test targets, and `Spot/Views/` are excluded
+because they are outside the unit-test coverage boundary.
+
+```bash
+xcrun xccov view --report --json TestResults.xcresult > coverage-report.json
+python3 scripts/summarize-xccov.py coverage-report.json
+```
 
 **Example:**
 ```bash

--- a/scripts/summarize-xccov.py
+++ b/scripts/summarize-xccov.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Summarize xccov data for Spot's unit-test coverage boundary."""
+
+import json
+import sys
+from pathlib import PurePosixPath
+
+
+APP_TARGET_NAMES = ("Spot.app", "Spot")
+
+
+def is_unit_test_scope(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    try:
+        spot_index = parts.index("Spot")
+    except ValueError:
+        return False
+
+    relative_parts = parts[spot_index + 1 :]
+    return (
+        bool(relative_parts)
+        and relative_parts[0] != "Views"
+        and "SpotTests" not in parts
+        and "SpotUITests" not in parts
+    )
+
+
+def summarize(report: dict) -> dict:
+    targets = report.get("targets", [])
+    target = next(
+        (
+            candidate
+            for name in APP_TARGET_NAMES
+            for candidate in targets
+            if candidate.get("name") == name
+        ),
+        None,
+    )
+    if target is None:
+        raise ValueError(
+            f"Spot app target not found (expected one of: {', '.join(APP_TARGET_NAMES)})"
+        )
+
+    covered_lines = 0
+    executable_lines = 0
+    file_count = 0
+
+    for file_report in target.get("files", []):
+        if not is_unit_test_scope(file_report.get("path", "")):
+            continue
+
+        executable = int(file_report.get("executableLines", 0))
+        covered = int(file_report.get("coveredLines", 0))
+        if executable <= 0:
+            continue
+
+        executable_lines += executable
+        covered_lines += covered
+        file_count += 1
+
+    if executable_lines == 0:
+        raise ValueError("Spot app target has no executable lines in the unit-test scope")
+
+    return {
+        "percent": round(covered_lines * 100 / executable_lines, 1),
+        "coveredLines": covered_lines,
+        "executableLines": executable_lines,
+        "fileCount": file_count,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <xccov-report.json>", file=sys.stderr)
+        return 2
+
+    try:
+        with open(sys.argv[1], encoding="utf-8") as report_file:
+            summary = summarize(json.load(report_file))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as error:
+        print(f"Unable to summarize coverage: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_summarize_xccov.py
+++ b/scripts/tests/test_summarize_xccov.py
@@ -1,0 +1,113 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "summarize-xccov.py"
+SPEC = importlib.util.spec_from_file_location("summarize_xccov", SCRIPT_PATH)
+summarize_xccov = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(summarize_xccov)
+
+
+class SummarizeXccovTests(unittest.TestCase):
+    def test_summarizes_only_non_view_files_in_app_target(self):
+        report = {
+            "targets": [
+                {
+                    "name": "FirebaseAuth",
+                    "files": [
+                        {
+                            "path": "/SourcePackages/Firebase/Auth.swift",
+                            "coveredLines": 0,
+                            "executableLines": 1000,
+                        }
+                    ],
+                },
+                {
+                    "name": "Spot.app",
+                    "files": [
+                        {
+                            "path": "/runner/repo/Spot/Services/AuthService.swift",
+                            "coveredLines": 75,
+                            "executableLines": 100,
+                        },
+                        {
+                            "path": "/runner/repo/Spot/Models/User.swift",
+                            "coveredLines": 15,
+                            "executableLines": 20,
+                        },
+                        {
+                            "path": "/runner/repo/Spot/Views/Home/HomeView.swift",
+                            "coveredLines": 0,
+                            "executableLines": 300,
+                        },
+                    ],
+                },
+                {
+                    "name": "SpotTests.xctest",
+                    "files": [
+                        {
+                            "path": "/runner/repo/SpotTests/AuthServiceTests.swift",
+                            "coveredLines": 50,
+                            "executableLines": 50,
+                        }
+                    ],
+                },
+            ]
+        }
+
+        self.assertEqual(
+            summarize_xccov.summarize(report),
+            {
+                "percent": 75.0,
+                "coveredLines": 90,
+                "executableLines": 120,
+                "fileCount": 2,
+            },
+        )
+
+    def test_accepts_target_name_without_app_suffix(self):
+        report = {
+            "targets": [
+                {
+                    "name": "Spot",
+                    "files": [
+                        {
+                            "path": "Spot/Utils/Validator.swift",
+                            "coveredLines": 2,
+                            "executableLines": 3,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        self.assertEqual(summarize_xccov.summarize(report)["percent"], 66.7)
+
+    def test_rejects_report_without_spot_app_target(self):
+        with self.assertRaisesRegex(ValueError, "Spot app target not found"):
+            summarize_xccov.summarize({"targets": [{"name": "SpotTests.xctest"}]})
+
+    def test_rejects_empty_unit_test_scope(self):
+        report = {
+            "targets": [
+                {
+                    "name": "Spot.app",
+                    "files": [
+                        {
+                            "path": "/runner/repo/Spot/Views/HomeView.swift",
+                            "coveredLines": 1,
+                            "executableLines": 1,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(ValueError, "no executable lines"):
+            summarize_xccov.summarize(report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- replace the root `xccov` aggregate with a Spot unit-test-scope metric that excludes package dependencies, test targets, and SwiftUI views
- keep the existing 80% changed-line gate as the enforced PR check and clarify its labels
- add a tested coverage-summary parser and align CI/coverage documentation

## Testing
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 7 passed
- `python3 -m py_compile scripts/summarize-xccov.py scripts/tests/test_summarize_xccov.py`
- PR CI / PR Validation — passed with 658 tests; corrected metric reports 28.7% (4,475/15,566 lines)

## Checklist
- [x] Added unit tests for new coverage parsing logic
- [x] All relevant tests pass
- [x] No breaking API changes
- [x] Documentation updated
- [x] No data-plane changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd487-1d64-796e-9993-cc3261b282e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd487-1d64-796e-9993-cc3261b282e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

