### PR TITLE
Fix DEBUG device log file writing while Xcode is attached

### DIFF
--- a/Spot/Utils/LoggingConfig.swift
+++ b/Spot/Utils/LoggingConfig.swift
@@ -15,6 +15,7 @@ enum LoggingConfig {
 
         #if DEBUG
         applyFromUserDefaults()
+        SpotLogger.ensureDebugLogFile()
         #else
         SpotLogger.setProfile(.errorsOnly)
         #endif

--- a/Spot/Utils/SpotLogger.swift
+++ b/Spot/Utils/SpotLogger.swift
@@ -1,8 +1,5 @@
 import Foundation
 import os
-#if DEBUG
-import Darwin
-#endif
 
 // MARK: - Structured log definitions
 
@@ -265,20 +262,20 @@ final class SpotLogger {
 }
 
 #if DEBUG
-private enum DebuggerDetector {
-    static var isAttached: Bool {
-        var processInfo = kinfo_proc()
-        var size = MemoryLayout<kinfo_proc>.stride
-        var name = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
-        let nameCount = name.count
-        let result = name.withUnsafeMutableBufferPointer {
-            sysctl($0.baseAddress, u_int(nameCount), &processInfo, &size, nil, 0)
-        }
-        return result == 0 && (processInfo.kp_proc.p_flag & P_TRACED) != 0
+extension SpotLogger {
+    /// Ensures `Documents/spot-debug.txt` exists with a session marker so Files
+    /// shows the Spot folder even before the first structured log.
+    static func ensureDebugLogFile() {
+        DebugFileLogWriter.shared.ensureSessionHeader()
+    }
+
+    /// Documents path for the active DEBUG log file (nil if unavailable).
+    static var debugLogFileURL: URL? {
+        DebugFileLogWriter.shared.fileURL
     }
 }
 
-/// Writes DEBUG logs only when the process is not attached to Xcode.
+/// Appends DEBUG logs to Documents/spot-debug.txt for Files and Finder.
 private final class DebugFileLogWriter {
     static let shared = DebugFileLogWriter()
 
@@ -291,10 +288,21 @@ private final class DebugFileLogWriter {
 
     private init() {}
 
+    var fileURL: URL? {
+        currentFileURL()
+    }
+
     func write(_ message: String) {
-        guard !DebuggerDetector.isAttached else { return }
         queue.async {
             self.append(message)
+        }
+    }
+
+    func ensureSessionHeader() {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        // Sync so configure() leaves a visible file before the first emit.
+        queue.sync {
+            self.append("--- Spot DEBUG session \(timestamp) ---")
         }
     }
 

--- a/Spot/Views/Profile/LoggingSettingsDetailView.swift
+++ b/Spot/Views/Profile/LoggingSettingsDetailView.swift
@@ -45,7 +45,7 @@ struct LoggingSettingsDetailView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             sectionHeader("Device log file")
                             Text(
-                                "When a DEBUG build runs without Xcode attached, logs appear in Files → On My iPhone → Spot → spot-debug.txt. They are also available through Finder when the phone is connected to a Mac. Files rotate at 1 MB and retain three archives."
+                                "In a DEBUG build, logs appear in Files → On My iPhone → Spot → spot-debug.txt (including while Xcode is attached). They are also available through Finder when the phone is connected to a Mac. Files rotate at 1 MB and retain three archives."
                             )
                             .font(.system(size: 12))
                             .foregroundColor(.gray)

--- a/SpotTests/SpotLoggerTests.swift
+++ b/SpotTests/SpotLoggerTests.swift
@@ -145,4 +145,17 @@ struct SpotLoggerTests {
         #expect(!SpotLogger.shouldEmit(level: .error, tag: "AuthService", file: serviceFile, profile: .uiOnly))
         #expect(SpotLogger.shouldEmit(level: .debug, tag: "LocationManager", file: serviceFile, profile: .all))
     }
+
+    #if DEBUG
+    @Test func debugLogFileIsSeededWithSessionHeader() throws {
+        SpotLogger.ensureDebugLogFile()
+
+        let url = try #require(SpotLogger.debugLogFileURL)
+        #expect(url.lastPathComponent == "spot-debug.txt")
+        #expect(FileManager.default.fileExists(atPath: url.path))
+
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("--- Spot DEBUG session "))
+    }
+    #endif
 }

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -70,15 +70,16 @@ Non-DEBUG builds always use profile 0 regardless of saved DEBUG settings.
 
 ## Device file
 
-In a DEBUG build without an attached debugger, emitted logs are also appended to:
+In a DEBUG build, emitted logs are also appended to:
 
 ```text
 Documents/spot-debug.txt
 ```
 
-The file is protected until first device unlock, rotates at 1 MB, and retains
-three archives. File writing is compiled out of release builds. When Xcode is
-attached, the file sink stays off and logs go only to Apple Unified Logging.
+`LoggingConfig.configure()` seeds the file with a session header so Files shows
+the Spot folder even before the first structured log. The file is protected
+until first device unlock, rotates at 1 MB, and retains three archives. File
+writing is compiled out of release builds.
 
 The Debug target’s `UIFileSharingEnabled` and
 `LSSupportsOpeningDocumentsInPlace` build settings expose the Documents


### PR DESCRIPTION
## Summary
- DEBUG builds always append structured logs to `Documents/spot-debug.txt`, including when Xcode is attached (the previous debugger skip left Documents empty).
- Seed a session header on `LoggingConfig.configure()` so Files → On My iPhone → Spot appears immediately.
- Update Settings/docs copy and add a unit test for the seeded log file.

## Test plan
- [ ] Install a Debug build on device (Run from Xcode is fine)
- [ ] Open the app, then check Files → On My iPhone → Spot → `spot-debug.txt` contains a session header and subsequent logs
- [ ] Confirm Finder file sharing still shows the same Documents file when the phone is connected
- [ ] Confirm `SpotLoggerTests` (including `debugLogFileIsSeededWithSessionHeader`) pass


Made with [Cursor](https://cursor.com)