### PR TITLE
Add GitHub branch rulesets for main and release/*

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,56 @@
+# Repository rulesets
+
+GitHub rulesets for `main` and `release/*` enforce:
+
+- **No direct pushes** — changes must land via pull request (`pull_request` rule).
+- **Required CI** — the `PR Validation` check from `.github/workflows/ci.yml` must pass.
+- **No force-push** — `non_fast_forward` blocks history rewrites.
+- **`main` only: merge queue** — use **Merge when ready** so merges go through the queue (see manual step below).
+
+## Files
+
+| File | Branches | Notes |
+|------|----------|-------|
+| `main.json` | `main` | Includes merge-queue config (may require a UI step; see below). |
+| `release-branches.json` | `release/*` | PR + CI only (merge queue is not supported on wildcard refs). |
+
+## Apply / update
+
+From repo root (requires `gh` authenticated as a repo admin):
+
+```bash
+./scripts/apply-github-rulesets.sh
+```
+
+The script creates or updates rulesets by name. If GitHub rejects `merge_queue` or `bypass_actors` via API, it retries without those fields and prints what to finish in the UI.
+
+## One-time UI steps (if API apply skips them)
+
+### 1. Enable merge queue on `main`
+
+GitHub may reject the `merge_queue` rule via REST on some accounts. If **Merge when ready** is not available after applying:
+
+1. Open [Repository rules](https://github.com/Ewynman/spot-ios-app/settings/rules).
+2. Edit **Protect main (merge queue + CI)**.
+3. Add rule **Require merge queue** with:
+   - Require all queue entries to pass required checks: **on**
+   - Status check timeout: **90** minutes
+   - Merge method: **Merge commit** (matches current repo practice)
+4. Save.
+
+`ci.yml` already listens for `merge_group` so queue checks run once this is enabled.
+
+### 2. Allow deploy workflows to push build numbers
+
+`deploy.yml` and `testflight.yml` push automated build-number commits to protected branches. Add a bypass so `GITHUB_TOKEN` is not blocked:
+
+1. Edit each ruleset (**main** and **release branches**).
+2. **Bypass list → Add bypass → GitHub Actions**.
+3. Mode: **Always**.
+4. Save.
+
+Without this bypass, Firebase/TestFlight deploys fail when pushing `[skip ci]` build bumps.
+
+## Current live rulesets
+
+After apply, confirm at: https://github.com/Ewynman/spot-ios-app/settings/rules

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,56 @@
+{
+  "name": "Protect main (merge queue + CI)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 15368,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "PR Validation"
+          }
+        ]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 90,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "max_entries_to_merge": 5,
+        "merge_method": "MERGE",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/.github/rulesets/release-branches.json
+++ b/.github/rulesets/release-branches.json
@@ -1,0 +1,44 @@
+{
+  "name": "Protect release branches (CI)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/release/*"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 15368,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "PR Validation"
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,9 @@ This directory contains GitHub Actions workflows for the Spot iOS app.
 ### `ci.yml` - Continuous Integration
 
 **Triggers:**
-- Pull requests to `main`
+- Pull requests to `main` and `release/**`
 - Pushes to `main` (except `[skip ci]` commits)
+- Merge queue groups on `main` (`merge_group`, when merge queue is enabled)
 
 **What it does:**
 - Runs comprehensive PR validation including:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+  merge_group:
 
 # Required so the "Comment PR with results" step can post/update PR comments.
 # Without pull-requests: write the github-script call fails with
@@ -22,6 +24,7 @@ jobs:
     # Skip automated bump commits pushed by deploy.yml ([skip ci]).
     if: |
       github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
       (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]'))
 
     steps:
@@ -66,13 +69,13 @@ jobs:
             -showdestinations
       
       - name: Validate API Changes
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: |
           echo "Checking for breaking API changes..."
           ./scripts/validate-api-changes.sh origin/${{ github.base_ref }}
       
       - name: Validate Documentation
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: |
           echo "Validating documentation updates..."
           ./scripts/validate-documentation.sh origin/${{ github.base_ref }}
@@ -114,7 +117,7 @@ jobs:
       
       - name: Validate Code Coverage
         id: coverage_validation
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: |
           set -o pipefail
           echo "Validating coverage of the lines changed by this PR..."

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -475,5 +475,6 @@ If the team decides to re-enable Xcode Cloud in the future:
 - ~~Firebase build automation on merge to main~~ _(completed: deploy.yml)_
 - ~~Build number automation and release notes generation~~ _(completed: deploy.yml)_
 - Add SwiftLint or SwiftFormat for code style consistency (on roadmap)
-- Configure required status checks in GitHub branch protection (should be enabled for production)
 - Add the App Store Connect API secrets (`APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8_BASE64`) so the TestFlight upload step in `testflight.yml` can complete
+
+Branch protection is configured via GitHub repository rulesets (see [.github/rulesets/README.md](../../.github/rulesets/README.md)).

--- a/scripts/apply-github-rulesets.sh
+++ b/scripts/apply-github-rulesets.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Apply repository rulesets from .github/rulesets/*.json via the GitHub REST API.
+#
+# Requires: gh CLI authenticated with repo admin access.
+# Usage: ./scripts/apply-github-rulesets.sh
+#
+# Idempotent: updates an existing ruleset when the name matches, otherwise creates it.
+# Retries without merge_queue / bypass_actors when the API rejects those fields.
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-Ewynman/spot-ios-app}"
+RULESET_DIR="$(cd "$(dirname "$0")/.." && pwd)/.github/rulesets"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required" >&2
+  exit 1
+fi
+
+ruleset_id_for_name() {
+  local name="$1"
+  gh api "repos/${REPO}/rulesets" --paginate --jq ".[] | select(.name == \"${name}\") | .id"
+}
+
+apply_payload() {
+  local name="$1"
+  local payload="$2"
+  local id
+
+  id="$(ruleset_id_for_name "$name" || true)"
+  if [[ -n "$id" ]]; then
+    echo "$payload" | gh api "repos/${REPO}/rulesets/${id}" --method PUT --input -
+  else
+    echo "$payload" | gh api "repos/${REPO}/rulesets" --method POST --input -
+  fi
+}
+
+should_retry_without_extras() {
+  local err="$1"
+  [[ "$err" == *"merge_queue"* || "$err" == *"bypass_actors"* || "$err" == *"GitHub Actions integration"* ]]
+}
+
+apply_ruleset() {
+  local file="$1"
+  local name payload fallback err status
+
+  name="$(jq -r '.name' "$file")"
+  payload="$(cat "$file")"
+  echo "Applying ruleset: ${name}"
+
+  set +e
+  err="$(apply_payload "$name" "$payload" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "  applied"
+    return 0
+  fi
+
+  if ! should_retry_without_extras "$err"; then
+    echo "error: failed to apply ${file}" >&2
+    echo "$err" >&2
+    return 1
+  fi
+
+  echo "  API rejected merge_queue and/or bypass_actors; retrying with core rules only."
+  echo "  Finish merge queue + GitHub Actions bypass in the UI — see .github/rulesets/README.md"
+
+  fallback="$(jq 'del(.bypass_actors) | .rules = [.rules[] | select(.type != "merge_queue")]' "$file")"
+  apply_payload "$name" "$fallback" >/dev/null
+  echo "  applied core rules"
+}
+
+for file in "${RULESET_DIR}"/*.json; do
+  [[ -f "$file" ]] || continue
+  apply_ruleset "$file"
+done
+
+echo "Done. Review rulesets at: https://github.com/${REPO}/settings/rules"


### PR DESCRIPTION
## Summary
- Adds version-controlled GitHub rulesets for `main` and `release/*` that require pull requests, passing `PR Validation` CI, and block force-pushes.
- Adds `scripts/apply-github-rulesets.sh` to create or update rulesets from `.github/rulesets/*.json`.
- Updates `ci.yml` to run on `release/**` PRs and `merge_group` (for merge queue / Merge when ready).

## Notes
Rulesets are already live on the repo (applied via API). Two items still need a one-time UI step — see `.github/rulesets/README.md`:
1. **Require merge queue** on `main` (Merge when ready) — GitHub API rejected this field.
2. **GitHub Actions bypass** on both rulesets so `deploy.yml` / `testflight.yml` can push build-number commits.

## Test plan
- [ ] Confirm PR Validation runs on this PR
- [ ] After merge, verify direct push to `main` is rejected
- [ ] Complete merge queue + GitHub Actions bypass steps in repo Settings → Rules
- [ ] Run `./scripts/apply-github-rulesets.sh` locally to confirm idempotent apply


Made with [Cursor](https://cursor.com)