### PR TITLE
Fix Firebase deploy build-number allocation under branch rulesets

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -2,7 +2,7 @@
 
 GitHub rulesets for `main` and `release/*` enforce:
 
-- **No direct pushes** — changes must land via pull request (`pull_request` rule).
+- **No direct pushes for non-admins** — changes must land via pull request (`pull_request` rule).
 - **Required CI** — the `PR Validation` check from `.github/workflows/ci.yml` must pass.
 - **No force-push** — `non_fast_forward` blocks history rewrites.
 - **`main` only: merge queue** — use **Merge when ready** so merges go through the queue (see manual step below).
@@ -22,11 +22,21 @@ From repo root (requires `gh` authenticated as a repo admin):
 ./scripts/apply-github-rulesets.sh
 ```
 
-The script creates or updates rulesets by name. If GitHub rejects `merge_queue` or `bypass_actors` via API, it retries without those fields and prints what to finish in the UI.
+The script creates or updates rulesets by name. If GitHub rejects `merge_queue` via API, it retries without that field and prints what to finish in the UI.
+
+## Bypass actors (user-owned repository)
+
+This repository is owned by a **user account**, not an organization. GitHub rejects the **GitHub Actions** integration (`actor_id` 15368) as a ruleset bypass on user-owned repos:
+
+> Actor GitHub Actions integration must be part of the ruleset source or owner organization
+
+`bypass_actors` therefore uses **Repository role: Admin** (`actor_id` 5) so the owner can emergency-push if needed.
+
+Deploy workflows **must not** rely on `GITHUB_TOKEN` pushing bump commits to protected branches. Instead they allocate build numbers via the repository Actions variable `SPOT_IOS_BUILD_NUMBER` (`scripts/allocate-ci-build-number.sh`).
 
 ## One-time UI steps (if API apply skips them)
 
-### 1. Enable merge queue on `main`
+### Enable merge queue on `main`
 
 GitHub may reject the `merge_queue` rule via REST on some accounts. If **Merge when ready** is not available after applying:
 
@@ -39,17 +49,6 @@ GitHub may reject the `merge_queue` rule via REST on some accounts. If **Merge w
 4. Save.
 
 `ci.yml` already listens for `merge_group` so queue checks run once this is enabled.
-
-### 2. Allow deploy workflows to push build numbers
-
-`deploy.yml` and `testflight.yml` push automated build-number commits to protected branches. Add a bypass so `GITHUB_TOKEN` is not blocked:
-
-1. Edit each ruleset (**main** and **release branches**).
-2. **Bypass list → Add bypass → GitHub Actions**.
-3. Mode: **Always**.
-4. Save.
-
-Without this bypass, Firebase/TestFlight deploys fail when pushing `[skip ci]` build bumps.
 
 ## Current live rulesets
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -10,8 +10,8 @@
   },
   "bypass_actors": [
     {
-      "actor_id": 15368,
-      "actor_type": "Integration",
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
       "bypass_mode": "always"
     }
   ],

--- a/.github/rulesets/release-branches.json
+++ b/.github/rulesets/release-branches.json
@@ -10,8 +10,8 @@
   },
   "bypass_actors": [
     {
-      "actor_id": 15368,
-      "actor_type": "Integration",
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
       "bypass_mode": "always"
     }
   ],

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,8 +76,8 @@ Documentation and repository-maintenance-only pushes are ignored, so they do not
 This trigger does not depend on the separate CI workflow. Repository branch protection and merge policy are responsible for preventing unvalidated changes from reaching `main`.
 
 **What it does:**
-- Automatically increments build number in `CURRENT_PROJECT_VERSION` (build number `+1` only)
-- Pushes build number update to `main` before building (prevents duplicate Firebase build numbers)
+- Automatically allocates the next build number via repository variable `SPOT_IOS_BUILD_NUMBER` and updates `CURRENT_PROJECT_VERSION` for the archive only (no push to `main`; Actions cannot bypass rulesets on this user-owned repo)
+- Persists the allocated number before building (prevents duplicate Firebase build numbers)
 - Resolves the merged PR associated with the deployed commit
 - Converts the PR's `Changes` section to concise plain-text Firebase release notes (Markdown and checklist boilerplate are removed)
 - Injects Firebase configuration (`GoogleService-Info.plist`) from secrets
@@ -110,7 +110,8 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 - GoogleService-Info.plist is required for Firebase initialization - without it, the app will crash on launch
 - Build number is committed and pushed before archiving to prevent duplicate Firebase builds
 - Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
-- Bump commits (`Bump build number to ... [skip ci]`) do not re-trigger CI or deploy workflows
+- Build numbers are stored in Actions variable `SPOT_IOS_BUILD_NUMBER` (seed/update with `gh variable set`)
+- Legacy bump commits (`Bump build number to ... [skip ci]`) still do not re-trigger deploy workflows
 - Firebase App Distribution treats release notes as plain text; `scripts/format-firebase-release-notes.py` keeps the tester notes and rendered Actions summary readable
 - Documentation/Markdown, agent configuration, ignore-file, and license-only changes do not trigger a Firebase build
 
@@ -224,9 +225,9 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 
 ### Duplicate Firebase build numbers
 
-**Cause**: Deploy workflow uploaded an IPA but failed to push the incremented build number back to `main`.
+**Cause**: Deploy workflow uploaded an IPA but failed to persist the incremented build number (historically a blocked push to `main` under branch rulesets).
 
-**Solution**: The workflow now commits and pushes build numbers *before* archiving, preventing this issue. If you encounter duplicate builds from old deploys, they can be ignored - new deploys will use the correct incremented number.
+**Solution**: The workflow allocates and writes `SPOT_IOS_BUILD_NUMBER` *before* archiving. If duplicates appear from older runs, bump the variable ahead of the highest Firebase build (`gh variable set SPOT_IOS_BUILD_NUMBER --body <n>`) and re-run deploy.
 
 ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,13 @@ jobs:
     name: Build and Deploy to Firebase App Distribution
     runs-on: macos-15
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
+      # Persist SPOT_IOS_BUILD_NUMBER (GITHUB_TOKEN cannot push bump commits on
+      # this user-owned repo's protected branches).
+      actions: write
 
-    # Deploy on merges/direct pushes to main, but skip automated bump commits.
+    # Deploy on merges/direct pushes to main, but skip legacy bump commits.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' &&
@@ -42,7 +45,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restrict manual deployment branch
         if: github.event_name == 'workflow_dispatch'
@@ -55,11 +57,6 @@ jobs:
       - name: Resolve source SHA
         run: |
           echo "SOURCE_SHA=${{ github.sha }}" >> "$GITHUB_ENV"
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Sync with latest main
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
@@ -96,37 +93,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      - name: Get current build number
-        id: get_build_number
-        run: |
-          CURRENT_BUILD=$(grep -m 1 "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/')
-          if [ -z "$CURRENT_BUILD" ]; then
-            echo "Could not read CURRENT_PROJECT_VERSION from project.pbxproj"
-            exit 1
-          fi
-          echo "Current build number: $CURRENT_BUILD"
-          echo "current_build=$CURRENT_BUILD" >> $GITHUB_OUTPUT
-
-      - name: Increment build number
+      - name: Allocate CI build number
         id: increment_build
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ./scripts/increment-build-number.sh
-
-          NEW_BUILD=$(grep -m 1 "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/')
-          echo "New build number: $NEW_BUILD"
-          echo "new_build=$NEW_BUILD" >> $GITHUB_OUTPUT
-
+          set -euo pipefail
+          # Persist the next build in SPOT_IOS_BUILD_NUMBER before archive/upload
+          # so a failed deploy cannot reuse the same Firebase build number.
+          ./scripts/allocate-ci-build-number.sh
           echo "Build numbers in project file:"
           grep "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | head -4
-
-          git add Spot.xcodeproj/project.pbxproj
-          git commit -m "Bump build number to $NEW_BUILD [skip ci]"
-
-      - name: Push build number update
-        run: |
-          # Push before build/upload so a failed deploy cannot leave main stale and
-          # cause the next run to reuse the same build number in Firebase.
-          git push origin HEAD:main
 
       - name: Extract release notes from merged PR
         id: release_notes

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,9 +16,12 @@ jobs:
     name: Build and Upload to App Store Connect / TestFlight
     runs-on: macos-15
     permissions:
-      contents: write
+      contents: read
+      # Persist SPOT_IOS_BUILD_NUMBER (GITHUB_TOKEN cannot push bump commits on
+      # protected release branches for this user-owned repository).
+      actions: write
 
-    # Skip automated bump commits pushed by this workflow ([skip ci]).
+    # Skip legacy automated bump commits ([skip ci]).
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' &&
@@ -30,12 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Restrict workflow dispatch branch
         if: github.event_name == 'workflow_dispatch'
@@ -64,25 +61,17 @@ jobs:
           echo "Marketing version: $VERSION"
           echo "marketing_version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Increment build number
+      - name: Allocate CI build number
         id: increment_build
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          ./scripts/increment-build-number.sh
-
-          NEW_BUILD=$(grep -m 1 "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/')
-          echo "New build number: $NEW_BUILD"
-          echo "new_build=$NEW_BUILD" >> "$GITHUB_OUTPUT"
-
-          git add Spot.xcodeproj/project.pbxproj
-          git commit -m "Bump build number to $NEW_BUILD [skip ci]"
-
-      - name: Push build number update
-        run: |
-          # Push before archive/upload so a failed deploy cannot leave the branch stale
-          # and cause the next run to reuse the same build number in App Store Connect.
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          # Persist the next build in SPOT_IOS_BUILD_NUMBER before archive/upload
+          # so a failed upload cannot reuse the same App Store Connect build number.
+          ./scripts/allocate-ci-build-number.sh
+          echo "Build numbers in project file:"
+          grep "CURRENT_PROJECT_VERSION = " Spot.xcodeproj/project.pbxproj | head -4
 
       - name: Select Xcode 26 (iOS 26 SDK required by App Store Connect)
         run: |

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -88,25 +88,25 @@ Documentation, Markdown, agent configuration, ignore-file, and license-only push
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
-2. **Version Management:** Auto-increment build number
-3. **Version Commit:** Push build number update back to `main`
-4. **Release Notes:** Resolve the PR associated with the deployed commit and convert its `Changes` section to plain text
-5. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
-6. **Supabase Configuration:** Inject and verify staging project credentials
-7. **Code Signing:** Install certificates and provisioning profiles
-8. **Build:** Archive and export signed IPA
-9. **Deploy:** Upload to Firebase App Distribution
+2. **Version Management:** Allocate next build number (`SPOT_IOS_BUILD_NUMBER` Actions variable + local `CURRENT_PROJECT_VERSION` update)
+3. **Release Notes:** Resolve the PR associated with the deployed commit and convert its `Changes` section to plain text
+4. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
+5. **Supabase Configuration:** Inject and verify staging project credentials
+6. **Code Signing:** Install certificates and provisioning profiles
+7. **Build:** Archive and export signed IPA
+8. **Deploy:** Upload to Firebase App Distribution
 
 **What it does:**
-- Automatically increments `CURRENT_PROJECT_VERSION` in Xcode project via `scripts/increment-build-number.sh`
-- **Pushes the build number bump to `main` before building** (prevents duplicate Firebase build numbers when upload succeeds but a later step fails)
+- Allocates the next build via `scripts/allocate-ci-build-number.sh` (repository variable `SPOT_IOS_BUILD_NUMBER`, floored by `CURRENT_PROJECT_VERSION` in the checked-out project)
+- **Persists the allocated number before building** (prevents duplicate Firebase build numbers when upload succeeds but a later step fails)
+- Does **not** push bump commits to `main` — on this user-owned repository, `GITHUB_TOKEN` cannot bypass branch rulesets
 - Pins Firebase-distributed internal builds to staging Supabase project `aeurigbbohyxvtsfiyul`; the workflow fails if another project URL is embedded
 - Defines `INTERNAL_TESTING` through the Spot target's `SPOT_DISTRIBUTION_CONDITION` setting; it is not applied to Swift Package targets
 - Builds signed IPA for distribution
 - Generates concise release notes from the associated merged PR title and `Changes` section
 - Removes Markdown, automated PR metadata, testing details, and checklist boilerplate because Firebase App Distribution displays release notes as plain text
 - Uploads to Firebase App Distribution with testers group
-- Skips re-deploy on bump commits (`Bump build number to … [skip ci]`)
+- Skips re-deploy on legacy bump commits (`Bump build number to … [skip ci]`)
 - Skips documentation and repository-maintenance-only pushes so they do not increment the build number or publish an unchanged IPA
 
 **Required secrets:**
@@ -138,7 +138,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
-2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and increment `CURRENT_PROJECT_VERSION` with `scripts/increment-build-number.sh`
+2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and allocate the next build via `scripts/allocate-ci-build-number.sh` (`SPOT_IOS_BUILD_NUMBER`)
 3. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
 4. **Code Signing:** Install `TESTFLIGHT_APPLE_CERT` + `TESTFLIGHT_APPLE_PROFILE` into a temporary keychain
 5. **Build:** Archive unsigned, then export an App Store `.ipa`
@@ -148,9 +148,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 
 **Versioning rule:**
 - The release branch name controls the user-facing version. `release/1.1.0` → `MARKETING_VERSION = 1.1.0`.
-- The build number increments from the project value using the same script as the Firebase lane:
-  - if the branch contains build 35, the workflow builds version `1.1.0` (36)
-  - a later run only advances again if the branch's committed project value has advanced
+- The build number is allocated the same way as the Firebase lane (`SPOT_IOS_BUILD_NUMBER`, floored by checked-in `CURRENT_PROJECT_VERSION`); the workflow does not push bump commits to protected `release/*` branches
 - The pipeline never bumps `1.1.0` → `1.2.0` automatically. To ship a new version, create a new `release/<version>` branch.
 - TestFlight upload does **not** submit the build to App Store Review.
 
@@ -407,8 +405,8 @@ If Xcode Cloud starts building again:
    - All tests pass
 3. PR is reviewed and merged to `main`
 4. **Deployment workflow triggers** (`deploy.yml`):
-   - Build number auto-increments (e.g., 7 → 8)
-   - **Build number is pushed to `main` before archive/upload** so a failed deploy cannot leave the repo stale and cause duplicate Firebase build numbers
+   - Build number auto-increments (e.g., 52 → 53) via `SPOT_IOS_BUILD_NUMBER`
+   - **Allocated number is persisted before archive/upload** so a failed deploy cannot reuse the same Firebase build number
    - Plain-text release notes generated from the merged PR associated with the deployed commit
    - App is built and signed
    - IPA uploaded to Firebase App Distribution
@@ -416,26 +414,26 @@ If Xcode Cloud starts building again:
 
 **Build versioning:**
 - Marketing version: `1.000` (manual updates for releases)
-- Build number: Auto-incremented from `CURRENT_PROJECT_VERSION` on every deployment
-- The Xcode project is authoritative; do not duplicate a static “current build” number in this runbook.
+- Build number: Auto-incremented from the max of `SPOT_IOS_BUILD_NUMBER` and checked-in `CURRENT_PROJECT_VERSION`
+- CI source of truth for shipped builds is the Actions variable; the Xcode project is updated in the runner workspace for the archive only
 
 **Deploy safeguards:**
 - **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)
 - **Path filter:** Documentation and repository-maintenance-only pushes do not create Firebase deploy runs
-- **Skip bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
-- **Skip CI on bumps:** `ci.yml` skips validation on `[skip ci]` commits
-- **Push before build:** The incremented build number is committed and pushed to `main` before archiving/uploading to Firebase
+- **Skip legacy bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
+- **Skip CI on `[skip ci]` commits:** `ci.yml` skips validation on those commits
+- **Allocate before build:** `scripts/allocate-ci-build-number.sh` writes `SPOT_IOS_BUILD_NUMBER` before archiving/uploading
 
 **Troubleshooting duplicate Firebase build numbers**
 
-If multiple Firebase releases show the same build number (e.g. three `1.000 (7)` entries), the usual cause is deploy runs that **uploaded an IPA but failed to push** the incremented `CURRENT_PROJECT_VERSION` back to `main`. Each subsequent run then read the same build number from the repo and produced the same Firebase build.
+If multiple Firebase releases show the same build number (e.g. three `1.000 (7)` entries), the usual cause is deploy runs that **uploaded an IPA but failed to persist** the next build number. Historically this was a blocked `git push` to `main` under branch rulesets (`GITHUB_TOKEN` cannot bypass rules on this user-owned repo).
 
-Common failure modes (July 2026):
-1. Missing `contents: write` permission on deploy — push failed with 403 after Firebase upload
-2. Manual `workflow_dispatch` runs from feature branches — upload succeeds but push to `main` is skipped
-3. Concurrent deploy runs before concurrency was added — both read the same `CURRENT_PROJECT_VERSION`
+Common failure modes:
+1. Ruleset rejection of bump commits to `main` (fixed by using `SPOT_IOS_BUILD_NUMBER` instead of pushing)
+2. Concurrent deploy runs before concurrency was added — both read the same base build number
+3. Stale variable — set it ahead of the highest Firebase build: `gh variable set SPOT_IOS_BUILD_NUMBER --body <n>`
 
-The push-before-build ordering prevents new duplicates even when archive or Firebase upload fails later in the job.
+Allocate-before-build ordering prevents new duplicates even when archive or Firebase upload fails later in the job.
 
 ### Future Enhancements
 

--- a/scripts/allocate-ci-build-number.sh
+++ b/scripts/allocate-ci-build-number.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# allocate-ci-build-number.sh
+#
+# Allocates the next iOS CI build number and updates Spot.xcodeproj locally.
+#
+# Source of truth: repository Actions variable SPOT_IOS_BUILD_NUMBER (override
+# with SPOT_IOS_BUILD_NUMBER_VAR). The checked-in CURRENT_PROJECT_VERSION is
+# used as a floor so a stale variable cannot move the number backwards.
+#
+# This script does not commit or push. On this user-owned repository, GitHub
+# Actions cannot bypass branch rulesets, so deploy workflows must not push
+# bump commits to protected branches.
+#
+# Requires: gh authenticated for the repo, with permission to read/write
+# repository Actions variables (workflow permission: actions: write).
+#
+# Usage: ./scripts/allocate-ci-build-number.sh
+#
+# Outputs (stdout): the new build number
+# When GITHUB_OUTPUT is set: previous_build / new_build
+
+set -euo pipefail
+
+VAR_NAME="${SPOT_IOS_BUILD_NUMBER_VAR:-SPOT_IOS_BUILD_NUMBER}"
+PROJECT_FILE="Spot.xcodeproj/project.pbxproj"
+REPO="${GITHUB_REPOSITORY:-}"
+
+if [[ -z "$REPO" ]]; then
+  echo "error: GITHUB_REPOSITORY must be set" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT_FILE" ]]; then
+  echo "error: $PROJECT_FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required" >&2
+  exit 1
+fi
+
+PBX_BUILD="$(
+  grep -m 1 "CURRENT_PROJECT_VERSION = " "$PROJECT_FILE" \
+    | sed 's/.*CURRENT_PROJECT_VERSION = \([0-9]*\);/\1/'
+)"
+if [[ -z "$PBX_BUILD" || ! "$PBX_BUILD" =~ ^[0-9]+$ ]]; then
+  echo "error: could not read CURRENT_PROJECT_VERSION from $PROJECT_FILE" >&2
+  exit 1
+fi
+
+STORED="$(gh variable get "$VAR_NAME" -R "$REPO" 2>/dev/null || true)"
+BASE="$PBX_BUILD"
+if [[ -n "$STORED" && "$STORED" =~ ^[0-9]+$ ]] && (( STORED > PBX_BUILD )); then
+  BASE="$STORED"
+fi
+
+NEW_BUILD=$((BASE + 1))
+
+echo "pbxproj build: $PBX_BUILD"
+echo "stored variable ($VAR_NAME): ${STORED:-<unset>}"
+echo "allocating build: $NEW_BUILD"
+
+gh variable set "$VAR_NAME" -R "$REPO" --body "$NEW_BUILD"
+./scripts/increment-build-number.sh "$NEW_BUILD"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "previous_build=$BASE"
+    echo "new_build=$NEW_BUILD"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+echo "$NEW_BUILD"

--- a/scripts/apply-github-rulesets.sh
+++ b/scripts/apply-github-rulesets.sh
@@ -35,11 +35,6 @@ apply_payload() {
   fi
 }
 
-should_retry_without_extras() {
-  local err="$1"
-  [[ "$err" == *"merge_queue"* || "$err" == *"bypass_actors"* || "$err" == *"GitHub Actions integration"* ]]
-}
-
 apply_ruleset() {
   local file="$1"
   local name payload fallback err status
@@ -58,18 +53,35 @@ apply_ruleset() {
     return 0
   fi
 
-  if ! should_retry_without_extras "$err"; then
-    echo "error: failed to apply ${file}" >&2
-    echo "$err" >&2
-    return 1
+  # Prefer dropping merge_queue first (often unsupported via REST) while keeping
+  # RepositoryRole Admin bypass for this user-owned repository.
+  if [[ "$err" == *"merge_queue"* ]]; then
+    echo "  API rejected merge_queue; retrying without it."
+    echo "  Enable merge queue in the UI if needed — see .github/rulesets/README.md"
+    fallback="$(jq '.rules = [.rules[] | select(.type != "merge_queue")]' "$file")"
+    set +e
+    err="$(apply_payload "$name" "$fallback" 2>&1)"
+    status=$?
+    set -e
+    if [[ "$status" -eq 0 ]]; then
+      echo "  applied (without merge_queue)"
+      return 0
+    fi
   fi
 
-  echo "  API rejected merge_queue and/or bypass_actors; retrying with core rules only."
-  echo "  Finish merge queue + GitHub Actions bypass in the UI — see .github/rulesets/README.md"
+  if [[ "$err" == *"bypass_actors"* || "$err" == *"GitHub Actions integration"* ]]; then
+    echo "  API rejected bypass_actors; retrying without bypass list."
+    echo "  Note: GitHub Actions integration bypass is not available on user-owned repos."
+    echo "  Deploy workflows use SPOT_IOS_BUILD_NUMBER instead of pushing bump commits."
+    fallback="$(jq 'del(.bypass_actors) | .rules = [.rules[] | select(.type != "merge_queue")]' "$file")"
+    apply_payload "$name" "$fallback" >/dev/null
+    echo "  applied core rules"
+    return 0
+  fi
 
-  fallback="$(jq 'del(.bypass_actors) | .rules = [.rules[] | select(.type != "merge_queue")]' "$file")"
-  apply_payload "$name" "$fallback" >/dev/null
-  echo "  applied core rules"
+  echo "error: failed to apply ${file}" >&2
+  echo "$err" >&2
+  return 1
 }
 
 for file in "${RULESET_DIR}"/*.json; do


### PR DESCRIPTION
## Summary
- Firebase/TestFlight deploys failed after main rulesets blocked `git push` of bump commits (`GITHUB_TOKEN` cannot use the GitHub Actions bypass on a user-owned repo).
- Allocate build numbers via repository Actions variable `SPOT_IOS_BUILD_NUMBER` (`scripts/allocate-ci-build-number.sh`) before archive/upload — no protected-branch push required.
- Align ruleset JSON/docs with **Repository role: Admin** bypass (owner escape hatch) and document the user-owned-repo limitation.

## Test plan
- [x] Seeded `SPOT_IOS_BUILD_NUMBER=52` from current `main` pbxproj
- [x] Applied Admin bypass on main + release rulesets via API
- [ ] CI PR Validation passes
- [ ] After merge, re-run **Deploy to Firebase** (or merge triggers it) and confirm build allocates 53+ and uploads


Made with [Cursor](https://cursor.com)