### PR TITLE
Fix CI build number persistence (ci/build-number branch)

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -32,7 +32,7 @@ This repository is owned by a **user account**, not an organization. GitHub reje
 
 `bypass_actors` therefore uses **Repository role: Admin** (`actor_id` 5) so the owner can emergency-push if needed.
 
-Deploy workflows **must not** rely on `GITHUB_TOKEN` pushing bump commits to protected branches. Instead they allocate build numbers via the repository Actions variable `SPOT_IOS_BUILD_NUMBER` (`scripts/allocate-ci-build-number.sh`).
+Deploy workflows **must not** rely on `GITHUB_TOKEN` pushing bump commits to protected branches, and cannot use repository Actions variables (`GITHUB_TOKEN` lacks admin rights for that API). They allocate build numbers on the unprotected `ci/build-number` branch (`scripts/allocate-ci-build-number.sh`).
 
 ## One-time UI steps (if API apply skips them)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,7 +76,7 @@ Documentation and repository-maintenance-only pushes are ignored, so they do not
 This trigger does not depend on the separate CI workflow. Repository branch protection and merge policy are responsible for preventing unvalidated changes from reaching `main`.
 
 **What it does:**
-- Automatically allocates the next build number via repository variable `SPOT_IOS_BUILD_NUMBER` and updates `CURRENT_PROJECT_VERSION` for the archive only (no push to `main`; Actions cannot bypass rulesets on this user-owned repo)
+- Automatically allocates the next build number on unprotected branch `ci/build-number` (`BUILD_NUMBER`) and updates `CURRENT_PROJECT_VERSION` for the archive only (no push to `main` / `release/*`)
 - Persists the allocated number before building (prevents duplicate Firebase build numbers)
 - Resolves the merged PR associated with the deployed commit
 - Converts the PR's `Changes` section to concise plain-text Firebase release notes (Markdown and checklist boilerplate are removed)
@@ -110,7 +110,7 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 - GoogleService-Info.plist is required for Firebase initialization - without it, the app will crash on launch
 - Build number is committed and pushed before archiving to prevent duplicate Firebase builds
 - Concurrent deploys are serialized via the `deploy-firebase-main` concurrency group
-- Build numbers are stored in Actions variable `SPOT_IOS_BUILD_NUMBER` (seed/update with `gh variable set`)
+- Build numbers are stored on `ci/build-number` (`BUILD_NUMBER`); do not protect that branch
 - Legacy bump commits (`Bump build number to ... [skip ci]`) still do not re-trigger deploy workflows
 - Firebase App Distribution treats release notes as plain text; `scripts/format-firebase-release-notes.py` keeps the tester notes and rendered Actions summary readable
 - Documentation/Markdown, agent configuration, ignore-file, and license-only changes do not trigger a Firebase build
@@ -225,9 +225,9 @@ See [docs/engineering/firebase-distribution-setup.md](../../docs/engineering/fir
 
 ### Duplicate Firebase build numbers
 
-**Cause**: Deploy workflow uploaded an IPA but failed to persist the incremented build number (historically a blocked push to `main` under branch rulesets).
+**Cause**: Deploy workflow uploaded an IPA but failed to persist the incremented build number (historically a blocked push to `main`, or Actions-variable APIs that `GITHUB_TOKEN` cannot call).
 
-**Solution**: The workflow allocates and writes `SPOT_IOS_BUILD_NUMBER` *before* archiving. If duplicates appear from older runs, bump the variable ahead of the highest Firebase build (`gh variable set SPOT_IOS_BUILD_NUMBER --body <n>`) and re-run deploy.
+**Solution**: The workflow allocates and pushes `ci/build-number` *before* archiving. If duplicates appear, set `BUILD_NUMBER` on that branch ahead of the highest Firebase build and re-run deploy.
 
 ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,9 @@ jobs:
     name: Build and Deploy to Firebase App Distribution
     runs-on: macos-15
     permissions:
-      contents: read
+      # Push allocated build numbers to unprotected ci/build-number only.
+      contents: write
       pull-requests: read
-      # Persist SPOT_IOS_BUILD_NUMBER (GITHUB_TOKEN cannot push bump commits on
-      # this user-owned repo's protected branches).
-      actions: write
 
     # Deploy on merges/direct pushes to main, but skip legacy bump commits.
     if: |
@@ -95,11 +93,9 @@ jobs:
 
       - name: Allocate CI build number
         id: increment_build
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Persist the next build in SPOT_IOS_BUILD_NUMBER before archive/upload
+          # Persist the next build on unprotected ci/build-number before archive
           # so a failed deploy cannot reuse the same Firebase build number.
           ./scripts/allocate-ci-build-number.sh
           echo "Build numbers in project file:"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,10 +16,8 @@ jobs:
     name: Build and Upload to App Store Connect / TestFlight
     runs-on: macos-15
     permissions:
-      contents: read
-      # Persist SPOT_IOS_BUILD_NUMBER (GITHUB_TOKEN cannot push bump commits on
-      # protected release branches for this user-owned repository).
-      actions: write
+      # Push allocated build numbers to unprotected ci/build-number only.
+      contents: write
 
     # Skip legacy automated bump commits ([skip ci]).
     if: |
@@ -63,11 +61,9 @@ jobs:
 
       - name: Allocate CI build number
         id: increment_build
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Persist the next build in SPOT_IOS_BUILD_NUMBER before archive/upload
+          # Persist the next build on unprotected ci/build-number before archive
           # so a failed upload cannot reuse the same App Store Connect build number.
           ./scripts/allocate-ci-build-number.sh
           echo "Build numbers in project file:"

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -88,7 +88,7 @@ Documentation, Markdown, agent configuration, ignore-file, and license-only push
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
-2. **Version Management:** Allocate next build number (`SPOT_IOS_BUILD_NUMBER` Actions variable + local `CURRENT_PROJECT_VERSION` update)
+2. **Version Management:** Allocate next build number (`ci/build-number` + local `CURRENT_PROJECT_VERSION` update)
 3. **Release Notes:** Resolve the PR associated with the deployed commit and convert its `Changes` section to plain text
 4. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
 5. **Supabase Configuration:** Inject and verify staging project credentials
@@ -97,9 +97,9 @@ Documentation, Markdown, agent configuration, ignore-file, and license-only push
 8. **Deploy:** Upload to Firebase App Distribution
 
 **What it does:**
-- Allocates the next build via `scripts/allocate-ci-build-number.sh` (repository variable `SPOT_IOS_BUILD_NUMBER`, floored by `CURRENT_PROJECT_VERSION` in the checked-out project)
+- Allocates the next build via `scripts/allocate-ci-build-number.sh` (unprotected `ci/build-number` / `BUILD_NUMBER`, floored by `CURRENT_PROJECT_VERSION` in the checked-out project)
 - **Persists the allocated number before building** (prevents duplicate Firebase build numbers when upload succeeds but a later step fails)
-- Does **not** push bump commits to `main` — on this user-owned repository, `GITHUB_TOKEN` cannot bypass branch rulesets
+- Does **not** push bump commits to `main` / `release/*` — `GITHUB_TOKEN` cannot bypass those rulesets, and cannot use the repository Actions variables API either
 - Pins Firebase-distributed internal builds to staging Supabase project `aeurigbbohyxvtsfiyul`; the workflow fails if another project URL is embedded
 - Defines `INTERNAL_TESTING` through the Spot target's `SPOT_DISTRIBUTION_CONDITION` setting; it is not applied to Swift Package targets
 - Builds signed IPA for distribution
@@ -138,7 +138,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 **Pipeline stages:**
 
 1. **Checkout:** Pull repository code with full history
-2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and allocate the next build via `scripts/allocate-ci-build-number.sh` (`SPOT_IOS_BUILD_NUMBER`)
+2. **Resolve version:** Derive `MARKETING_VERSION` from the branch name and allocate the next build via `scripts/allocate-ci-build-number.sh` (`ci/build-number`)
 3. **Firebase Configuration:** Inject GoogleService-Info.plist from secrets
 4. **Code Signing:** Install `TESTFLIGHT_APPLE_CERT` + `TESTFLIGHT_APPLE_PROFILE` into a temporary keychain
 5. **Build:** Archive unsigned, then export an App Store `.ipa`
@@ -148,7 +148,7 @@ See [firebase-distribution-setup.md](firebase-distribution-setup.md) for detaile
 
 **Versioning rule:**
 - The release branch name controls the user-facing version. `release/1.1.0` → `MARKETING_VERSION = 1.1.0`.
-- The build number is allocated the same way as the Firebase lane (`SPOT_IOS_BUILD_NUMBER`, floored by checked-in `CURRENT_PROJECT_VERSION`); the workflow does not push bump commits to protected `release/*` branches
+- The build number is allocated the same way as the Firebase lane (`ci/build-number`, floored by checked-in `CURRENT_PROJECT_VERSION`); the workflow does not push bump commits to protected `release/*` branches
 - The pipeline never bumps `1.1.0` → `1.2.0` automatically. To ship a new version, create a new `release/<version>` branch.
 - TestFlight upload does **not** submit the build to App Store Review.
 
@@ -405,7 +405,7 @@ If Xcode Cloud starts building again:
    - All tests pass
 3. PR is reviewed and merged to `main`
 4. **Deployment workflow triggers** (`deploy.yml`):
-   - Build number auto-increments (e.g., 52 → 53) via `SPOT_IOS_BUILD_NUMBER`
+   - Build number auto-increments (e.g., 52 → 53) via `ci/build-number`
    - **Allocated number is persisted before archive/upload** so a failed deploy cannot reuse the same Firebase build number
    - Plain-text release notes generated from the merged PR associated with the deployed commit
    - App is built and signed
@@ -414,24 +414,24 @@ If Xcode Cloud starts building again:
 
 **Build versioning:**
 - Marketing version: `1.000` (manual updates for releases)
-- Build number: Auto-incremented from the max of `SPOT_IOS_BUILD_NUMBER` and checked-in `CURRENT_PROJECT_VERSION`
-- CI source of truth for shipped builds is the Actions variable; the Xcode project is updated in the runner workspace for the archive only
+- Build number: Auto-incremented from the max of `ci/build-number`’s `BUILD_NUMBER` and checked-in `CURRENT_PROJECT_VERSION`
+- CI source of truth for shipped builds is `ci/build-number`; the Xcode project is updated in the runner workspace for the archive only
 
 **Deploy safeguards:**
 - **Concurrency:** Only one deploy runs at a time (`deploy-firebase-main` group)
 - **Path filter:** Documentation and repository-maintenance-only pushes do not create Firebase deploy runs
 - **Skip legacy bump commits:** Pushes with message `Bump build number to … [skip ci]` do not re-trigger deploy
 - **Skip CI on `[skip ci]` commits:** `ci.yml` skips validation on those commits
-- **Allocate before build:** `scripts/allocate-ci-build-number.sh` writes `SPOT_IOS_BUILD_NUMBER` before archiving/uploading
+- **Allocate before build:** `scripts/allocate-ci-build-number.sh` pushes `ci/build-number` before archiving/uploading
 
 **Troubleshooting duplicate Firebase build numbers**
 
-If multiple Firebase releases show the same build number (e.g. three `1.000 (7)` entries), the usual cause is deploy runs that **uploaded an IPA but failed to persist** the next build number. Historically this was a blocked `git push` to `main` under branch rulesets (`GITHUB_TOKEN` cannot bypass rules on this user-owned repo).
+If multiple Firebase releases show the same build number (e.g. three `1.000 (7)` entries), the usual cause is deploy runs that **uploaded an IPA but failed to persist** the next build number. Historically this was a blocked `git push` to `main`, or a 403 writing repository Actions variables with `GITHUB_TOKEN`.
 
 Common failure modes:
-1. Ruleset rejection of bump commits to `main` (fixed by using `SPOT_IOS_BUILD_NUMBER` instead of pushing)
+1. Ruleset rejection of bump commits to `main` (fixed by persisting on unprotected `ci/build-number`)
 2. Concurrent deploy runs before concurrency was added — both read the same base build number
-3. Stale variable — set it ahead of the highest Firebase build: `gh variable set SPOT_IOS_BUILD_NUMBER --body <n>`
+3. Stale counter — set `BUILD_NUMBER` on `ci/build-number` ahead of the highest Firebase build and re-run deploy
 
 Allocate-before-build ordering prevents new duplicates even when archive or Firebase upload fails later in the job.
 

--- a/scripts/allocate-ci-build-number.sh
+++ b/scripts/allocate-ci-build-number.sh
@@ -1,42 +1,44 @@
 #!/usr/bin/env bash
 # allocate-ci-build-number.sh
 #
-# Allocates the next iOS CI build number and updates Spot.xcodeproj locally.
+# Allocates the next iOS CI build number, updates Spot.xcodeproj locally, and
+# persists the allocated number on the unprotected branch `ci/build-number`
+# (file: BUILD_NUMBER).
 #
-# Source of truth: repository Actions variable SPOT_IOS_BUILD_NUMBER (override
-# with SPOT_IOS_BUILD_NUMBER_VAR). The checked-in CURRENT_PROJECT_VERSION is
-# used as a floor so a stale variable cannot move the number backwards.
+# Why a branch (not Actions variables / not main):
+# - GITHUB_TOKEN cannot read/write repository Actions variables (admin-only API).
+# - Branch rulesets block GITHUB_TOKEN from pushing bump commits to main/release/*.
+# - `ci/build-number` is intentionally unprotected so deploy/TestFlight can push.
 #
-# This script does not commit or push. On this user-owned repository, GitHub
-# Actions cannot bypass branch rulesets, so deploy workflows must not push
-# bump commits to protected branches.
+# The checked-in CURRENT_PROJECT_VERSION is used as a floor so a stale counter
+# cannot move the number backwards.
 #
-# Requires: gh authenticated for the repo, with permission to read/write
-# repository Actions variables (workflow permission: actions: write).
+# Requires: git + push access to refs/heads/ci/build-number
+#   (workflow permission: contents: write).
 #
 # Usage: ./scripts/allocate-ci-build-number.sh
+#
+# Env overrides:
+#   SPOT_IOS_BUILD_NUMBER_REF   default: ci/build-number
+#   SPOT_IOS_BUILD_NUMBER_FILE  default: BUILD_NUMBER
 #
 # Outputs (stdout): the new build number
 # When GITHUB_OUTPUT is set: previous_build / new_build
 
 set -euo pipefail
 
-VAR_NAME="${SPOT_IOS_BUILD_NUMBER_VAR:-SPOT_IOS_BUILD_NUMBER}"
+BUILD_REF="${SPOT_IOS_BUILD_NUMBER_REF:-ci/build-number}"
+BUILD_FILE="${SPOT_IOS_BUILD_NUMBER_FILE:-BUILD_NUMBER}"
 PROJECT_FILE="Spot.xcodeproj/project.pbxproj"
-REPO="${GITHUB_REPOSITORY:-}"
-
-if [[ -z "$REPO" ]]; then
-  echo "error: GITHUB_REPOSITORY must be set" >&2
-  exit 1
-fi
+REPO_ROOT="$(pwd)"
 
 if [[ ! -f "$PROJECT_FILE" ]]; then
-  echo "error: $PROJECT_FILE not found" >&2
+  echo "error: $PROJECT_FILE not found (run from repo root)" >&2
   exit 1
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "error: gh CLI is required" >&2
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "error: not a git repository" >&2
   exit 1
 fi
 
@@ -49,7 +51,13 @@ if [[ -z "$PBX_BUILD" || ! "$PBX_BUILD" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-STORED="$(gh variable get "$VAR_NAME" -R "$REPO" 2>/dev/null || true)"
+git fetch origin "+refs/heads/${BUILD_REF}:refs/remotes/origin/${BUILD_REF}" 2>/dev/null || true
+
+STORED=""
+if git rev-parse --verify "origin/${BUILD_REF}" >/dev/null 2>&1; then
+  STORED="$(git show "origin/${BUILD_REF}:${BUILD_FILE}" 2>/dev/null | tr -d '[:space:]' || true)"
+fi
+
 BASE="$PBX_BUILD"
 if [[ -n "$STORED" && "$STORED" =~ ^[0-9]+$ ]] && (( STORED > PBX_BUILD )); then
   BASE="$STORED"
@@ -58,11 +66,54 @@ fi
 NEW_BUILD=$((BASE + 1))
 
 echo "pbxproj build: $PBX_BUILD"
-echo "stored variable ($VAR_NAME): ${STORED:-<unset>}"
+echo "stored counter (origin/${BUILD_REF}:${BUILD_FILE}): ${STORED:-<unset>}"
 echo "allocating build: $NEW_BUILD"
 
-gh variable set "$VAR_NAME" -R "$REPO" --body "$NEW_BUILD"
 ./scripts/increment-build-number.sh "$NEW_BUILD"
+
+WT="$(mktemp -d "${TMPDIR:-/tmp}/spot-build-number.XXXXXX")"
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove --force "$WT" >/dev/null 2>&1 || true
+  rm -rf "$WT"
+}
+trap cleanup EXIT
+
+if git rev-parse --verify "origin/${BUILD_REF}" >/dev/null 2>&1; then
+  git worktree add --detach "$WT" "origin/${BUILD_REF}" >/dev/null
+else
+  git worktree add --detach "$WT" HEAD >/dev/null
+  git -C "$WT" checkout --orphan "$BUILD_REF" >/dev/null
+  # Orphan checkout keeps the index from HEAD; clear it so the branch stays tiny.
+  git -C "$WT" rm -rf --quiet . >/dev/null 2>&1 || true
+  find "$WT" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+fi
+
+printf '%s\n' "$NEW_BUILD" > "${WT}/${BUILD_FILE}"
+cat > "${WT}/README.md" <<'EOF'
+# CI iOS build number
+
+Unprotected counter branch used by `deploy.yml` / `testflight.yml`.
+
+- `BUILD_NUMBER` is the last allocated CI build (source of truth for Firebase / TestFlight).
+- Do **not** add branch protection here — `GITHUB_TOKEN` must be able to push.
+- Do **not** merge this branch into `main`.
+
+Advance manually if needed:
+
+```bash
+git fetch origin ci/build-number
+git show origin/ci/build-number:BUILD_NUMBER
+# then push a commit that sets BUILD_NUMBER ahead of the highest shipped build
+```
+EOF
+
+git -C "$WT" add "$BUILD_FILE" README.md
+git -C "$WT" \
+  -c user.name="github-actions[bot]" \
+  -c user.email="github-actions[bot]@users.noreply.github.com" \
+  commit -m "Set iOS CI build number to ${NEW_BUILD} [skip ci]" >/dev/null
+
+git -C "$WT" push origin "HEAD:refs/heads/${BUILD_REF}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {

--- a/scripts/apply-github-rulesets.sh
+++ b/scripts/apply-github-rulesets.sh
@@ -72,7 +72,7 @@ apply_ruleset() {
   if [[ "$err" == *"bypass_actors"* || "$err" == *"GitHub Actions integration"* ]]; then
     echo "  API rejected bypass_actors; retrying without bypass list."
     echo "  Note: GitHub Actions integration bypass is not available on user-owned repos."
-    echo "  Deploy workflows use SPOT_IOS_BUILD_NUMBER instead of pushing bump commits."
+    echo "  Deploy workflows persist build numbers on unprotected ci/build-number."
     fallback="$(jq 'del(.bypass_actors) | .rules = [.rules[] | select(.type != "merge_queue")]' "$file")"
     apply_payload "$name" "$fallback" >/dev/null
     echo "  applied core rules"


### PR DESCRIPTION
## Summary
- Deploy failed with `HTTP 403` setting `SPOT_IOS_BUILD_NUMBER` — `GITHUB_TOKEN` cannot use the repository Actions variables API (admin-only).
- Persist allocated builds on unprotected `ci/build-number` (`BUILD_NUMBER`) via `scripts/allocate-ci-build-number.sh` before archive/upload.
- Seeded `ci/build-number` at `52` so the next deploy allocates `53`.

## Test plan
- [x] Bootstrapped `origin/ci/build-number` with `BUILD_NUMBER=52`
- [ ] PR Validation passes
- [ ] After merge, Firebase deploy allocates 53, pushes counter branch, and uploads IPA


Made with [Cursor](https://cursor.com)