### PR TITLE
Fix Spot creation and feed UI bugs

### DIFF
--- a/Spot/Models/Spot+Extensions.swift
+++ b/Spot/Models/Spot+Extensions.swift
@@ -16,6 +16,33 @@ extension Spot {
     /// Fields that can change after a feed refresh while `id` stays the same (likes, media, saves).
     /// Used so `SpotCard` can sync `@State currentSpot` from the parent `spot` when SwiftUI reuses the row.
     var feedRowSyncToken: String {
-        "\(safeId)|\(imageURL ?? "")|\(likes ?? -1)|\(isLiked ?? false)|\(isSaved ?? false)|\(mediaCount ?? -1)"
+        "\(safeId)|\(imageURL ?? "")|\(username ?? "")|\(userProfileImageURL ?? "")|\(likes ?? -1)|\(isLiked ?? false)|\(isSaved ?? false)|\(mediaCount ?? -1)"
+    }
+}
+
+struct SpotAuthorDisplay: Equatable {
+    let username: String
+    let profileImageURL: String?
+
+    static func resolve(
+        spotUsername: String?,
+        spotProfileImageURL: String?,
+        isCurrentUser: Bool,
+        currentUsername: String?,
+        currentProfileImageURL: String?
+    ) -> SpotAuthorDisplay {
+        let spotName = spotUsername?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentName = currentUsername?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = nonempty(spotName)
+            ?? (isCurrentUser ? nonempty(currentName) : nil)
+            ?? "User"
+        let profileImageURL = nonempty(spotProfileImageURL)
+            ?? (isCurrentUser ? nonempty(currentProfileImageURL) : nil)
+        return SpotAuthorDisplay(username: username, profileImageURL: profileImageURL)
+    }
+
+    private static func nonempty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 }

--- a/Spot/Services/Spots/PostPhotoProcessor.swift
+++ b/Spot/Services/Spots/PostPhotoProcessor.swift
@@ -23,6 +23,7 @@ enum PostPhotoImportError: LocalizedError, Equatable {
 
 enum PostPhotoProcessor {
     static let previewMaxPixelSize: CGFloat = 1_600
+    static let editorPreviewMaxPixelSize: CGFloat = 900
     private static let context = CIContext(options: [.cacheIntermediates: false])
 
     static func importImage(
@@ -68,9 +69,34 @@ enum PostPhotoProcessor {
     }
 
     static func render(original: UIImage, edits proposedEdits: PostComposerPhotoEdits) throws -> UIImage {
+        try render(
+            original: original,
+            edits: proposedEdits,
+            maxPixelSize: previewMaxPixelSize
+        )
+    }
+
+    /// Fast, display-only render used while editor controls are moving. The
+    /// full 1600px render still runs after the user taps Done.
+    static func renderEditorPreview(
+        original: UIImage,
+        edits proposedEdits: PostComposerPhotoEdits
+    ) throws -> UIImage {
+        try render(
+            original: original,
+            edits: proposedEdits,
+            maxPixelSize: editorPreviewMaxPixelSize
+        )
+    }
+
+    private static func render(
+        original: UIImage,
+        edits proposedEdits: PostComposerPhotoEdits,
+        maxPixelSize: CGFloat
+    ) throws -> UIImage {
         var edits = proposedEdits
         edits.normalize()
-        guard var result = normalizeOrientationAndResize(original, maxPixelSize: previewMaxPixelSize) else {
+        guard var result = normalizeOrientationAndResize(original, maxPixelSize: maxPixelSize) else {
             throw PostPhotoImportError.decodeFailed
         }
 

--- a/Spot/Services/Spots/SpotPublishCoordinator.swift
+++ b/Spot/Services/Spots/SpotPublishCoordinator.swift
@@ -9,6 +9,50 @@ import Foundation
 import SwiftUI
 import UIKit
 
+enum SpotPublishProgress: Equatable, Sendable {
+    case preparing
+    case resolvingVibes
+    case uploadingPhoto(index: Int, total: Int)
+    case checkingPhoto(index: Int, total: Int)
+    case publishing
+    case finalizing
+    case complete
+
+    var fraction: Double {
+        switch self {
+        case .preparing: return 0.05
+        case .resolvingVibes: return 0.12
+        case let .uploadingPhoto(index, total):
+            return photoFraction(index: index, total: total, stage: 0)
+        case let .checkingPhoto(index, total):
+            return photoFraction(index: index, total: total, stage: 0.65)
+        case .publishing: return 0.9
+        case .finalizing: return 0.97
+        case .complete: return 1
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .preparing: return "Preparing your Spot…"
+        case .resolvingVibes: return "Adding vibe tags…"
+        case let .uploadingPhoto(index, total):
+            return "Uploading photo \(min(index + 1, total)) of \(total)…"
+        case let .checkingPhoto(index, total):
+            return "Checking photo \(min(index + 1, total)) of \(total)…"
+        case .publishing: return "Publishing your Spot…"
+        case .finalizing: return "Finishing up…"
+        case .complete: return "Spot posted"
+        }
+    }
+
+    private func photoFraction(index: Int, total: Int, stage: Double) -> Double {
+        let safeTotal = max(total, 1)
+        let completed = min(max(Double(index) + stage, 0), Double(safeTotal))
+        return 0.15 + 0.7 * completed / Double(safeTotal)
+    }
+}
+
 /// Serializable draft so the publish pipeline does not retain `UIImage` after the composer resets.
 struct SpotPublishDraft: Equatable {
     let imageJPEGs: [Data]
@@ -41,6 +85,7 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
     }
 
     @Published private(set) var bannerPhase: BannerPhase = .hidden
+    @Published private(set) var publishProgress: SpotPublishProgress = .preparing
     @Published private(set) var showToast = false
     @Published private(set) var toastMessage = ""
     @Published private(set) var toastIsError = false
@@ -61,6 +106,7 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
 
     private func runPublish(draft: SpotPublishDraft) async {
         bannerPhase = .uploading
+        publishProgress = .preparing
 
         guard UUID(uuidString: draft.userId) != nil else {
             await presentErrorToast("Error Posting Spot Try Again Later")
@@ -81,6 +127,7 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
             let spotId = try await publishSpotWithTimeout(draft: draft)
             let spotIdString = spotId.uuidString
             let postedAt = Date()
+            publishProgress = .finalizing
             let signedFirstImage = try? await SpotSupabaseRepository.signFirstImageURLForSpot(spotId: spotId)
 
             let postedSpot = Spot(
@@ -120,6 +167,7 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
                 object: nil,
                 userInfo: ["postedSpot": postedSpot]
             )
+            publishProgress = .complete
         } catch let error as PublishError {
             switch error {
             case .timedOut:
@@ -151,7 +199,7 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
     var bannerTitle: String {
         switch bannerPhase {
         case .hidden: return ""
-        case .uploading: return "Posting your spot…"
+        case .uploading: return publishProgress.title
         }
     }
 
@@ -170,6 +218,9 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
 
     private func publishSpotWithTimeout(draft: SpotPublishDraft) async throws -> UUID {
         let userId = try parseUserId(draft.userId)
+        let progressHandler: @MainActor @Sendable (SpotPublishProgress) -> Void = { [weak self] progress in
+            self?.publishProgress = progress
+        }
         return try await withThrowingTaskGroup(of: UUID.self) { group in
             group.addTask {
                 try await SpotSupabaseRepository.publishSpotFromDraft(
@@ -178,7 +229,8 @@ final class SpotPublishCoordinator: ObservableObject, SpotPublishing {
                     vibeTags: draft.vibeTags,
                     latitude: draft.latitude,
                     longitude: draft.longitude,
-                    locationName: draft.placeName
+                    locationName: draft.placeName,
+                    progress: progressHandler
                 )
             }
             group.addTask { [publishTimeoutSeconds] in

--- a/Spot/Services/Supabase/SpotSupabaseRepository.swift
+++ b/Spot/Services/Supabase/SpotSupabaseRepository.swift
@@ -916,7 +916,8 @@ enum SpotSupabaseRepository {
         vibeTags: [String],
         latitude: Double,
         longitude: Double,
-        locationName: String
+        locationName: String,
+        progress: (@MainActor @Sendable (SpotPublishProgress) -> Void)? = nil
     ) async throws -> UUID {
         guard !imageJPEGs.isEmpty else {
             throw NSError(domain: "SpotSupabaseRepository", code: 0, userInfo: [NSLocalizedDescriptionKey: "No images"])
@@ -935,6 +936,7 @@ enum SpotSupabaseRepository {
         if let locationError = InputValidation.validateLocationName(locationName) {
             throw NSError(domain: "SpotSupabaseRepository", code: 400, userInfo: [NSLocalizedDescriptionKey: locationError])
         }
+        await progress?(.resolvingVibes)
         var vibeIds: [UUID] = []
         vibeIds.reserveCapacity(vibeTags.count)
         for tag in vibeTags {
@@ -963,7 +965,8 @@ enum SpotSupabaseRepository {
         }
 
         var approvedAssetIds: [UUID] = []
-        for data in imageJPEGs {
+        for (index, data) in imageJPEGs.enumerated() {
+            await progress?(.uploadingPhoto(index: index, total: imageJPEGs.count))
             let assetId = UUID()
             let path = "\(userId.uuidString.lowercased())/\(assetId.uuidString.lowercased()).jpg"
             let pixelSize = SpotJPEGImageDimensions.pixelSize(jpeg: data)
@@ -1002,6 +1005,7 @@ enum SpotSupabaseRepository {
                 .from(pendingImagesBucketId)
                 .upload(path, data: data, options: FileOptions(contentType: "image/jpeg", upsert: true))
 
+            await progress?(.checkingPhoto(index: index, total: imageJPEGs.count))
             let moderate = try await invokeModerateImageFunction(mediaAssetId: assetId)
             guard moderate.approved else {
                 if moderate.reason == "image_policy_rejected" {
@@ -1020,6 +1024,7 @@ enum SpotSupabaseRepository {
             approvedAssetIds.append(assetId)
         }
 
+        await progress?(.publishing)
         let trimmedPlace = locationName.trimmingCharacters(in: .whitespacesAndNewlines)
         let spotIdString: String = try await supabase.rpc(
             "publish_spot_with_approved_media_assets_v1",

--- a/Spot/Views/Components/BottomTabNavigationView.swift
+++ b/Spot/Views/Components/BottomTabNavigationView.swift
@@ -18,6 +18,7 @@ private struct PostTabView: View {
 
 private struct PublishBannerView: View {
     let title: String
+    let progress: Double
 
     var body: some View {
         VStack(spacing: 8) {
@@ -26,7 +27,7 @@ private struct PublishBannerView: View {
                 .foregroundColor(Constants.Colors.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            ProgressView()
+            ProgressView(value: progress, total: 1)
                 .progressViewStyle(.linear)
                 .tint(Constants.Colors.primary)
                 .scaleEffect(x: 1, y: 0.8, anchor: .center)
@@ -147,7 +148,10 @@ struct BottomTabNavigationView: View {
 
             VStack(spacing: 8) {
                 if spotPublishCoordinator.bannerPhase != .hidden {
-                    PublishBannerView(title: spotPublishCoordinator.bannerTitle)
+                    PublishBannerView(
+                        title: spotPublishCoordinator.bannerTitle,
+                        progress: spotPublishCoordinator.publishProgress.fraction
+                    )
                         .transition(.move(edge: .top).combined(with: .opacity))
                 }
                 if spotPublishCoordinator.showToast {

--- a/Spot/Views/Components/SpotCard.swift
+++ b/Spot/Views/Components/SpotCard.swift
@@ -23,6 +23,36 @@ struct MenuButtonFrameKey: PreferenceKey {
     }
 }
 
+private struct SpotMenuSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next != .zero { value = next }
+    }
+}
+
+enum SpotMenuPlacement {
+    static func center(
+        buttonFrame: CGRect,
+        menuSize: CGSize,
+        containerSize: CGSize,
+        margin: CGFloat = 8
+    ) -> CGPoint {
+        let width = max(menuSize.width, 150)
+        let height = max(menuSize.height, 44)
+        let minX = width / 2 + margin
+        let maxX = max(minX, containerSize.width - width / 2 - margin)
+        let x = min(max(buttonFrame.midX, minX), maxX)
+        let fitsBelow = buttonFrame.maxY + margin + height <= containerSize.height
+        let proposedY = fitsBelow
+            ? buttonFrame.maxY + margin + height / 2
+            : buttonFrame.minY - margin - height / 2
+        let minY = height / 2 + margin
+        let maxY = max(minY, containerSize.height - height / 2 - margin)
+        return CGPoint(x: x, y: min(max(proposedY, minY), maxY))
+    }
+}
+
 #Preview {
     let sample = Spot(
         id: "s1",
@@ -75,6 +105,7 @@ struct SpotCard: View {
     @State private var showEditSheet: Bool = false
     @State private var showCustomMenu: Bool = false
     @State private var menuButtonFrame: CGRect = .zero
+    @State private var menuSize: CGSize = .zero
     @EnvironmentObject var authVM: AuthViewModel
     @State private var isLiked: Bool = false
     @State private var isSaved: Bool = false
@@ -113,6 +144,16 @@ struct SpotCard: View {
         _currentSpot = State(initialValue: spot)
     }
 
+    private var authorDisplay: SpotAuthorDisplay {
+        SpotAuthorDisplay.resolve(
+            spotUsername: currentSpot.username,
+            spotProfileImageURL: currentSpot.userProfileImageURL,
+            isCurrentUser: currentSpot.userId == authVM.userId,
+            currentUsername: authVM.currentUserUsername,
+            currentProfileImageURL: authVM.currentUserProfileImageURL
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 12) {
@@ -141,6 +182,7 @@ struct SpotCard: View {
         .padding(.horizontal, 12)
         .background(Constants.Colors.background)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .coordinateSpace(name: "spotCard")
         .measure(target: .spotCard)
         .onChange(of: currentSpot.id) { _, _ in
             thumbnailFailed = false
@@ -261,7 +303,7 @@ struct SpotCard: View {
                 NavigationLink(value: Route.profile(userId)) {
                     HStack(spacing: 8) {
                         // (event recorded via simultaneousGesture below)
-                        if let urlString = currentSpot.userProfileImageURL,
+                        if let urlString = authorDisplay.profileImageURL,
                            let url = URL(string: urlString) {
                             AsyncImage(url: url) { img in
                                 img.resizable()
@@ -289,7 +331,7 @@ struct SpotCard: View {
                                 )
                         }
 
-                        Text(currentSpot.username ?? "")
+                        Text(authorDisplay.username)
                             .font(FontManager.primaryText())
                             .fontWeight(.semibold)
                             .foregroundColor(Constants.Colors.primary)
@@ -577,7 +619,10 @@ struct SpotCard: View {
                         .accessibilityLabel("More actions")
                         .background(
                             GeometryReader { geo in
-                                Color.clear.preference(key: MenuButtonFrameKey.self, value: geo.frame(in: .global))
+                                Color.clear.preference(
+                                    key: MenuButtonFrameKey.self,
+                                    value: geo.frame(in: .named("spotCard"))
+                                )
                             }
                         )
                 }
@@ -684,25 +729,31 @@ struct SpotCard: View {
 
     // MARK: - Custom Menu
     private var customMenuOverlay: some View {
-        GeometryReader { _ in
+        GeometryReader { proxy in
             ZStack {
                 // Tappable background to dismiss
                 Color.black.opacity(0.001)
                     .ignoresSafeArea()
                     .onTapGesture { showCustomMenu = false }
 
-                // Position menu near the three dots button
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        customMenuContent
-                            .padding(.trailing, 16)
-                            .padding(.bottom, 8)
+                customMenuContent
+                    .background {
+                        GeometryReader { menuProxy in
+                            Color.clear.preference(
+                                key: SpotMenuSizeKey.self,
+                                value: menuProxy.size
+                            )
+                        }
                     }
-                }
-                .offset(x: -menuButtonFrame.width - 8, y: -menuButtonFrame.height - 8)
+                    .position(
+                        SpotMenuPlacement.center(
+                            buttonFrame: menuButtonFrame,
+                            menuSize: menuSize,
+                            containerSize: proxy.size
+                        )
+                    )
             }
+            .onPreferenceChange(SpotMenuSizeKey.self) { menuSize = $0 }
         }
     }
 
@@ -836,7 +887,7 @@ struct SpotCard: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Constants.Colors.primary, lineWidth: 1)
         )
-        .frame(width: 150)
+        .frame(width: 170)
     }
 
     // MARK: - Collection Picker Sheet

--- a/Spot/Views/Home/MapView.swift
+++ b/Spot/Views/Home/MapView.swift
@@ -103,7 +103,11 @@ struct MapView: View {
                             handleMapRegionChanged(region)
                         }
                     )
-                    .ignoresSafeArea(edges: .bottom)
+                    // The map is the canvas for this tab. Let it continue behind the
+                    // status bar as well as the home indicator so no cream strip cuts
+                    // the map off at the top; MapControlsOverlay applies its own safe
+                    // area spacing for interactive controls.
+                    .ignoresSafeArea()
                     .accessibilityIdentifier("map.mapView")
                     .overlay {
                         mapOnboardingTargets

--- a/Spot/Views/PostFlow/LocationSelectionView.swift
+++ b/Spot/Views/PostFlow/LocationSelectionView.swift
@@ -90,7 +90,7 @@ struct LocationSelectionView: View {
                     .font(FontManager.sectionHeader())
                     .foregroundColor(Constants.Colors.primary)
                 Text("Search for the place or choose one near you.")
-                    .font(FontManager.primaryText())
+                    .font(.system(size: 16))
                     .foregroundColor(Constants.Colors.welcomeMutedText)
             }
 
@@ -137,7 +137,7 @@ struct LocationSelectionView: View {
             }
             .padding(.horizontal, Constants.Layout.Padding.verticalLarge)
             .frame(height: 54)
-            .background(Color.white.opacity(0.72))
+            .background(Color.white)
             .clipShape(RoundedRectangle(cornerRadius: Constants.Layout.CornerRadius.large))
             .overlay {
                 RoundedRectangle(cornerRadius: Constants.Layout.CornerRadius.large)

--- a/Spot/Views/PostFlow/LocationSelectionView.swift
+++ b/Spot/Views/PostFlow/LocationSelectionView.swift
@@ -99,9 +99,15 @@ struct LocationSelectionView: View {
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(Constants.Colors.primary)
 
-                TextField("Search a place, venue, or address", text: $searchText)
+                TextField(
+                    "",
+                    text: $searchText,
+                    prompt: Text("Search a place, venue, or address")
+                        .foregroundColor(Constants.Colors.primary.opacity(0.62))
+                )
                     .font(FontManager.primaryText())
                     .foregroundColor(Constants.Colors.primary)
+                    .tint(Constants.Colors.primary)
                     .focused($searchFieldFocused)
                     .submitLabel(.search)
                     .onChange(of: searchText) { _, query in

--- a/Spot/Views/PostFlow/PhotoSelectionView.swift
+++ b/Spot/Views/PostFlow/PhotoSelectionView.swift
@@ -359,9 +359,9 @@ struct PhotoSelectionView: View {
                 .padding(.horizontal, 24)
             }
 
-            Text("Hold and drag photos to reorder. The first photo is the cover.")
+            Text("Tap a photo to select it. Use the arrows to reorder; the first photo is the cover.")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Constants.Colors.primary.opacity(0.72))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
@@ -413,78 +413,105 @@ struct PhotoSelectionView: View {
     }
 
     private func thumbnail(_ photo: PostComposerPhoto, index: Int) -> some View {
-        Menu {
-            Button("Edit Photo") {
+        VStack(spacing: 6) {
+            Button {
                 activePhotoID = photo.id
-                openEditor()
+            } label: {
+                ZStack(alignment: .bottomLeading) {
+                    Image(uiImage: photo.image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 80, height: 80)
+                        .clipped()
+                    if index == 0 {
+                        Text("Cover")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Constants.Colors.buttonText)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 3)
+                            .background(Constants.Colors.primary)
+                            .clipShape(Capsule())
+                            .padding(4)
+                    }
+                    if photo.processingState == .processing {
+                        ProgressView().tint(.white).frame(width: 80, height: 80)
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(
+                            photo.id == activePhotoID
+                                ? Constants.Colors.primary
+                                : Constants.Colors.primary.opacity(0.16),
+                            lineWidth: photo.id == activePhotoID ? 3 : 1
+                        )
+                )
+                .contentShape(Rectangle())
             }
-            if index > 0 {
-                Button("Make Cover") { makeCover(photo.id) }
-            }
-            Button("Move Left") { move(photo.id, by: -1) }
-                .disabled(index == 0)
-            Button("Move Right") { move(photo.id, by: 1) }
-                .disabled(index == selectedPhotos.count - 1)
-            Button("Move to Start") { move(photo.id, to: 0) }
-                .disabled(index == 0)
-            Button("Move to End") { move(photo.id, to: selectedPhotos.count - 1) }
-                .disabled(index == selectedPhotos.count - 1)
-            Button("Remove Photo", role: .destructive) {
-                activePhotoID = photo.id
-                requestDelete()
-            }
-        } label: {
-            ZStack(alignment: .bottomLeading) {
+            .buttonStyle(.plain)
+            .accessibilityLabel("Select photo \(index + 1) of \(selectedPhotos.count)\(index == 0 ? ", cover photo" : "")")
+            .draggable(photo.id.uuidString) {
                 Image(uiImage: photo.image)
                     .resizable()
                     .scaledToFill()
                     .frame(width: 80, height: 80)
-                    .clipped()
-                if index == 0 {
-                    Text("Cover")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(Constants.Colors.buttonText)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 3)
-                        .background(Constants.Colors.primary)
-                        .clipShape(Capsule())
-                        .padding(4)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .onAppear {
+                        draggedPhotoID = photo.id
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    }
+            }
+            .dropDestination(for: String.self) { items, _ in
+                guard let raw = items.first,
+                      let sourceID = UUID(uuidString: raw),
+                      let source = selectedPhotos.firstIndex(where: { $0.id == sourceID }) else { return false }
+                move(sourceID, to: index)
+                draggedPhotoID = nil
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                return source != index
+            } isTargeted: { _ in }
+
+            HStack(spacing: 4) {
+                reorderButton(
+                    label: "Move photo \(index + 1) left",
+                    icon: "chevron.left",
+                    disabled: index == 0
+                ) {
+                    move(photo.id, by: -1)
                 }
-                if photo.processingState == .processing {
-                    ProgressView().tint(.white).frame(width: 80, height: 80)
+                reorderButton(
+                    label: "Move photo \(index + 1) right",
+                    icon: "chevron.right",
+                    disabled: index == selectedPhotos.count - 1
+                ) {
+                    move(photo.id, by: 1)
                 }
             }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(photo.id == activePhotoID ? Constants.Colors.primary : .clear, lineWidth: 3)
-            )
-            .contentShape(Rectangle())
-        } primaryAction: {
-            activePhotoID = photo.id
         }
-        .accessibilityLabel("Photo \(index + 1) of \(selectedPhotos.count)\(index == 0 ? ", cover photo" : "")")
-        .accessibilityHint("Double tap to select. Actions include editing and reordering.")
-        .draggable(photo.id.uuidString) {
-            Image(uiImage: photo.image)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 80, height: 80)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .onAppear {
-                    draggedPhotoID = photo.id
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                }
+    }
+
+    private func reorderButton(
+        label: String,
+        icon: String,
+        disabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(
+                    disabled
+                        ? Constants.Colors.primary.opacity(0.28)
+                        : Constants.Colors.primary
+                )
+                .frame(width: 36, height: 30)
+                .background(Constants.Colors.accent.opacity(disabled ? 0.35 : 0.8))
+                .clipShape(RoundedRectangle(cornerRadius: 9))
         }
-        .dropDestination(for: String.self) { items, _ in
-            guard let raw = items.first,
-                  let sourceID = UUID(uuidString: raw),
-                  let source = selectedPhotos.firstIndex(where: { $0.id == sourceID }) else { return false }
-            move(sourceID, to: index)
-            draggedPhotoID = nil
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            return source != index
-        } isTargeted: { _ in }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .accessibilityLabel(label)
     }
 
     @ViewBuilder

--- a/Spot/Views/PostFlow/PostFlowView.swift
+++ b/Spot/Views/PostFlow/PostFlowView.swift
@@ -144,6 +144,7 @@ struct PostFlowView: View {
             .background(Constants.Colors.background.ignoresSafeArea())
         }
         .ignoresSafeArea(.keyboard)
+        .preferredColorScheme(.light)
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/Spot/Views/PostFlow/PostFlowView.swift
+++ b/Spot/Views/PostFlow/PostFlowView.swift
@@ -278,7 +278,7 @@ struct NavigationButtonsView: View {
     let onSaveDraft: () -> Void
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 10) {
             if currentStep > 1 {
                 Button(action: onBack) {
                     Text("Back")
@@ -309,20 +309,26 @@ struct NavigationButtonsView: View {
             .buttonStyle(PlainButtonStyle())
 
             if currentStep == totalSteps {
-                Menu {
-                    Button("Post", action: onFinish)
-                        .disabled(!canProceed || isBusy)
-                    Button("Save as Draft", action: onSaveDraft)
-                        .disabled(!canSaveDraft || isBusy)
-                } label: {
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(Constants.Colors.primary)
-                        .padding(12)
-                        .background(Color.white)
-                        .clipShape(Circle())
-                        .overlay(Circle().stroke(Constants.Colors.primary, lineWidth: 1))
+                Button(action: onSaveDraft) {
+                    Text("Save Draft")
+                        .font(FontManager.buttonText())
+                        .foregroundColor(
+                            canSaveDraft && !isBusy
+                                ? Constants.Colors.primary
+                                : Constants.Colors.primary.opacity(0.4)
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Constants.Colors.accent.opacity(canSaveDraft ? 0.75 : 0.35))
+                        .cornerRadius(20)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(Constants.Colors.primary.opacity(canSaveDraft ? 1 : 0.3), lineWidth: 1)
+                        )
                 }
+                .buttonStyle(.plain)
+                .disabled(!canSaveDraft || isBusy)
+                .accessibilityHint("Saves this Spot without publishing it")
             }
         }
         .padding(.horizontal, 16)

--- a/Spot/Views/PostFlow/SpotPhotoEditorView.swift
+++ b/Spot/Views/PostFlow/SpotPhotoEditorView.swift
@@ -51,26 +51,30 @@ struct SpotPhotoEditorView: View {
             VStack(spacing: 0) {
                 ZStack {
                     Color.black.opacity(0.92)
-                    Image(uiImage: preview)
-                        .resizable()
-                        .scaledToFit()
-                        .overlay {
-                            if selectedTool == .crop ||
-                                (selectedTool == .rotate && abs(edits.straightenDegrees) > 0.01) {
-                                PhotoEditorGrid()
-                                    .allowsHitTesting(false)
+                    GeometryReader { proxy in
+                        let fittedSize = PhotoEditorCanvasLayout.fittedSize(
+                            imageSize: preview.size,
+                            containerSize: proxy.size,
+                            inset: 12
+                        )
+                        Image(uiImage: preview)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: fittedSize.width, height: fittedSize.height)
+                            .overlay {
+                                if selectedTool == .crop ||
+                                    (selectedTool == .rotate && abs(edits.straightenDegrees) > 0.01) {
+                                    PhotoEditorGrid()
+                                        .allowsHitTesting(false)
+                                }
                             }
-                        }
-                        .padding(12)
-                        .background {
-                            GeometryReader { proxy in
-                                Color.clear
-                                    .onAppear { canvasSize = proxy.size }
-                                    .onChange(of: proxy.size) { _, size in canvasSize = size }
-                            }
-                        }
-                        .gesture(cropGesture)
-                        .accessibilityLabel("Photo editing preview")
+                            .contentShape(Rectangle())
+                            .gesture(cropGesture)
+                            .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                            .onAppear { canvasSize = fittedSize }
+                            .onChange(of: fittedSize) { _, size in canvasSize = size }
+                            .accessibilityLabel("Photo editing preview")
+                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -414,6 +418,28 @@ struct SpotPhotoEditorView: View {
             guard !Task.isCancelled, revision == renderRevision, let rendered else { return }
             preview = rendered
         }
+    }
+}
+
+enum PhotoEditorCanvasLayout {
+    static func fittedSize(
+        imageSize: CGSize,
+        containerSize: CGSize,
+        inset: CGFloat
+    ) -> CGSize {
+        let availableWidth = max(1, containerSize.width - inset * 2)
+        let availableHeight = max(1, containerSize.height - inset * 2)
+        guard imageSize.width > 0, imageSize.height > 0 else {
+            return CGSize(width: availableWidth, height: availableHeight)
+        }
+        let scale = min(
+            availableWidth / imageSize.width,
+            availableHeight / imageSize.height
+        )
+        return CGSize(
+            width: imageSize.width * scale,
+            height: imageSize.height * scale
+        )
     }
 }
 

--- a/Spot/Views/PostFlow/SpotPhotoEditorView.swift
+++ b/Spot/Views/PostFlow/SpotPhotoEditorView.swift
@@ -22,6 +22,7 @@ struct SpotPhotoEditorView: View {
     @State private var preview: UIImage
     @State private var selectedTool: Tool = .crop
     @State private var renderTask: Task<Void, Never>?
+    @State private var renderRevision = 0
     @State private var showResetConfirmation = false
     @State private var cropGestureStart: PostComposerPhotoCrop?
     @State private var canvasSize: CGSize = CGSize(width: 400, height: 400)
@@ -53,6 +54,14 @@ struct SpotPhotoEditorView: View {
                     Image(uiImage: preview)
                         .resizable()
                         .scaledToFit()
+                        .overlay {
+                            if selectedTool == .crop ||
+                                (selectedTool == .rotate && abs(edits.straightenDegrees) > 0.01) {
+                                PhotoEditorGrid()
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                        .padding(12)
                         .background {
                             GeometryReader { proxy in
                                 Color.clear
@@ -62,16 +71,10 @@ struct SpotPhotoEditorView: View {
                         }
                         .gesture(cropGesture)
                         .accessibilityLabel("Photo editing preview")
-                    if selectedTool == .crop ||
-                        (selectedTool == .rotate && abs(edits.straightenDegrees) > 0.01) {
-                        PhotoEditorGrid()
-                            .padding(28)
-                            .allowsHitTesting(false)
-                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-                VStack(spacing: 14) {
+                VStack(spacing: 10) {
                     HStack(spacing: 8) {
                         ForEach(Tool.allCases) { tool in
                             Button {
@@ -99,7 +102,7 @@ struct SpotPhotoEditorView: View {
                     .accessibilityElement(children: .contain)
 
                     toolControls
-                        .frame(minHeight: 132, alignment: .top)
+                        .frame(minHeight: 108, alignment: .top)
                 }
                 .padding(16)
                 .background(Constants.Colors.background)
@@ -168,6 +171,10 @@ struct SpotPhotoEditorView: View {
     private var toolControls: some View {
         switch selectedTool {
         case .crop:
+            Text("Drag to reposition • Pinch to zoom")
+                .font(.caption)
+                .foregroundStyle(Constants.Colors.primary.opacity(0.72))
+                .frame(maxWidth: .infinity, alignment: .leading)
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(cropOptions) { option in
@@ -194,9 +201,6 @@ struct SpotPhotoEditorView: View {
                     }
                 }
             }
-            Text("Choose an aspect ratio. Free keeps the current crop.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     editorIconButton("Move crop left", icon: "arrow.left") { adjustCrop(dx: -0.03) }
@@ -397,15 +401,17 @@ struct SpotPhotoEditorView: View {
 
     private func schedulePreviewRender() {
         renderTask?.cancel()
+        renderRevision += 1
+        let revision = renderRevision
         let original = photo.originalImage
         let editsSnapshot = edits
         renderTask = Task {
-            try? await Task.sleep(for: .milliseconds(80))
+            try? await Task.sleep(for: .milliseconds(100))
             guard !Task.isCancelled else { return }
             let rendered = await Task.detached(priority: .userInitiated) {
-                try? PostPhotoProcessor.render(original: original, edits: editsSnapshot)
+                try? PostPhotoProcessor.renderEditorPreview(original: original, edits: editsSnapshot)
             }.value
-            guard !Task.isCancelled, let rendered else { return }
+            guard !Task.isCancelled, revision == renderRevision, let rendered else { return }
             preview = rendered
         }
     }

--- a/Spot/Views/PostFlow/VibeSelectionView.swift
+++ b/Spot/Views/PostFlow/VibeSelectionView.swift
@@ -161,10 +161,16 @@ struct VibeSelectionView: View {
             .padding(.horizontal, Constants.Layout.Padding.horizontal)
 
             HStack(spacing: Constants.Layout.Spacing.small) {
-                TextField("e.g. Golden Hour", text: $customVibe)
+                TextField(
+                    "",
+                    text: $customVibe,
+                    prompt: Text("e.g. Golden Hour")
+                        .foregroundColor(Constants.Colors.primary.opacity(0.62))
+                )
                     .textInputAutocapitalization(.words)
                     .disableAutocorrection(true)
                     .foregroundColor(Constants.Colors.primary)
+                    .tint(Constants.Colors.primary)
                     .padding(Constants.Layout.Padding.verticalMedium)
                     .background(Color.white)
                     .cornerRadius(Constants.Layout.CornerRadius.medium)

--- a/Spot/Views/PostFlow/VibeSelectionView.swift
+++ b/Spot/Views/PostFlow/VibeSelectionView.swift
@@ -169,6 +169,7 @@ struct VibeSelectionView: View {
                 )
                     .textInputAutocapitalization(.words)
                     .disableAutocorrection(true)
+                    .font(.system(size: 16))
                     .foregroundColor(Constants.Colors.primary)
                     .tint(Constants.Colors.primary)
                     .padding(Constants.Layout.Padding.verticalMedium)

--- a/Spot/Views/Search/SearchView.swift
+++ b/Spot/Views/Search/SearchView.swift
@@ -12,12 +12,20 @@ struct SearchView: View {
         NavigationStack(path: $path) {
             VStack(spacing: 16) {
                 HStack(spacing: 12) {
-                    Image(systemName: "magnifyingglass").foregroundColor(.gray)
-                    TextField("Search users, locations, vibes", text: $vm.query)
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(Constants.Colors.primary)
+                    TextField(
+                        "",
+                        text: $vm.query,
+                        prompt: Text("Search users, locations, vibes")
+                            .foregroundColor(Constants.Colors.primary.opacity(0.62))
+                    )
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .focused($focused)
+                        .font(.system(size: 16))
                         .foregroundColor(Constants.Colors.textPrimary)
+                        .tint(Constants.Colors.primary)
                         .onChange(of: focused) { _, newValue in
                             if newValue && vm.query.isEmpty {
                                 vm.loadSearchHistory()
@@ -37,7 +45,7 @@ struct SearchView: View {
                     }
                 }
                 .padding(12)
-                .background(Color.white)
+                .background(Constants.Colors.accent.opacity(0.55))
                 .cornerRadius(12)
                 .overlay(RoundedRectangle(cornerRadius: 12).stroke(Constants.Colors.primary, lineWidth: 1))
                 .padding(.horizontal, 16)
@@ -243,6 +251,7 @@ struct SearchView: View {
             showFilters = false
             focused = false
         }
+        .preferredColorScheme(.light)
     }
 }
 

--- a/SpotTests/Services/Spots/PostComposerPhotoTests.swift
+++ b/SpotTests/Services/Spots/PostComposerPhotoTests.swift
@@ -130,6 +130,23 @@ struct PostComposerPhotoTests {
         #expect(preview.size.height > 0)
     }
 
+    @Test func editorGridFitsDisplayedImageAspectRatio() {
+        let landscape = PhotoEditorCanvasLayout.fittedSize(
+            imageSize: CGSize(width: 1_600, height: 900),
+            containerSize: CGSize(width: 390, height: 500),
+            inset: 12
+        )
+        let square = PhotoEditorCanvasLayout.fittedSize(
+            imageSize: CGSize(width: 900, height: 900),
+            containerSize: CGSize(width: 390, height: 500),
+            inset: 12
+        )
+
+        #expect(abs(landscape.width / landscape.height - 16.0 / 9.0) < 0.001)
+        #expect(abs(square.width / square.height - 1) < 0.001)
+        #expect(landscape.height < square.height)
+    }
+
     @Test func legacyDraftDecodesWithoutPhotoMetadata() throws {
         let json = """
         {

--- a/SpotTests/Services/Spots/PostComposerPhotoTests.swift
+++ b/SpotTests/Services/Spots/PostComposerPhotoTests.swift
@@ -112,6 +112,24 @@ struct PostComposerPhotoTests {
         #expect(rendered !== source)
     }
 
+    @Test func editorPreviewUsesSmallerInteractiveRenderBudget() throws {
+        let source = testImage(.purple, size: CGSize(width: 1_800, height: 1_200))
+        var edits = PostComposerPhotoEdits.neutral
+        edits.crop = PostComposerPhotoCrop(
+            normalizedX: 0.1,
+            normalizedY: 0.1,
+            normalizedWidth: 0.8,
+            normalizedHeight: 0.8,
+            aspectRatio: "Free"
+        )
+
+        let preview = try PostPhotoProcessor.renderEditorPreview(original: source, edits: edits)
+
+        #expect(max(preview.size.width, preview.size.height) <= PostPhotoProcessor.editorPreviewMaxPixelSize)
+        #expect(preview.size.width > 0)
+        #expect(preview.size.height > 0)
+    }
+
     @Test func legacyDraftDecodesWithoutPhotoMetadata() throws {
         let json = """
         {

--- a/SpotTests/Services/Spots/SpotPublishDraftTests.swift
+++ b/SpotTests/Services/Spots/SpotPublishDraftTests.swift
@@ -27,4 +27,49 @@ struct SpotPublishDraftTests {
         #expect(draft.username == "Eddie5")
         #expect(draft.userProfileImageURL == "https://example.com/a.jpg")
     }
+
+    @Test func publishProgressMovesForwardAcrossMultiplePhotos() {
+        let stages: [SpotPublishProgress] = [
+            .preparing,
+            .resolvingVibes,
+            .uploadingPhoto(index: 0, total: 2),
+            .checkingPhoto(index: 0, total: 2),
+            .uploadingPhoto(index: 1, total: 2),
+            .checkingPhoto(index: 1, total: 2),
+            .publishing,
+            .finalizing,
+            .complete
+        ]
+
+        #expect(zip(stages, stages.dropFirst()).allSatisfy { pair in
+            pair.0.fraction < pair.1.fraction
+        })
+        #expect(stages.last?.fraction == 1)
+        #expect(SpotPublishProgress.uploadingPhoto(index: 1, total: 2).title == "Uploading photo 2 of 2…")
+    }
+
+    @Test func currentUserIdentityFillsMissingOptimisticAuthorFields() {
+        let resolved = SpotAuthorDisplay.resolve(
+            spotUsername: nil,
+            spotProfileImageURL: nil,
+            isCurrentUser: true,
+            currentUsername: "eddie",
+            currentProfileImageURL: "https://example.com/me.jpg"
+        )
+
+        #expect(resolved.username == "eddie")
+        #expect(resolved.profileImageURL == "https://example.com/me.jpg")
+    }
+
+    @Test func anotherAuthorsIdentityNeverUsesCurrentUserFallback() {
+        let resolved = SpotAuthorDisplay.resolve(
+            spotUsername: nil,
+            spotProfileImageURL: nil,
+            isCurrentUser: false,
+            currentUsername: "eddie",
+            currentProfileImageURL: "https://example.com/me.jpg"
+        )
+
+        #expect(resolved == SpotAuthorDisplay(username: "User", profileImageURL: nil))
+    }
 }

--- a/SpotTests/Utils/MapFeedLogicTests.swift
+++ b/SpotTests/Utils/MapFeedLogicTests.swift
@@ -44,6 +44,30 @@ struct SpotGridLayoutTests {
     }
 }
 
+struct SpotMenuPlacementTests {
+    @Test func anchorsMenuToTappedButtonInsteadOfCardEdge() {
+        let center = SpotMenuPlacement.center(
+            buttonFrame: CGRect(x: 92, y: 520, width: 24, height: 24),
+            menuSize: CGSize(width: 170, height: 220),
+            containerSize: CGSize(width: 390, height: 600)
+        )
+
+        #expect(center.x == 104)
+        #expect(center.y < 520)
+    }
+
+    @Test func clampsMenuInsideHorizontalCardBounds() {
+        let center = SpotMenuPlacement.center(
+            buttonFrame: CGRect(x: 378, y: 40, width: 24, height: 24),
+            menuSize: CGSize(width: 170, height: 100),
+            containerSize: CGSize(width: 390, height: 600)
+        )
+
+        #expect(center.x == 297)
+        #expect(center.y > 64)
+    }
+}
+
 struct SpotMapFilterStateTransitionTests {
     @Test func togglingDimensionOnAndOff() {
         var state = SpotMapFilterState.empty

--- a/docs/product/posting-flow.md
+++ b/docs/product/posting-flow.md
@@ -20,9 +20,9 @@ User opens **Post** tab → multi-step composer (`Spot/Views/PostFlow`) → sele
 
 ### Media
 
-Photos are chosen from an image-only multi-select library picker or the still-image camera. The first ordered photo is the cover. The photo workspace supports previewing, adding, replacing, removing, accessible reordering, and making any photo the cover.
+Photos are chosen from an image-only multi-select library picker or the still-image camera. The first ordered photo is the cover. The photo workspace supports previewing, adding, replacing, removing, and making any photo the cover. Reordering is exposed with visible left/right controls on every thumbnail (with drag and drop as an additional interaction), so it does not depend on discovering a long press.
 
-Each photo has a stable ID and non-destructive edit instructions. Crop, quarter-turn rotation, straightening, horizontal/vertical flip, brightness, contrast, saturation, and warmth are rendered from an orientation-normalized original. The original is retained until publication so edits can be reset or changed without repeatedly recompressing an earlier render. Picker filtering, client decoding, JPEG upload encoding, storage MIME restrictions, and moderation provide layered video exclusion.
+Each photo has a stable ID and non-destructive edit instructions. Crop, quarter-turn rotation, straightening, horizontal/vertical flip, brightness, contrast, saturation, and warmth are rendered from an orientation-normalized original. Interactive editor updates use a smaller display-only render budget for smooth gestures; the saved result still uses the full composer render budget. The crop grid is attached to the displayed image bounds so aspect-ratio changes update the visible editing frame. The original is retained until publication so edits can be reset or changed without repeatedly recompressing an earlier render. Picker filtering, client decoding, JPEG upload encoding, storage MIME restrictions, and moderation provide layered video exclusion.
 
 Free accounts can publish one photo and one vibe tag. Pro accounts can publish up to five photos and five vibe tags. The publish RPC independently enforces entitlement limits.
 
@@ -38,7 +38,7 @@ User picks from known tags and adds caption/details as the UI allows.
 
 `PostDraftStore` persists drafts locally under Application Support, including a reserved `autosave` draft and user-saved drafts. Draft schema version 2 stores each photo's stable ID, durable original and rendered preview, source, ordered position, non-destructive edit instructions, and processing state. Version 1 drafts are migrated lazily when loaded: their known file order is retained, stable IDs are generated, and neutral edits are supplied. A missing version-2 photo file restores as an unavailable item that can be replaced or removed instead of crashing. Draft metadata is indexed locally; no server draft table is involved.
 
-Submission persists a snapshot before JPEG encoding and queueing. The composer resets as soon as `SpotPublishCoordinator` accepts the job, allowing the user to leave the Post tab while the global publish banner reports progress.
+Submission persists a snapshot before JPEG encoding and queueing. The composer resets as soon as `SpotPublishCoordinator` accepts the job, allowing the user to leave the Post tab. The global banner uses determinate progress from real pipeline stages: vibe resolution, each photo upload, each moderation check, RPC publication, and final feed preparation.
 
 ### Publish and moderation
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- extend the map canvas behind the top safe area
- keep cream app surfaces in their intended light appearance and use larger, Spot-green composer/search fields
- add visible photo reorder controls and improve photo editor responsiveness/layout
- keep the crop grid fitted to the displayed image as aspect ratios change
- replace the unclear final-step options control with a labeled Save Draft action
- report real publish pipeline stages in a determinate progress bar
- restore current-user identity on optimistic feed cards and anchor card menus to the tapped button

## Testing
- Added focused unit coverage for publish progress, author fallback, editor preview sizing/grid layout, and menu placement
- Documentation validation passed (with the expected advisory for the touched Supabase upload callback)
- Secret scan and diff formatting checks passed
- iOS unit/build validation is running in CI; this Linux environment does not include Xcode

## Checklist

### Code Quality & Testing (Required)
- [x] Added unit tests for new logic
- [ ] All tests pass (`SpotTests` running in CI)
- [x] No breaking API changes
- [ ] Confirmed no new warnings introduced (running in CI)
- [x] Code follows existing patterns and style

### Documentation (Required)
- [x] Updated `docs/product/posting-flow.md`
- [x] Updated relevant product docs for user-facing behavior
- [x] Architecture/engineering docs not required; no architecture or data-plane change
- [x] Diagrams not required; flow topology is unchanged

### Data plane
- [x] No Firebase data plane
- [x] Posting uses SpotPublishCoordinator / SpotSupabaseRepository
- [x] No schema/RLS changes
- [ ] DataPlaneGuardTests pass (running in CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe35b-edbf-7097-9650-e0aaaab96aa7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe35b-edbf-7097-9650-e0aaaab96aa7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

